### PR TITLE
Allow specification of linear coefficients in joint coupling

### DIFF
--- a/mujoco_urdf_loader/mjcf_fcn.py
+++ b/mujoco_urdf_loader/mjcf_fcn.py
@@ -177,15 +177,22 @@ def add_joint_vel_sensor(mjcf: ET.Element, joint: str, name: str = None) -> ET.E
 
 
 def add_joint_eq(
-    mjcf: ET.Element, joint1: str, joint2: str, name: str = None
+    mjcf: ET.Element, 
+    joint1: str, 
+    joint2: str, 
+    name: str = None, 
+    multiplier: float = 1.0, 
+    offset: float = 0.0
 ) -> ET.Element:
     """Add a joint equality constraint between two joints.
 
     Args:
         mjcf (ET.Element): The mjcf file.
-        joint1 (str): The first joint.
-        joint2 (str): The second joint.
+        joint1 (str): The first joint, the dependent joint.
+        joint2 (str): The second joint, the independent joint.
         name (str): The name of the equality constraint (default: f"{joint1}_{joint2}").
+        multiplier (float): The multiplier for the equality constraint (default: 1.0).
+        offset (float): The offset for the equality constraint (default: 0.0).
     """
 
     # check if there already is an equality element in the mjcf
@@ -200,6 +207,10 @@ def add_joint_eq(
     dist_eq.set("name", name if name is not None else f"{joint1}_{joint2}")
     dist_eq.set("joint1", joint1)
     dist_eq.set("joint2", joint2)
+
+    # Set the polynomial coefficients for the equality constraint: joint1 = multiplier * joint2 + offset
+    polycoef = f"{offset} {multiplier} 0 0 0"
+    dist_eq.set("polycoef", polycoef)
 
     return mjcf
 

--- a/mujoco_urdf_loader/urdf_fcn.py
+++ b/mujoco_urdf_loader/urdf_fcn.py
@@ -139,7 +139,6 @@ def add_mujoco_element(robot_urdf: ET.Element, mesh_path: Path) -> ET.Element:
         "meshdir",
         str(mesh_path),
     )
-
     return new_robot_urdf
 
 
@@ -166,3 +165,24 @@ def get_joint_limits(robot_urdf: ET.Element) -> dict:
         }
 
     return joint_limits
+
+def get_joint_couplings(robot_urdf: ET.Element) -> dict:
+    """
+    Get the joint couplings from the urdf.
+
+    Args:
+        robot_urdf (ET.Element): The robot urdf.
+    Returns:
+        dict: The joint couplings.
+    """
+    joint_couplings = {}
+    for joint in robot_urdf.findall(".//joint"):
+        mimic = joint.find("mimic")
+        if mimic is not None:
+            joint_couplings[joint.attrib["name"]] = {
+                "joint": mimic.attrib["joint"],
+                "multiplier": float(mimic.attrib.get("multiplier", 1.0)),
+                "offset": float(mimic.attrib.get("offset", 0.0)),
+            }
+
+    return joint_couplings


### PR DESCRIPTION
This PR introduces a couple of utility functions to better handle the coupling of the joints.

In our use case, the URDF provides some information about the joint coupling. The URDF parameters (`multiplier` and `offset`) allow you to describe the linear relationship between the joints. Mujoco's format actually allows you to describe a 5th order polynomial, but we should be good with just the first two parameters.

In the previous code, you could only specify an exact 1 to 1 equality between two joints.