### PR TITLE
Fix temporary file management on Windows OS

### DIFF
--- a/mujoco_urdf_loader/generator.py
+++ b/mujoco_urdf_loader/generator.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import xml.etree.ElementTree as ET
 
@@ -9,8 +10,14 @@ def load_urdf_into_mjcf(robot_urdf: ET.Element) -> ET.Element:
 
     model = mujoco.MjModel.from_xml_string(model_str)
 
-    with tempfile.NamedTemporaryFile(mode="w+") as f:
+    # Use delete=False to allow mujoco to write to the file on Windows
+    # (Windows doesn't allow opening a file that's already open)
+    f = tempfile.NamedTemporaryFile(mode="w+", suffix=".xml", delete=False)
+    try:
+        f.close()  # Close the file so mujoco can write to it
         mujoco.mj_saveLastXML(f.name, model)
         mjcf_file = ET.parse(f.name).getroot()
+    finally:
+        os.unlink(f.name)  # Clean up the temp file
 
     return mjcf_file


### PR DESCRIPTION
While testing https://github.com/gbionics/gb-gene-models/pull/5, I discovered an error in loading the urdf on Windows. The problem seems related to the management of temporary files on Windows OS:

```cmd
Traceback (most recent call last):
  File "C:\Users\AntonelloPaolino\code\gb-gene-models\scripts\generate_mjcf_model.py", line 142, in <module>
    main()
    ~~~~^^
  File "C:\Users\AntonelloPaolino\code\gb-gene-models\scripts\generate_mjcf_model.py", line 95, in main
    loader = URDFtoMuJoCoLoader.load_urdf(urdf_path, mesh_path, cfg)
  File "C:\Users\AntonelloPaolino\code\mujoco-urdf-loader\mujoco_urdf_loader\loader.py", line 68, in load_urdf
    mjcf = load_urdf_into_mjcf(urdf_string)
  File "C:\Users\AntonelloPaolino\code\mujoco-urdf-loader\mujoco_urdf_loader\generator.py", line 13, in load_urdf_into_mjcf
    mujoco.mj_saveLastXML(f.name, model)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
mujoco.FatalError: File not found
```

I changed the code and now it works, I would check if the behavior is correct also on Ubuntu and the change doesn't break the current code.

cc @traversaro @GiulioRomualdi 