### PR TITLE
Fix floating base add 

### DIFF
--- a/examples/generate_ergoCub_xml.py
+++ b/examples/generate_ergoCub_xml.py
@@ -1,7 +1,16 @@
-from mujoco_urdf_loader import MujocoWrapper
-from mujoco_urdf_loader import URDFtoMuJoCoLoader, URDFtoMuJoCoLoaderCfg, ControlMode
-import resolve_robotics_uri_py as rru
+import xml.etree.ElementTree as ET
+
 import mujoco
+import mujoco.viewer
+import resolve_robotics_uri_py as rru
+
+from mujoco_urdf_loader import (
+    ControlMode,
+    MujocoWrapper,
+    URDFtoMuJoCoLoader,
+    URDFtoMuJoCoLoaderCfg,
+)
+from mujoco_urdf_loader.urdf_fcn import get_mesh_path
 
 controlled_joints = [
     "l_hip_pitch",
@@ -41,20 +50,50 @@ cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping
 urdf_string = str(
     rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN002/model.urdf")
 )
+mesh_path = get_mesh_path(ET.parse(urdf_string).getroot())
 
-loader = URDFtoMuJoCoLoader.load_urdf(urdf_string, cfg)
+loader = URDFtoMuJoCoLoader.load_urdf(urdf_string, mesh_path, cfg)
 
 # save xml_str to a file
 path = "ergocub.xml"
 with open(path, "w") as f:
     f.write(loader.get_mjcf_string())
 
-mujoco_wrapper = MujocoWrapper(loader.get_mjcf_string())
+        # include the model in a simple world
+world_str = f"""
+    <mujoco model="ergoCubWorld">
+        <include file="{path}"/>
+
+        <visual>
+            <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+            <rgba haze="0.15 0.25 0.35 1"/>
+            <global azimuth="120" elevation="-20"/>
+        </visual>
+
+        <asset>
+            <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+            <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+            markrgb="0.8 0.8 0.8" width="300" height="300"/>
+            <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+        </asset>
+
+        <worldbody>
+            <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
+            <camera name="default" pos="0.846 -1.465 0.916" xyaxes="0.866 0.500 0.000 -0.171 0.296 0.940"/>
+            <geom name="floor" pos="0 0 0" size="0 0 0.05" type="plane" material="groundplane"/>
+        </worldbody>
+    </mujoco>
+    """
+
+mujoco_wrapper = MujocoWrapper(world_str)
 model = mujoco_wrapper.model
 data = mujoco_wrapper.data
 
 # or directly load the model in mujoco
 
-model = mujoco.MjModel.from_xml_string(loader.get_mjcf_string())
+model = mujoco.MjModel.from_xml_string(world_str)
 data = mujoco.MjData(model)
 
+data.qpos[2] = 1.5
+# visualize the model
+mujoco.viewer.launch(model, data)

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -53,7 +53,7 @@ class URDFtoMuJoCoLoader:
         self.set_controlled_joints(cfg.controlled_joints)
 
     @staticmethod
-    def load_urdf(urdf_path: str, cfg: URDFtoMuJoCoLoaderCfg):    
+    def load_urdf(urdf_path: str, mesh_path: str, cfg: URDFtoMuJoCoLoaderCfg):
         """
         Load the URDF from the file.
 
@@ -65,7 +65,6 @@ class URDFtoMuJoCoLoader:
             str: The URDF string.
         """
         urdf_string = URDFtoMuJoCoLoader.simplify_urdf(urdf_path, cfg.controlled_joints, cfg.stiffness, cfg.damping)
-        mesh_path = get_mesh_path(urdf_string)
         urdf_string = remove_gazebo_elements(urdf_string)
         urdf_string = add_mujoco_element(urdf_string, mesh_path)
         mjcf = load_urdf_into_mjcf(urdf_string)

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -168,19 +168,20 @@ class URDFtoMuJoCoLoader:
         else:
             raise ValueError("joint must be a string or a list of strings.")
 
-    def add_actuator(self, joint: str, control_mode: ControlMode, ctrlrange: List[float] = None):
+    def add_actuator(self, joint: str, control_mode: ControlMode):
         """
         Add an actuator to the MJCF model.
 
         Args:
             joint (str): The joint name.
             control_mode (ControlMode): The control mode.
-            ctrlrange (List[float]): The control range.
         """
         if control_mode == ControlMode.POSITION:
+            joint_mjcf = self.mjcf.find(f".//joint[@name='{joint}']")
+            ctrlrange = list(map(float, joint_mjcf.attrib["range"].split()))
             add_position_actuator(self.mjcf, joint=joint, ctrlrange=ctrlrange)
         elif control_mode == ControlMode.TORQUE:
-            add_torque_actuator(self.mjcf, joint=joint, ctrlrange=ctrlrange)
+            add_torque_actuator(self.mjcf, joint=joint, ctrlrange=None)
         elif control_mode == ControlMode.VELOCITY:
             raise NotImplementedError("Velocity control is not implemented yet.")
         else:
@@ -199,8 +200,7 @@ class URDFtoMuJoCoLoader:
         for controlled_joint in self.controlled_joints:
             joint_element = joint_elements.get(controlled_joint)
             if joint_element is not None:
-                ctrlrange = list(map(float, joint_element.attrib["range"].split()))
-                self.add_actuator(controlled_joint, self.control_mode[controlled_joint], ctrlrange)
+                self.add_actuator(controlled_joint, self.control_mode[controlled_joint])
             else:
                 raise ValueError(f"Joint {controlled_joint} not found in the MJCF model.")
 

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -1,12 +1,10 @@
 import dataclasses
-import logging
 import tempfile
 import xml.etree.ElementTree as ET
 from enum import Enum
 from typing import List, Union
 
 import idyntree.bindings as idyn
-import resolve_robotics_uri_py as rru
 
 from mujoco_urdf_loader.generator import load_urdf_into_mjcf
 from mujoco_urdf_loader.mjcf_fcn import (

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -33,7 +33,7 @@ class URDFtoMuJoCoLoaderCfg:
     control_modes: Union[None, List[ControlMode]] = None
     stiffness: Union[None, List[float]] = None
     damping: Union[None, List[float]] = None
-    
+
 
 class URDFtoMuJoCoLoader:
     def __init__(self, mjcf: str, cfg: URDFtoMuJoCoLoaderCfg):
@@ -151,6 +151,7 @@ class URDFtoMuJoCoLoader:
         # Add a link called "world"
         world_link = ET.Element("link", attrib={"name": "world"})
         root.insert(0, world_link)
+
     def set_control_mode(self, joint: Union[str, List[str]], mode: ControlMode):
         """
         Set the control mode for the joint.
@@ -194,7 +195,7 @@ class URDFtoMuJoCoLoader:
         """
         self.controlled_joints = joints
         joint_elements = {joint.attrib["name"]: joint for joint in self.mjcf.findall(".//joint")}
-        
+
         for controlled_joint in self.controlled_joints:
             joint_element = joint_elements.get(controlled_joint)
             if joint_element is not None:
@@ -211,7 +212,7 @@ class URDFtoMuJoCoLoader:
             str: The Mujoco XML string.
         """
         return self.mjcf
-    
+
     def get_mjcf_string(self):
         """
         Get the Mujoco XML string.
@@ -220,4 +221,3 @@ class URDFtoMuJoCoLoader:
             str: The Mujoco XML string.
         """
         return ET.tostring(self.mjcf, encoding="unicode", method="xml")
-    

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -1,24 +1,25 @@
-import idyntree.bindings as idyn
-import xml.etree.ElementTree as ET
-from typing import List, Union
-import resolve_robotics_uri_py as rru
-import tempfile
 import dataclasses
 import logging
+import tempfile
+import xml.etree.ElementTree as ET
+from enum import Enum
+from typing import List, Union
 
-from mujoco_urdf_loader.urdf_fcn import (
-    add_mujoco_element,
-    get_mesh_path,
-    remove_gazebo_elements,
-)
+import idyntree.bindings as idyn
+import resolve_robotics_uri_py as rru
+
+from mujoco_urdf_loader.generator import load_urdf_into_mjcf
 from mujoco_urdf_loader.mjcf_fcn import (
     add_position_actuator,
     add_torque_actuator,
     separate_left_right_collision_groups,
 )
-from mujoco_urdf_loader.generator import load_urdf_into_mjcf
+from mujoco_urdf_loader.urdf_fcn import (
+    add_mujoco_element,
+    get_mesh_path,
+    remove_gazebo_elements,
+)
 
-from enum import Enum
 
 class ControlMode(Enum):
     POSITION = "position"

--- a/mujoco_urdf_loader/mjcf_fcn.py
+++ b/mujoco_urdf_loader/mjcf_fcn.py
@@ -105,7 +105,7 @@ def add_torque_actuator(
 
     # check if the ctrlrange is None
     if ctrlrange is None:
-        ctrlrange = [-1, 1]
+        ctrlrange = [-1000, 1000]
 
     # check if there already is an actuator element in the mjcf
     if mjcf.find(".//actuator") is None:

--- a/mujoco_urdf_loader/wrapper.py
+++ b/mujoco_urdf_loader/wrapper.py
@@ -1,7 +1,9 @@
 import dataclasses
 import logging
-import numpy as np
+
 import mujoco
+import numpy as np
+
 
 @dataclasses.dataclass
 class MujocoWrapper:
@@ -37,7 +39,7 @@ class MujocoWrapper:
         if control.shape != self.data.ctrl.shape:
             raise ValueError(f"Control input shape {control.shape} does not match the expected shape {self.data.ctrl.shape}.")
         self.data.ctrl[:] = control
-    
+
     @property
     def joint_positions(self):
         """
@@ -47,7 +49,7 @@ class MujocoWrapper:
             np.ndarray: The joint positions.
         """
         return self.joint_to_actuator_mapping @ self.data.qpos[7:]
-    
+
     @property
     def joint_velocities(self):
         """
@@ -57,7 +59,7 @@ class MujocoWrapper:
             np.ndarray: The joint velocities.
         """
         return self.joint_to_actuator_mapping @ self.data.qvel[6:]
-    
+
     @property
     def base_position(self):
         """
@@ -67,7 +69,7 @@ class MujocoWrapper:
             np.ndarray: The base position.
         """
         return self.data.qpos[:3]
-    
+
     @property
     def base_orientation(self):
         """
@@ -87,4 +89,3 @@ class MujocoWrapper:
             np.ndarray: The base velocity (linear and angular).
         """
         return self.data.qvel[:6]
-    

--- a/mujoco_urdf_loader/wrapper.py
+++ b/mujoco_urdf_loader/wrapper.py
@@ -12,8 +12,8 @@ class MujocoWrapper:
     def __post_init__(self):
         self.model = mujoco.MjModel.from_xml_string(self.mjcf)
         self.data = mujoco.MjData(self.model)
-        self.joint_names = [self.model.joint(j).name for j in range(self.model.njnt) if self.model.joint(j).name != "base_link_fixed_joint"]
         self.actuator_names = [self.model.actuator(a).name for a in range(self.model.nu)]
+        self.joint_names = [self.model.joint(j).name for j in range(self.model.njnt) if self.model.joint(j).name in self.actuator_names]
         logging.info(f"Actuator loaded: {self.actuator_names}")
         self.initialize_joint_mapping()
 

--- a/tests/test_urdf_to_mujoco_loader_class.py
+++ b/tests/test_urdf_to_mujoco_loader_class.py
@@ -1,5 +1,10 @@
-from mujoco_urdf_loader import URDFtoMuJoCoLoader, URDFtoMuJoCoLoaderCfg, ControlMode
+from xml.etree import ElementTree as ET
+
 import resolve_robotics_uri_py as rru
+
+from mujoco_urdf_loader import ControlMode, URDFtoMuJoCoLoader, URDFtoMuJoCoLoaderCfg
+from mujoco_urdf_loader.urdf_fcn import get_mesh_path
+
 
 def test_load_urdf_into_mjcf():
 
@@ -41,8 +46,9 @@ def test_load_urdf_into_mjcf():
     urdf_string = str(
         rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN002/model.urdf")
     )
+    mesh_path = get_mesh_path(ET.parse(urdf_string).getroot())
 
-    loader = URDFtoMuJoCoLoader.load_urdf(urdf_string, cfg)
+    loader = URDFtoMuJoCoLoader.load_urdf(urdf_string, mesh_path, cfg)
 
     mjcf = loader.get_mjcf_string()
 


### PR DESCRIPTION
This PR fixes a potential problem when adding an additional floating joint to connect the root of the robot to the world. 
I was exploiting the fact that the idyntree model reducer is adding/renaming the not actuated joints to `{joint}_fixed_joint`. TBH I was thinking that the model reducer was adding an additional link and `base_link_fixed_joint` whatever robot. 

```python
for joint in root.findall(".//joint"):
    if joint.attrib.get("name") == "base_link_fixed_joint":
        joint.attrib["type"] = "floating"
        logging.info(f"Modified joint base_link_fixed_joint to type floating.")
        break
```

This is clearly wrong and can fail when loading different `urdf`s. For completeness, I was generating the ergocub model retrieved with `cub-model,` `v2.8.0` if I'm not wrong. 

The new logic checks what is the root link and adds an additional `world` link and a new `floating_joint` with
```python
# Find all the links and joints in the URDF
links = {link.attrib["name"]: link for link in root.findall(".//link")}
joints = root.findall(".//joint")
# Find child and parent links for each joint
child_links = {joint.find("child").attrib["link"] for joint in joints}
parent_links = {joint.find("parent").attrib["link"] for joint in joints}
# The root link is a parent link that is not a child link
root_link = next(link for link in links if link not in child_links)

# Add a floating joint that connects the root link to the world
floating_joint = ET.Element("joint", attrib={
    "name": f"{root_link}_floating_joint",
    "type": "floating"
})
# Populate the floating joint
parent_element = ET.SubElement(floating_joint, "parent", attrib={"link": "world"})
child_element = ET.SubElement(floating_joint, "child", attrib={"link": root_link})
# Add the floating joint to the urdf root
root.insert(0, floating_joint)
# Add a link called "world"
world_link = ET.Element("link", attrib={"name": "world"})
root.insert(0, world_link)
```

This PR also 
- updates the default values for the `ctrlrange` for the torque control mode. Before was set to `[-1,1]`, clearly too small!
 - allows the user to set the `mesh_path` from the outside, for a more versatile configuration.