### PR TITLE
Refactor URDFtoMuJoCoLoader tests to use observed_joints instead of controlled_joints and add the possibility to set the frictionloss and the damping to the observed joints

### DIFF
--- a/examples/generate_ergoCub_xml.py
+++ b/examples/generate_ergoCub_xml.py
@@ -12,7 +12,7 @@ from mujoco_urdf_loader import (
 )
 from mujoco_urdf_loader.urdf_fcn import get_mesh_path
 
-controlled_joints = [
+observed_joints = [
     "l_hip_pitch",
     "r_hip_pitch",
     "torso_roll",
@@ -41,11 +41,16 @@ controlled_joints = [
     "r_elbow",
 ]
 
-control_modes = [ControlMode.TORQUE] * len(controlled_joints)
-stiffness = [0.0] * len(controlled_joints)
-damping = [0.0] * len(controlled_joints)
+control_modes = [ControlMode.TORQUE] * len(observed_joints)
+stiffness = [0.0] * len(observed_joints)
+damping = [0.0] * len(observed_joints)
 
-cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping)
+cfg = URDFtoMuJoCoLoaderCfg(
+    observed_joints=observed_joints,
+    control_modes=control_modes,
+    stiffness=stiffness,
+    damping=damping,
+)
 
 urdf_string = str(
     rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN002/model.urdf")

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -21,7 +21,6 @@ from mujoco_urdf_loader.mjcf_fcn import (
 )
 from mujoco_urdf_loader.urdf_fcn import (
     add_mujoco_element,
-    get_mesh_path,
     remove_gazebo_elements,
     detect_spherical_joint_groups,
     collapse_spherical_revolute_triplets,
@@ -61,10 +60,13 @@ class EqualityConstraintCfg:
 
 @dataclasses.dataclass
 class URDFtoMuJoCoLoaderCfg:
-    controlled_joints: List[str]
+    observed_joints: Union[None, List[str]] = None
+    actuated_joints: Union[None, List[str]] = None
     control_modes: Union[None, List[ControlMode]] = None
     stiffness: Union[None, List[float]] = None
     damping: Union[None, List[float]] = None
+    joint_damping: Union[None, List[float]] = None
+    joint_frictionloss: Union[None, List[float]] = None
     armature: Union[None, List[float]] = None
     all_missing_joints_as_sites: bool = False
     framequat_sensors_cfg: Union[None, List[Union[FrameQuatSensorCfg, Dict[str, Any]]]] = None
@@ -83,15 +85,232 @@ class URDFtoMuJoCoLoader:
 
         Args:
             mjcf (str): The MuJoCo string.
-            joints (List[str]): The list of joints to command.
+            cfg (URDFtoMuJoCoLoaderCfg): Loader configuration.
         """
+        normalized_cfg = self._normalize_cfg(cfg)
+
         self.mjcf = mjcf
-        self.controlled_joints = cfg.controlled_joints
+        self.observed_joints = normalized_cfg.observed_joints
+        self.actuated_joints = normalized_cfg.actuated_joints
+
+        self.control_mode = {
+            joint: mode
+            for joint, mode in zip(self.actuated_joints, normalized_cfg.control_modes)
+        }
+
+        self.set_observed_joint_dynamics(
+            damping=normalized_cfg.joint_damping,
+            frictionloss=normalized_cfg.joint_frictionloss,
+        )
+
+        self.set_actuated_joints(
+            normalized_cfg.actuated_joints,
+            stiffness=normalized_cfg.stiffness,
+            damping=normalized_cfg.damping,
+        )
+
+    @staticmethod
+    def _normalize_cfg(cfg: URDFtoMuJoCoLoaderCfg) -> URDFtoMuJoCoLoaderCfg:
+        """Normalize and validate joint/control related arrays."""
+        observed_joints = cfg.observed_joints
+
+        if observed_joints is None:
+            raise ValueError("observed_joints must be provided.")
+        observed_joints = list(observed_joints)
+
+        actuated_joints = (
+            list(cfg.actuated_joints)
+            if cfg.actuated_joints is not None
+            else list(observed_joints)
+        )
+
+        observed_set = set(observed_joints)
+        invalid_actuated = [j for j in actuated_joints if j not in observed_set]
+        if invalid_actuated:
+            raise ValueError(
+                "actuated_joints must be a subset of observed_joints. "
+                f"Invalid entries: {invalid_actuated}"
+            )
+
         if cfg.control_modes is None:
-            self.control_mode = {joint: ControlMode.TORQUE for joint in cfg.controlled_joints}
+            control_modes = [ControlMode.TORQUE] * len(actuated_joints)
         else:
-            self.control_mode = {joint: mode for joint, mode in zip(cfg.controlled_joints, cfg.control_modes)}
-        self.set_controlled_joints(cfg.controlled_joints)
+            if len(cfg.control_modes) != len(actuated_joints):
+                raise ValueError(
+                    f"Length of control_modes ({len(cfg.control_modes)}) must match "
+                    f"the number of actuated_joints ({len(actuated_joints)})."
+                )
+            control_modes = []
+            for mode in cfg.control_modes:
+                if isinstance(mode, ControlMode):
+                    control_modes.append(mode)
+                elif isinstance(mode, str):
+                    mode_upper = mode.upper()
+                    if mode_upper in ControlMode.__members__:
+                        control_modes.append(ControlMode[mode_upper])
+                    else:
+                        try:
+                            control_modes.append(ControlMode(mode.lower()))
+                        except ValueError as exc:
+                            raise ValueError(
+                                f"Unsupported control mode: {mode}"
+                            ) from exc
+                else:
+                    raise TypeError(
+                        "Each control mode must be a ControlMode enum or string."
+                    )
+
+        stiffness = list(cfg.stiffness) if cfg.stiffness is not None else None
+        damping = list(cfg.damping) if cfg.damping is not None else None
+
+        has_position = any(mode == ControlMode.POSITION for mode in control_modes)
+        if has_position:
+            if stiffness is None:
+                raise ValueError(
+                    "stiffness is required when any actuator uses POSITION control mode."
+                )
+            if damping is None:
+                raise ValueError(
+                    "damping is required when any actuator uses POSITION control mode."
+                )
+
+        if stiffness is not None and len(stiffness) != len(actuated_joints):
+            raise ValueError(
+                f"Length of stiffness ({len(stiffness)}) must match "
+                f"the number of actuated_joints ({len(actuated_joints)})."
+            )
+
+        if damping is not None and len(damping) != len(actuated_joints):
+            raise ValueError(
+                f"Length of damping ({len(damping)}) must match "
+                f"the number of actuated_joints ({len(actuated_joints)})."
+            )
+
+        joint_damping = (
+            list(cfg.joint_damping) if cfg.joint_damping is not None else None
+        )
+        if joint_damping is not None and len(joint_damping) != len(observed_joints):
+            raise ValueError(
+                f"Length of joint_damping ({len(joint_damping)}) must match "
+                f"the number of observed_joints ({len(observed_joints)})."
+            )
+
+        joint_frictionloss = (
+            list(cfg.joint_frictionloss)
+            if cfg.joint_frictionloss is not None
+            else None
+        )
+        if joint_frictionloss is not None and len(joint_frictionloss) != len(observed_joints):
+            raise ValueError(
+                f"Length of joint_frictionloss ({len(joint_frictionloss)}) must match "
+                f"the number of observed_joints ({len(observed_joints)})."
+            )
+
+        armature = list(cfg.armature) if cfg.armature is not None else None
+        normalized_armature = None
+        if armature is not None:
+            if len(armature) == len(actuated_joints):
+                # Canonical: one armature value per actuated joint.
+                normalized_armature = list(armature)
+            elif len(armature) == len(observed_joints):
+                # Also accept one value per observed joint and project by name to
+                # the actuated subset.
+                observed_armature = {
+                    joint_name: value
+                    for joint_name, value in zip(observed_joints, armature)
+                }
+                normalized_armature = [
+                    observed_armature[joint_name] for joint_name in actuated_joints
+                ]
+            else:
+                raise ValueError(
+                    f"Length of armature ({len(armature)}) must match "
+                    f"the number of actuated_joints ({len(actuated_joints)}) "
+                    f"or observed_joints ({len(observed_joints)})."
+                )
+
+        return URDFtoMuJoCoLoaderCfg(
+            observed_joints=list(observed_joints),
+            actuated_joints=list(actuated_joints),
+            control_modes=list(control_modes),
+            stiffness=stiffness,
+            damping=damping,
+            joint_damping=joint_damping,
+            joint_frictionloss=joint_frictionloss,
+            armature=normalized_armature,
+            all_missing_joints_as_sites=cfg.all_missing_joints_as_sites,
+            framequat_sensors_cfg=cfg.framequat_sensors_cfg,
+            gyro_sensors_cfg=cfg.gyro_sensors_cfg,
+            cameras_cfg=cfg.cameras_cfg,
+            equality_constraints_cfg=cfg.equality_constraints_cfg,
+            ball_joint_damping=cfg.ball_joint_damping,
+            ball_joint_armature=cfg.ball_joint_armature,
+            ball_joint_frictionloss=cfg.ball_joint_frictionloss,
+        )
+
+    @staticmethod
+    def _filter_cfg_for_removed_joints(
+        cfg: URDFtoMuJoCoLoaderCfg, removed_joints: set
+    ) -> URDFtoMuJoCoLoaderCfg:
+        if not removed_joints:
+            return cfg
+
+        filtered_observed_indices = [
+            i for i, joint in enumerate(cfg.observed_joints) if joint not in removed_joints
+        ]
+        filtered_observed = [cfg.observed_joints[i] for i in filtered_observed_indices]
+
+        filtered_actuated_indices = [
+            i for i, joint in enumerate(cfg.actuated_joints) if joint not in removed_joints
+        ]
+        filtered_actuated = [cfg.actuated_joints[i] for i in filtered_actuated_indices]
+
+        filtered_control_modes = [cfg.control_modes[i] for i in filtered_actuated_indices]
+
+        filtered_stiffness = (
+            [cfg.stiffness[i] for i in filtered_actuated_indices]
+            if cfg.stiffness is not None
+            else None
+        )
+        filtered_damping = (
+            [cfg.damping[i] for i in filtered_actuated_indices]
+            if cfg.damping is not None
+            else None
+        )
+        filtered_joint_damping = (
+            [cfg.joint_damping[i] for i in filtered_observed_indices]
+            if cfg.joint_damping is not None
+            else None
+        )
+        filtered_joint_frictionloss = (
+            [cfg.joint_frictionloss[i] for i in filtered_observed_indices]
+            if cfg.joint_frictionloss is not None
+            else None
+        )
+        filtered_armature = (
+            [cfg.armature[i] for i in filtered_actuated_indices]
+            if cfg.armature is not None
+            else None
+        )
+
+        return URDFtoMuJoCoLoaderCfg(
+            observed_joints=filtered_observed,
+            actuated_joints=filtered_actuated,
+            control_modes=filtered_control_modes,
+            stiffness=filtered_stiffness,
+            damping=filtered_damping,
+            joint_damping=filtered_joint_damping,
+            joint_frictionloss=filtered_joint_frictionloss,
+            armature=filtered_armature,
+            all_missing_joints_as_sites=cfg.all_missing_joints_as_sites,
+            framequat_sensors_cfg=cfg.framequat_sensors_cfg,
+            gyro_sensors_cfg=cfg.gyro_sensors_cfg,
+            cameras_cfg=cfg.cameras_cfg,
+            equality_constraints_cfg=cfg.equality_constraints_cfg,
+            ball_joint_damping=cfg.ball_joint_damping,
+            ball_joint_armature=cfg.ball_joint_armature,
+            ball_joint_frictionloss=cfg.ball_joint_frictionloss,
+        )
 
     @staticmethod
     def load_urdf(urdf_path: str, mesh_path: str, cfg: URDFtoMuJoCoLoaderCfg):
@@ -100,29 +319,35 @@ class URDFtoMuJoCoLoader:
 
         Args:
             urdf_path (Path): The URDF file path.
-            cfg (URDFtoMuJoCoLoaderCfg): The configuration containing the controlled joints, control modes, stiffness and damping.
+            cfg (URDFtoMuJoCoLoaderCfg): The loader configuration.
 
         Returns:
-            str: The URDF string.
+            URDFtoMuJoCoLoader: The initialized loader instance.
         """
-        original_urdf = ET.parse(urdf_path).getroot()
-        original_urdf = remove_gazebo_elements(original_urdf)
+        normalized_cfg = URDFtoMuJoCoLoader._normalize_cfg(cfg)
 
-        urdf_string = URDFtoMuJoCoLoader.simplify_urdf(urdf_path, cfg.controlled_joints, cfg.stiffness, cfg.damping)
+        urdf_string = URDFtoMuJoCoLoader.simplify_urdf(
+            urdf_path,
+            normalized_cfg.observed_joints,
+            None,
+            None,
+        )
         reduced_urdf = remove_gazebo_elements(urdf_string)
 
         # --- Spherical joint handling ---
         # Detect triplets of revolute joints that represent spherical joints
         # (iDynTree convention: 3 revolute joints with x/y/z axes + 2 dummy links)
-        spherical_groups = detect_spherical_joint_groups(cfg.controlled_joints)
+        spherical_groups = detect_spherical_joint_groups(normalized_cfg.observed_joints)
         ball_joint_map = {}
         if spherical_groups:
             reduced_urdf, ball_joint_map = collapse_spherical_revolute_triplets(
                 reduced_urdf, spherical_groups
             )
-            print(f"Collapsed {len(spherical_groups)} spherical joint group(s) "
-                  f"into ball joint placeholders: "
-                  f"{[g['base_name'] for g in spherical_groups]}")
+            print(
+                f"Collapsed {len(spherical_groups)} spherical joint group(s) "
+                "into ball joint placeholders: "
+                f"{[g['base_name'] for g in spherical_groups]}"
+            )
 
         urdf_for_mjcf = add_mujoco_element(reduced_urdf, mesh_path)
         mjcf = load_urdf_into_mjcf(urdf_for_mjcf)
@@ -131,56 +356,25 @@ class URDFtoMuJoCoLoader:
         # Convert placeholder hinge joints to MuJoCo ball joints
         if ball_joint_map:
             convert_hinge_to_ball_joints(
-                mjcf, ball_joint_map,
-                damping=cfg.ball_joint_damping,
-                armature=cfg.ball_joint_armature,
-                frictionloss=cfg.ball_joint_frictionloss,  # use damping value for frictionloss as well for stability
+                mjcf,
+                ball_joint_map,
+                damping=normalized_cfg.ball_joint_damping,
+                armature=normalized_cfg.ball_joint_armature,
+                frictionloss=normalized_cfg.ball_joint_frictionloss,
             )
 
         # Build the set of spherical joint names (all 3 axes) for filtering
         spherical_joint_names = set()
         for group in spherical_groups:
-            spherical_joint_names.update([
-                group["joint_x"], group["joint_y"], group["joint_z"]
-            ])
+            spherical_joint_names.update(
+                [group["joint_x"], group["joint_y"], group["joint_z"]]
+            )
 
-        # Create a filtered config that excludes the spherical revolute joints
-        # (ball joints are passive and don't need actuators)
-        if spherical_joint_names:
-            filtered_indices = [
-                i for i, j in enumerate(cfg.controlled_joints)
-                if j not in spherical_joint_names
-            ]
-            filtered_joints = [cfg.controlled_joints[i] for i in filtered_indices]
-            filtered_control_modes = (
-                [cfg.control_modes[i] for i in filtered_indices]
-                if cfg.control_modes is not None else None
-            )
-            filtered_stiffness = (
-                [cfg.stiffness[i] for i in filtered_indices]
-                if cfg.stiffness is not None else None
-            )
-            filtered_damping = (
-                [cfg.damping[i] for i in filtered_indices]
-                if cfg.damping is not None else None
-            )
-            filtered_armature = (
-                [cfg.armature[i] for i in filtered_indices]
-                if cfg.armature is not None else None
-            )
-            mjcf_cfg = URDFtoMuJoCoLoaderCfg(
-                controlled_joints=filtered_joints,
-                control_modes=filtered_control_modes,
-                stiffness=filtered_stiffness,
-                damping=filtered_damping,
-                armature=filtered_armature,
-                all_missing_joints_as_sites=cfg.all_missing_joints_as_sites,
-                framequat_sensors_cfg=cfg.framequat_sensors_cfg,
-                gyro_sensors_cfg=cfg.gyro_sensors_cfg,
-                equality_constraints_cfg=cfg.equality_constraints_cfg,
-            )
-        else:
-            mjcf_cfg = cfg
+        # Ball-joint triplets are passive: remove them from observed + actuated
+        # vectors before adding actuators and setting per-joint values.
+        mjcf_cfg = URDFtoMuJoCoLoader._filter_cfg_for_removed_joints(
+            normalized_cfg, spherical_joint_names
+        )
 
         # Use the reduced URDF (from iDynTree) for computing site transforms.
         # iDynTree modifies joint origins when merging links during model
@@ -189,17 +383,17 @@ class URDFtoMuJoCoLoader:
         missing_joint_sites = URDFtoMuJoCoLoader.get_missing_joint_sites(
             reduced_urdf,
             mjcf,
-            controlled_joints=mjcf_cfg.controlled_joints,
+            observed_joints=mjcf_cfg.observed_joints,
             all_missing_joints_as_sites=mjcf_cfg.all_missing_joints_as_sites,
         )
 
         loader = URDFtoMuJoCoLoader(mjcf, mjcf_cfg)
         loader.set_armature(mjcf_cfg.armature)
         loader.add_sites_for_missing_joints(missing_joint_sites)
-        loader.add_framequat_sensors(cfg.framequat_sensors_cfg)
-        loader.add_gyro_sensors(cfg.gyro_sensors_cfg)
-        loader.add_cameras(cfg.cameras_cfg)
-        loader.add_equality_constraints(cfg.equality_constraints_cfg)
+        loader.add_framequat_sensors(mjcf_cfg.framequat_sensors_cfg)
+        loader.add_gyro_sensors(mjcf_cfg.gyro_sensors_cfg)
+        loader.add_cameras(mjcf_cfg.cameras_cfg)
+        loader.add_equality_constraints(mjcf_cfg.equality_constraints_cfg)
         return loader
 
     @staticmethod
@@ -381,7 +575,7 @@ class URDFtoMuJoCoLoader:
     def get_missing_joint_sites(
         robot_urdf: ET.Element,
         mjcf: ET.Element,
-        controlled_joints: List[str] = None,
+        observed_joints: List[str] = None,
         all_missing_joints_as_sites: bool = False,
     ) -> List[dict]:
         """Extract metadata for URDF links missing as bodies in MJCF.
@@ -397,7 +591,7 @@ class URDFtoMuJoCoLoader:
         Args:
             robot_urdf (ET.Element): The URDF root element.
             mjcf (ET.Element): The MJCF root element.
-            controlled_joints (List[str]): The list of controlled joint names.
+            observed_joints (List[str]): The list of observed joint names.
                 Used only for context; detection is based on comparing all URDF
                 links against MJCF bodies.
             all_missing_joints_as_sites (bool): If True, enable site generation
@@ -409,8 +603,8 @@ class URDFtoMuJoCoLoader:
         if not all_missing_joints_as_sites:
             return []
 
-        if controlled_joints is None:
-            controlled_joints = []
+        if observed_joints is None:
+            observed_joints = []
 
         all_joint_elements = robot_urdf.findall(".//joint")
 
@@ -661,25 +855,60 @@ class URDFtoMuJoCoLoader:
             raise ValueError("No fixed joint found that can be modified to floating.")
 
     def set_armature(self, armature: Union[None, List[float]]):
-        """Set the armature attribute on each controlled joint in the MJCF model.
+        """Set the armature attribute on each actuated joint in the MJCF model.
 
         Args:
-            armature (List[float] | None): Armature values, one per controlled joint.
+            armature (List[float] | None): Armature values, one per actuated joint.
                 If None, no armature attribute is set.
         """
         if armature is None:
             return
 
-        if len(armature) != len(self.controlled_joints):
+        if len(armature) != len(self.actuated_joints):
             raise ValueError(
                 f"Length of armature ({len(armature)}) must match "
-                f"the number of controlled joints ({len(self.controlled_joints)})."
+                f"the number of actuated_joints ({len(self.actuated_joints)})."
             )
 
-        for joint_name, value in zip(self.controlled_joints, armature):
+        for joint_name, value in zip(self.actuated_joints, armature):
             joint_elem = self.mjcf.find(f".//joint[@name='{joint_name}']")
             if joint_elem is not None:
                 joint_elem.set("armature", str(value))
+
+    def set_observed_joint_dynamics(
+        self,
+        damping: Union[None, List[float]] = None,
+        frictionloss: Union[None, List[float]] = None,
+    ):
+        """Set damping/frictionloss attributes on observed joints.
+
+        Args:
+            damping (List[float] | None): Per-observed-joint damping values.
+            frictionloss (List[float] | None): Per-observed-joint frictionloss values.
+        """
+        if damping is None and frictionloss is None:
+            return
+
+        if damping is not None and len(damping) != len(self.observed_joints):
+            raise ValueError(
+                f"Length of joint_damping ({len(damping)}) must match "
+                f"the number of observed_joints ({len(self.observed_joints)})."
+            )
+
+        if frictionloss is not None and len(frictionloss) != len(self.observed_joints):
+            raise ValueError(
+                f"Length of joint_frictionloss ({len(frictionloss)}) must match "
+                f"the number of observed_joints ({len(self.observed_joints)})."
+            )
+
+        for index, joint_name in enumerate(self.observed_joints):
+            joint_elem = self.mjcf.find(f".//joint[@name='{joint_name}']")
+            if joint_elem is None:
+                continue
+            if damping is not None:
+                joint_elem.set("damping", str(float(damping[index])))
+            if frictionloss is not None:
+                joint_elem.set("frictionloss", str(float(frictionloss[index])))
 
     def set_control_mode(self, joint: Union[str, List[str]], mode: ControlMode):
         """
@@ -697,18 +926,48 @@ class URDFtoMuJoCoLoader:
         else:
             raise ValueError("joint must be a string or a list of strings.")
 
-    def add_actuator(self, joint: str, control_mode: ControlMode):
+    def add_actuator(
+        self,
+        joint: str,
+        control_mode: ControlMode,
+        stiffness: Union[None, float] = None,
+        damping: Union[None, float] = None,
+    ):
         """
         Add an actuator to the MJCF model.
 
         Args:
             joint (str): The joint name.
             control_mode (ControlMode): The control mode.
+            stiffness (float | None): Position gain used as kp for position mode.
+            damping (float | None): Joint damping applied for position mode.
         """
         if control_mode == ControlMode.POSITION:
+            if stiffness is None:
+                raise ValueError(
+                    f"POSITION control for joint {joint} requires stiffness (kp)."
+                )
+            if damping is None:
+                raise ValueError(
+                    f"POSITION control for joint {joint} requires damping."
+                )
+
             joint_mjcf = self.mjcf.find(f".//joint[@name='{joint}']")
+            if joint_mjcf is None:
+                raise ValueError(f"Joint {joint} not found in the MJCF model.")
+            if "range" not in joint_mjcf.attrib:
+                raise ValueError(
+                    f"Joint {joint} is missing range, required for position control."
+                )
+
             ctrlrange = list(map(float, joint_mjcf.attrib["range"].split()))
-            add_position_actuator(self.mjcf, joint=joint, ctrlrange=ctrlrange)
+            add_position_actuator(
+                self.mjcf,
+                joint=joint,
+                ctrlrange=ctrlrange,
+                kp=float(stiffness),
+            )
+            joint_mjcf.set("damping", str(float(damping)))
         elif control_mode == ControlMode.TORQUE:
             add_torque_actuator(self.mjcf, joint=joint, ctrlrange=None)
         elif control_mode == ControlMode.VELOCITY:
@@ -716,24 +975,44 @@ class URDFtoMuJoCoLoader:
         else:
             raise ValueError("Control mode not recognized.")
 
-    def set_controlled_joints(self, joints: List[str]):
-        """
-        Set the controlled joints.
+    def set_actuated_joints(
+        self,
+        joints: List[str],
+        stiffness: Union[None, List[float]] = None,
+        damping: Union[None, List[float]] = None,
+    ):
+        """Set actuated joints and add actuators according to per-joint modes."""
+        self.actuated_joints = list(joints)
+        joint_elements = {
+            joint.attrib["name"]: joint for joint in self.mjcf.findall(".//joint")
+        }
 
-        Args:
-            joints (List[str]): The list of joints.
-        """
-        self.controlled_joints = joints
-        joint_elements = {joint.attrib["name"]: joint for joint in self.mjcf.findall(".//joint")}
+        if stiffness is not None and len(stiffness) != len(self.actuated_joints):
+            raise ValueError(
+                f"Length of stiffness ({len(stiffness)}) must match "
+                f"the number of actuated_joints ({len(self.actuated_joints)})."
+            )
 
-        for controlled_joint in self.controlled_joints:
-            joint_element = joint_elements.get(controlled_joint)
-            if joint_element is not None:
-                self.add_actuator(controlled_joint, self.control_mode[controlled_joint])
-            else:
-                raise ValueError(
-                    f"Joint {controlled_joint} not found in the MJCF model."
-                )
+        if damping is not None and len(damping) != len(self.actuated_joints):
+            raise ValueError(
+                f"Length of damping ({len(damping)}) must match "
+                f"the number of actuated_joints ({len(self.actuated_joints)})."
+            )
+
+        for i, actuated_joint in enumerate(self.actuated_joints):
+            joint_element = joint_elements.get(actuated_joint)
+            if joint_element is None:
+                raise ValueError(f"Joint {actuated_joint} not found in the MJCF model.")
+
+            if actuated_joint not in self.control_mode:
+                self.control_mode[actuated_joint] = ControlMode.TORQUE
+
+            self.add_actuator(
+                actuated_joint,
+                self.control_mode[actuated_joint],
+                stiffness=(stiffness[i] if stiffness is not None else None),
+                damping=(damping[i] if damping is not None else None),
+            )
 
     def add_sites_for_missing_joints(self, fixed_joint_sites: List[dict]):
         """Add one MJCF site for each configured missing URDF joint.

--- a/tests/test_loader_camera_cfg.py
+++ b/tests/test_loader_camera_cfg.py
@@ -24,7 +24,7 @@ def _make_empty_mjcf() -> ET.Element:
 
 
 def test_add_cameras_none_keeps_model_unchanged():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_cameras(None)
 
@@ -32,7 +32,7 @@ def test_add_cameras_none_keeps_model_unchanged():
 
 
 def test_add_cameras_accepts_list_of_dataclasses():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_cameras(
         [
@@ -52,7 +52,7 @@ def test_add_cameras_accepts_list_of_dataclasses():
 
 
 def test_add_cameras_accepts_dict_with_site_key():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_cameras(
         [
@@ -70,7 +70,7 @@ def test_add_cameras_accepts_dict_with_site_key():
 
 
 def test_add_cameras_accepts_dict_with_link_alias():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_cameras(
         [
@@ -88,14 +88,14 @@ def test_add_cameras_accepts_dict_with_link_alias():
 
 
 def test_add_cameras_raises_on_missing_required_fields():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     with pytest.raises(ValueError):
         loader.add_cameras([{"name": "root_depth_camera", "fovy": 60.0}])
 
 def test_add_cameras_to_ergocub_sn001():
     urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
-    controlled_joints = [
+    observed_joints = [
             "l_hip_pitch",
             "r_hip_pitch",
             "torso_roll",
@@ -129,7 +129,7 @@ def test_add_cameras_to_ergocub_sn001():
         CameraCfg(name="root_rgb_camera", site="realsense_rgb_frame", fovy=75.0),
     ]
     cfg = URDFtoMuJoCoLoaderCfg(
-        controlled_joints=controlled_joints,
+        observed_joints=observed_joints,
         cameras_cfg=cameras_cfg,
         all_missing_joints_as_sites=True,
     )

--- a/tests/test_loader_equality_constraints_cfg.py
+++ b/tests/test_loader_equality_constraints_cfg.py
@@ -28,7 +28,7 @@ def _make_empty_mjcf() -> ET.Element:
 
 def test_add_equality_constraints_none_keeps_model_unchanged():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     loader.add_equality_constraints(None)
@@ -38,7 +38,7 @@ def test_add_equality_constraints_none_keeps_model_unchanged():
 
 def test_add_equality_constraints_accepts_list_of_dataclasses():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     loader.add_equality_constraints(
@@ -53,7 +53,7 @@ def test_add_equality_constraints_accepts_list_of_dataclasses():
 
 def test_add_equality_constraints_accepts_dict():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     loader.add_equality_constraints(
@@ -68,7 +68,7 @@ def test_add_equality_constraints_accepts_dict():
 
 def test_add_equality_constraints_multiple():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     loader.add_equality_constraints(
@@ -86,7 +86,7 @@ def test_add_equality_constraints_multiple():
 
 def test_add_equality_constraints_weld_type():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     loader.add_equality_constraints(
@@ -101,7 +101,7 @@ def test_add_equality_constraints_weld_type():
 
 def test_add_equality_constraints_raises_on_missing_fields():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     with pytest.raises(ValueError):
@@ -110,7 +110,7 @@ def test_add_equality_constraints_raises_on_missing_fields():
 
 def test_add_equality_constraints_raises_on_invalid_type():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     with pytest.raises(TypeError):

--- a/tests/test_loader_framequat_cfg.py
+++ b/tests/test_loader_framequat_cfg.py
@@ -20,7 +20,7 @@ def _make_empty_mjcf() -> ET.Element:
 
 
 def test_add_framequat_sensors_none_keeps_model_unchanged():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_framequat_sensors(None)
 
@@ -28,7 +28,7 @@ def test_add_framequat_sensors_none_keeps_model_unchanged():
 
 
 def test_add_framequat_sensors_accepts_list_of_dataclasses():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_framequat_sensors(
         [
@@ -50,7 +50,7 @@ def test_add_framequat_sensors_accepts_list_of_dataclasses():
 
 
 def test_add_framequat_sensors_accepts_dict_with_obtype_alias():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_framequat_sensors(
         [
@@ -69,7 +69,7 @@ def test_add_framequat_sensors_accepts_dict_with_obtype_alias():
 
 
 def test_add_framequat_sensors_raises_on_missing_required_fields():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     with pytest.raises(ValueError):
         loader.add_framequat_sensors([{"objname": "imu_frame", "name": "imu_quat"}])
@@ -77,7 +77,7 @@ def test_add_framequat_sensors_raises_on_missing_required_fields():
 
 def test_add_framequat_sensors_to_ergocub_sn001():
     urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
-    controlled_joints = [
+    observed_joints = [
         "l_hip_pitch",
         "r_hip_pitch",
         "torso_roll",
@@ -111,7 +111,7 @@ def test_add_framequat_sensors_to_ergocub_sn001():
         FrameQuatSensorCfg(objname="realsense_rgb_frame", objtype="site", name="realsense_rgb_quat"),
     ]
     cfg = URDFtoMuJoCoLoaderCfg(
-        controlled_joints=controlled_joints,
+        observed_joints=observed_joints,
         framequat_sensors_cfg=framequat_sensors_cfg,
         all_missing_joints_as_sites=True,
     )

--- a/tests/test_loader_gyro_cfg.py
+++ b/tests/test_loader_gyro_cfg.py
@@ -19,7 +19,7 @@ def _make_empty_mjcf() -> ET.Element:
 
 
 def test_add_gyro_sensors_none_keeps_model_unchanged():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_gyro_sensors(None)
 
@@ -27,7 +27,7 @@ def test_add_gyro_sensors_none_keeps_model_unchanged():
 
 
 def test_add_gyro_sensors_accepts_list_of_dataclasses():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_gyro_sensors(
         [
@@ -47,7 +47,7 @@ def test_add_gyro_sensors_accepts_list_of_dataclasses():
 
 
 def test_add_gyro_sensors_accepts_dict():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_gyro_sensors(
         [
@@ -64,7 +64,7 @@ def test_add_gyro_sensors_accepts_dict():
 
 
 def test_add_gyro_sensors_accepts_dict_with_objname_alias():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_gyro_sensors(
         [
@@ -82,7 +82,7 @@ def test_add_gyro_sensors_accepts_dict_with_objname_alias():
 
 def test_add_gyro_sensors_to_ergocub_sn001():
     urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
-    controlled_joints = [
+    observed_joints = [
         "l_hip_pitch",
         "r_hip_pitch",
         "torso_roll",
@@ -116,7 +116,7 @@ def test_add_gyro_sensors_to_ergocub_sn001():
         GyroSensorCfg(site="realsense_rgb_frame", name="realsense_rgb_gyro"),
     ]
     cfg = URDFtoMuJoCoLoaderCfg(
-        controlled_joints=controlled_joints,
+        observed_joints=observed_joints,
         gyro_sensors_cfg=gyro_sensors_cfg,
         all_missing_joints_as_sites=True,
     )

--- a/tests/test_loader_observed_actuated_cfg.py
+++ b/tests/test_loader_observed_actuated_cfg.py
@@ -1,0 +1,470 @@
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from mujoco_urdf_loader.loader import (
+    ControlMode,
+    EqualityConstraintCfg,
+    URDFtoMuJoCoLoader,
+    URDFtoMuJoCoLoaderCfg,
+)
+
+
+def _make_joint_mjcf() -> ET.Element:
+    return ET.fromstring(
+        """
+        <mujoco model="test_model">
+            <worldbody>
+                <body name="base">
+                    <joint name="l_hip_pitch" type="hinge" range="-1 1"/>
+                    <joint name="l_motor_1" type="hinge" range="-1 1"/>
+                    <joint name="l_motor_rod_in_universal_0" type="hinge" range="-1 1"/>
+                </body>
+            </worldbody>
+        </mujoco>
+        """
+    )
+
+
+def _make_closed_chain_urdf() -> str:
+    return """
+    <robot name="closed_chain_test">
+      <link name="world"/>
+      <link name="base">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="1.0"/>
+          <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        </inertial>
+      </link>
+      <joint name="world_to_base" type="fixed">
+        <parent link="world"/>
+        <child link="base"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+      </joint>
+
+      <link name="left_ankle">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.2"/>
+          <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+        </inertial>
+      </link>
+      <joint name="l_hip_pitch" type="revolute">
+        <parent link="base"/>
+        <child link="left_ankle"/>
+        <origin xyz="0 0.1 0" rpy="0 0 0"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-1.57" upper="1.57" effort="100" velocity="10"/>
+      </joint>
+
+      <link name="l_anklecr_in">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="l_anklecr_in_j" type="fixed">
+        <parent link="left_ankle"/>
+        <child link="l_anklecr_in"/>
+        <origin xyz="0 0.02 0" rpy="0 0 0"/>
+      </joint>
+      <link name="l_anklecr_out">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="l_anklecr_out_j" type="fixed">
+        <parent link="left_ankle"/>
+        <child link="l_anklecr_out"/>
+        <origin xyz="0 -0.02 0" rpy="0 0 0"/>
+      </joint>
+      <link name="l_rod_in_bottom">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="l_rod_in_bottom_j" type="fixed">
+        <parent link="left_ankle"/>
+        <child link="l_rod_in_bottom"/>
+        <origin xyz="0 0.03 0" rpy="0 0 0"/>
+      </joint>
+      <link name="l_rod_out_bottom">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="l_rod_out_bottom_j" type="fixed">
+        <parent link="left_ankle"/>
+        <child link="l_rod_out_bottom"/>
+        <origin xyz="0 -0.03 0" rpy="0 0 0"/>
+      </joint>
+
+      <link name="right_ankle">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.2"/>
+          <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+        </inertial>
+      </link>
+      <joint name="r_hip_pitch" type="revolute">
+        <parent link="base"/>
+        <child link="right_ankle"/>
+        <origin xyz="0 -0.1 0" rpy="0 0 0"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-1.57" upper="1.57" effort="100" velocity="10"/>
+      </joint>
+
+      <link name="r_anklecr_in">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="r_anklecr_in_j" type="fixed">
+        <parent link="right_ankle"/>
+        <child link="r_anklecr_in"/>
+        <origin xyz="0 0.02 0" rpy="0 0 0"/>
+      </joint>
+      <link name="r_anklecr_out">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="r_anklecr_out_j" type="fixed">
+        <parent link="right_ankle"/>
+        <child link="r_anklecr_out"/>
+        <origin xyz="0 -0.02 0" rpy="0 0 0"/>
+      </joint>
+      <link name="r_rod_in_bottom">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="r_rod_in_bottom_j" type="fixed">
+        <parent link="right_ankle"/>
+        <child link="r_rod_in_bottom"/>
+        <origin xyz="0 0.03 0" rpy="0 0 0"/>
+      </joint>
+      <link name="r_rod_out_bottom">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="r_rod_out_bottom_j" type="fixed">
+        <parent link="right_ankle"/>
+        <child link="r_rod_out_bottom"/>
+        <origin xyz="0 -0.03 0" rpy="0 0 0"/>
+      </joint>
+    </robot>
+    """
+
+
+def _write_closed_chain_urdf(tmp_path) -> str:
+    urdf_path = tmp_path / "closed_chain_test.urdf"
+    urdf_path.write_text(_make_closed_chain_urdf(), encoding="utf-8")
+    return str(urdf_path)
+
+
+def test_observed_joints_must_be_provided():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=None,
+        actuated_joints=[],
+    )
+
+    with pytest.raises(ValueError, match="observed_joints must be provided"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_only_actuated_subset_gets_actuators():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1", "l_motor_rod_in_universal_0"],
+        actuated_joints=["l_hip_pitch", "l_motor_1"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+    )
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+    actuator_joints = sorted(
+        actuator.attrib["joint"] for actuator in loader.mjcf.findall(".//actuator/*")
+    )
+    assert actuator_joints == ["l_hip_pitch", "l_motor_1"]
+    assert loader.mjcf.find(
+        ".//actuator/*[@joint='l_motor_rod_in_universal_0']"
+    ) is None
+
+
+def test_observed_joint_without_actuator_remains_readable():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1", "l_motor_rod_in_universal_0"],
+        actuated_joints=["l_hip_pitch", "l_motor_1"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+    )
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+    assert loader.mjcf.find(".//joint[@name='l_motor_rod_in_universal_0']") is not None
+
+
+def test_actuated_joints_must_be_subset_of_observed_joints():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch"],
+        actuated_joints=["not_observed"],
+        control_modes=[ControlMode.TORQUE],
+    )
+
+    with pytest.raises(ValueError, match="subset of observed_joints"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_torque_mode_allows_missing_gains():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE],
+    )
+
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+    assert loader.mjcf.find(".//actuator/motor[@joint='l_hip_pitch']") is not None
+
+
+def test_position_mode_requires_stiffness():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.POSITION],
+        damping=[0.5],
+    )
+
+    with pytest.raises(ValueError, match="stiffness is required"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_position_mode_requires_damping():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.POSITION],
+        stiffness=[20.0],
+    )
+
+    with pytest.raises(ValueError, match="damping is required"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_position_mode_gain_length_mismatch_raises():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1"],
+        actuated_joints=["l_hip_pitch", "l_motor_1"],
+        control_modes=[ControlMode.POSITION, ControlMode.POSITION],
+        stiffness=[20.0],
+        damping=[0.5, 0.6],
+    )
+
+    with pytest.raises(ValueError, match="Length of stiffness"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_position_mode_sets_kp_and_joint_damping():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.POSITION],
+        stiffness=[42.0],
+        damping=[0.7],
+    )
+
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+    actuator = loader.mjcf.find(".//actuator/position[@joint='l_hip_pitch']")
+    assert actuator is not None
+    assert actuator.attrib["kp"] == "42.0"
+
+    joint = loader.mjcf.find(".//joint[@name='l_hip_pitch']")
+    assert joint is not None
+    assert joint.attrib["damping"] == "0.7"
+
+
+def test_joint_dynamics_are_set_from_observed_joint_lists():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1", "l_motor_rod_in_universal_0"],
+        actuated_joints=["l_hip_pitch", "l_motor_1"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        joint_damping=[0.1, 0.2, 0.3],
+        joint_frictionloss=[1.0, 2.0, 3.0],
+    )
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+    assert loader.mjcf.find(".//joint[@name='l_hip_pitch']").attrib["damping"] == "0.1"
+    assert loader.mjcf.find(".//joint[@name='l_motor_1']").attrib["damping"] == "0.2"
+    assert (
+        loader.mjcf.find(".//joint[@name='l_motor_rod_in_universal_0']").attrib["damping"]
+        == "0.3"
+    )
+
+    assert (
+        loader.mjcf.find(".//joint[@name='l_hip_pitch']").attrib["frictionloss"] == "1.0"
+    )
+    assert loader.mjcf.find(".//joint[@name='l_motor_1']").attrib["frictionloss"] == "2.0"
+    assert (
+        loader.mjcf.find(".//joint[@name='l_motor_rod_in_universal_0']").attrib[
+            "frictionloss"
+        ]
+        == "3.0"
+    )
+
+
+def test_joint_damping_length_must_match_observed_joints():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE],
+        joint_damping=[0.1],
+    )
+
+    with pytest.raises(ValueError, match="Length of joint_damping"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_joint_frictionloss_length_must_match_observed_joints():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE],
+        joint_frictionloss=[0.0],
+    )
+
+    with pytest.raises(ValueError, match="Length of joint_frictionloss"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_armature_defined_on_observed_joints_is_applied_only_to_actuated_joints():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_rod_in_universal_0", "l_motor_1"],
+        actuated_joints=["l_motor_1", "l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        armature=[1.1, 2.2, 3.3],
+    )
+    normalized_cfg = URDFtoMuJoCoLoader._normalize_cfg(cfg)
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+    loader.set_armature(normalized_cfg.armature)
+
+    assert loader.mjcf.find(".//joint[@name='l_motor_1']").attrib["armature"] == "3.3"
+    assert loader.mjcf.find(".//joint[@name='l_hip_pitch']").attrib["armature"] == "1.1"
+    assert (
+        loader.mjcf.find(".//joint[@name='l_motor_rod_in_universal_0']").attrib.get(
+            "armature"
+        )
+        is None
+    )
+
+
+def test_armature_can_be_specified_for_actuated_joints_only():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_rod_in_universal_0", "l_motor_1"],
+        actuated_joints=["l_motor_1", "l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        armature=[9.0, 8.0],
+    )
+    normalized_cfg = URDFtoMuJoCoLoader._normalize_cfg(cfg)
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+    loader.set_armature(normalized_cfg.armature)
+
+    assert loader.mjcf.find(".//joint[@name='l_motor_1']").attrib["armature"] == "9.0"
+    assert loader.mjcf.find(".//joint[@name='l_hip_pitch']").attrib["armature"] == "8.0"
+
+
+def test_armature_length_must_match_actuated_or_observed_joints():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_rod_in_universal_0", "l_motor_1"],
+        actuated_joints=["l_motor_1", "l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        armature=[0.1],
+    )
+
+    with pytest.raises(ValueError, match="Length of armature"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def _closed_chain_cfg_with_constraints() -> URDFtoMuJoCoLoaderCfg:
+    return URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "r_hip_pitch"],
+        actuated_joints=["l_hip_pitch", "r_hip_pitch"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        all_missing_joints_as_sites=True,
+        equality_constraints_cfg=[
+            EqualityConstraintCfg(site1="l_anklecr_in", site2="l_rod_in_bottom"),
+            EqualityConstraintCfg(site1="l_anklecr_out", site2="l_rod_out_bottom"),
+            EqualityConstraintCfg(site1="r_anklecr_in", site2="r_rod_in_bottom"),
+            EqualityConstraintCfg(site1="r_anklecr_out", site2="r_rod_out_bottom"),
+        ],
+    )
+
+
+def test_closed_chain_connect_constraints_are_added_from_synthetic_urdf(tmp_path):
+    urdf_path = _write_closed_chain_urdf(tmp_path)
+    loader = URDFtoMuJoCoLoader.load_urdf(
+        urdf_path=urdf_path,
+        mesh_path=tmp_path,
+        cfg=_closed_chain_cfg_with_constraints(),
+    )
+
+    # Missing fixed-link frames are recovered as sites and can be constrained.
+    for site_name in (
+        "l_anklecr_in",
+        "l_anklecr_out",
+        "l_rod_in_bottom",
+        "l_rod_out_bottom",
+        "r_anklecr_in",
+        "r_anklecr_out",
+        "r_rod_in_bottom",
+        "r_rod_out_bottom",
+    ):
+        assert loader.mjcf.find(f".//site[@name='{site_name}']") is not None
+
+    connects = loader.mjcf.findall(".//equality/connect")
+    assert len(connects) == 4
+    pairs = {(c.attrib["site1"], c.attrib["site2"]) for c in connects}
+    assert pairs == {
+        ("l_anklecr_in", "l_rod_in_bottom"),
+        ("l_anklecr_out", "l_rod_out_bottom"),
+        ("r_anklecr_in", "r_rod_in_bottom"),
+        ("r_anklecr_out", "r_rod_out_bottom"),
+    }
+
+
+def test_closed_chain_missing_site_raises_from_synthetic_urdf(tmp_path):
+    urdf_path = _write_closed_chain_urdf(tmp_path)
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "r_hip_pitch"],
+        actuated_joints=["l_hip_pitch", "r_hip_pitch"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        all_missing_joints_as_sites=True,
+    )
+    loader = URDFtoMuJoCoLoader.load_urdf(
+        urdf_path=urdf_path,
+        mesh_path=tmp_path,
+        cfg=cfg,
+    )
+
+    with pytest.raises(ValueError, match="not found"):
+        loader.add_equality_constraints(
+            [
+                EqualityConstraintCfg(
+                    site1="l_anklecr_in",
+                    site2="missing_site",
+                )
+            ]
+        )

--- a/tests/test_missing_joint_sites.py
+++ b/tests/test_missing_joint_sites.py
@@ -65,7 +65,7 @@ def test_get_missing_joint_sites_all_flag_collects_missing_urdf_links():
     sites = URDFtoMuJoCoLoader.get_missing_joint_sites(
         urdf_root,
         mjcf,
-        controlled_joints=["j1"],
+        observed_joints=["j1"],
         all_missing_joints_as_sites=True,
     )
 
@@ -79,13 +79,13 @@ def test_add_sites_for_missing_joints_handles_nested_lumped_missing_joints():
     fixed_joint_sites = URDFtoMuJoCoLoader.get_missing_joint_sites(
         urdf_root,
         _make_mjcf_with_base_only(),
-        controlled_joints=[],
+        observed_joints=[],
         all_missing_joints_as_sites=True,
     )
 
     fixed_joint_sites = [site for site in fixed_joint_sites if site["name"] == "l2"]
 
-    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+    cfg = URDFtoMuJoCoLoaderCfg(observed_joints=[])
     loader = URDFtoMuJoCoLoader(_make_mjcf_with_base_only(), cfg)
 
     loader.add_sites_for_missing_joints(fixed_joint_sites)
@@ -109,7 +109,7 @@ def test_add_sites_for_missing_joints_handles_nested_lumped_missing_joints():
 
 def test_ergocub_sn001_missing_joint_sites():
     urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
-    controlled_joints = [
+    observed_joints = [
             "l_hip_pitch",
             "r_hip_pitch",
             "torso_roll",
@@ -138,7 +138,10 @@ def test_ergocub_sn001_missing_joint_sites():
             "r_elbow",
     ]
     mesh_path = get_mesh_path(ET.parse(urdf_root).getroot())
-    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, all_missing_joints_as_sites=True)
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=observed_joints,
+        all_missing_joints_as_sites=True,
+    )
     loader = URDFtoMuJoCoLoader.load_urdf(urdf_root, mesh_path, cfg)
 
     mjcf_string = loader.get_mjcf_string()
@@ -149,7 +152,7 @@ def test_ergocub_sn001_missing_joint_sites():
 
     # ---- iDynTree reduced-model setup (using controlled joints) ----
     idt_loader = idyntree.ModelLoader()
-    assert idt_loader.loadReducedModelFromFile(urdf_root, controlled_joints)
+    assert idt_loader.loadReducedModelFromFile(urdf_root, observed_joints)
     reduced_model = idt_loader.model()
 
     kin_dyn = idyntree.KinDynComputations()
@@ -159,7 +162,7 @@ def test_ergocub_sn001_missing_joint_sites():
 
     # Map each controlled joint name to its DOF index in the reduced model
     controlled_dof_indices = {}
-    for jname in controlled_joints:
+    for jname in observed_joints:
         jidx = reduced_model.getJointIndex(jname)
         assert jidx >= 0, f"Joint {jname} not found in the reduced model"
         controlled_dof_indices[jname] = reduced_model.getJoint(jidx).getDOFsOffset()
@@ -173,8 +176,8 @@ def test_ergocub_sn001_missing_joint_sites():
     assert len(sites_to_check) > 0, "No sites with matching iDynTree frames found"
 
     # Get joint limits from MuJoCo for uniform sampling
-    joint_limits = np.zeros((len(controlled_joints), 2))
-    for i, jname in enumerate(controlled_joints):
+    joint_limits = np.zeros((len(observed_joints), 2))
+    for i, jname in enumerate(observed_joints):
         jid = mj_model.joint(jname).id
         if mj_model.jnt_limited[jid]:
             joint_limits[i] = mj_model.jnt_range[jid]
@@ -192,7 +195,7 @@ def test_ergocub_sn001_missing_joint_sites():
         # ---- iDynTree: set reduced-model state ----
         s = idyntree.VectorDynSize(n_reduced_dofs)
         s.zero()
-        for i, jname in enumerate(controlled_joints):
+        for i, jname in enumerate(observed_joints):
             s.setVal(controlled_dof_indices[jname], s_ctrl[i])
 
         ds = idyntree.VectorDynSize(n_reduced_dofs)
@@ -209,7 +212,7 @@ def test_ergocub_sn001_missing_joint_sites():
         # ---- MuJoCo: set qpos and run forward kinematics ----
         mj_data.qpos[:] = 0.0
         mj_data.qpos[3] = 1.0  # identity quaternion (w, x, y, z)
-        for i, jname in enumerate(controlled_joints):
+        for i, jname in enumerate(observed_joints):
             jid = mj_model.joint(jname).id
             addr = mj_model.jnt_qposadr[jid]
             mj_data.qpos[addr] = s_ctrl[i]

--- a/tests/test_urdf_to_mujoco_loader_class.py
+++ b/tests/test_urdf_to_mujoco_loader_class.py
@@ -14,7 +14,7 @@ from mujoco_urdf_loader.urdf_fcn import get_mesh_path
 # Define robot configurations in a dictionary
 ROBOTS = {
     "ergoCub": {
-        "controlled_joints": [
+        "observed_joints": [
             "l_hip_pitch",
             "r_hip_pitch",
             "torso_roll",
@@ -48,7 +48,7 @@ ROBOTS = {
         "mesh_path": None,  # Will be set later
     },
     "ANYmal": {
-        "controlled_joints": [
+        "observed_joints": [
             "LF_HAA",
             "LF_HFE",
             "LF_KFE",
@@ -76,14 +76,19 @@ for robot in ROBOTS.values():
 @pytest.mark.parametrize("robot_name", ["ergoCub", "ANYmal"])
 def test_load_urdf_into_mjcf(robot_name):
     robot = ROBOTS[robot_name]
-    controlled_joints = robot["controlled_joints"]
+    observed_joints = robot["observed_joints"]
     urdf_path = robot["urdf_path"]
     mesh_path = robot["mesh_path"]
 
-    control_modes = [ControlMode.TORQUE] * len(controlled_joints)
-    stiffness = [0.0] * len(controlled_joints)
-    damping = [0.0] * len(controlled_joints)
-    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping)
+    control_modes = [ControlMode.TORQUE] * len(observed_joints)
+    stiffness = [0.0] * len(observed_joints)
+    damping = [0.0] * len(observed_joints)
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=observed_joints,
+        control_modes=control_modes,
+        stiffness=stiffness,
+        damping=damping,
+    )
 
     loader = URDFtoMuJoCoLoader.load_urdf(urdf_path, mesh_path, cfg)
     mjcf = loader.get_mjcf_string()
@@ -94,14 +99,20 @@ def test_load_urdf_into_mjcf(robot_name):
 @pytest.mark.parametrize("robot_name", ["ergoCub", "ANYmal"])
 def test_total_mass(robot_name):
     robot = ROBOTS[robot_name]
-    controlled_joints = robot["controlled_joints"]
+    observed_joints = robot["observed_joints"]
     urdf_path = robot["urdf_path"]
     mesh_path = robot["mesh_path"]
 
-    control_modes = [ControlMode.TORQUE] * len(controlled_joints)
-    stiffness = [0.0] * len(controlled_joints)
-    damping = [0.0] * len(controlled_joints)
-    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping, all_missing_joints_as_sites=False)
+    control_modes = [ControlMode.TORQUE] * len(observed_joints)
+    stiffness = [0.0] * len(observed_joints)
+    damping = [0.0] * len(observed_joints)
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=observed_joints,
+        control_modes=control_modes,
+        stiffness=stiffness,
+        damping=damping,
+        all_missing_joints_as_sites=False,
+    )
 
     loader = URDFtoMuJoCoLoader.load_urdf(urdf_path, mesh_path, cfg)
     mjcf = loader.get_mjcf_string()
@@ -113,7 +124,7 @@ def test_total_mass(robot_name):
 
     # Test with iDynTree
     model_loader = idyntree.ModelLoader()
-    model_loader.loadReducedModelFromFile(urdf_path, controlled_joints)
+    model_loader.loadReducedModelFromFile(urdf_path, observed_joints)
     idt_model = model_loader.model()
     total_mass_idt = idt_model.getTotalMass()
 
@@ -122,14 +133,20 @@ def test_total_mass(robot_name):
 @pytest.mark.parametrize("robot_name", ["ergoCub", "ANYmal"])
 def test_total_mass_with_missing_links(robot_name):
     robot = ROBOTS[robot_name]
-    controlled_joints = robot["controlled_joints"]
+    observed_joints = robot["observed_joints"]
     urdf_path = robot["urdf_path"]
     mesh_path = robot["mesh_path"]
 
-    control_modes = [ControlMode.TORQUE] * len(controlled_joints)
-    stiffness = [0.0] * len(controlled_joints)
-    damping = [0.0] * len(controlled_joints)
-    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping, all_missing_joints_as_sites=True)
+    control_modes = [ControlMode.TORQUE] * len(observed_joints)
+    stiffness = [0.0] * len(observed_joints)
+    damping = [0.0] * len(observed_joints)
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=observed_joints,
+        control_modes=control_modes,
+        stiffness=stiffness,
+        damping=damping,
+        all_missing_joints_as_sites=True,
+    )
 
     loader = URDFtoMuJoCoLoader.load_urdf(urdf_path, mesh_path, cfg)
     mjcf = loader.get_mjcf_string()
@@ -141,7 +158,7 @@ def test_total_mass_with_missing_links(robot_name):
 
     # Test with iDynTree
     model_loader = idyntree.ModelLoader()
-    model_loader.loadReducedModelFromFile(urdf_path, controlled_joints)
+    model_loader.loadReducedModelFromFile(urdf_path, observed_joints)
     idt_model = model_loader.model()
     total_mass_idt = idt_model.getTotalMass()
 


### PR DESCRIPTION
- Updated test cases in test_loader_camera_cfg.py, test_loader_equality_constraints_cfg.py, test_loader_framequat_cfg.py, test_loader_gyro_cfg.py to replace controlled_joints with observed_joints.
- Introduced new test file test_loader_observed_actuated_cfg.py to validate observed and actuated joint configurations.
- Adjusted test_missing_joint_sites.py to align with observed_joints.
- Modified test_urdf_to_mujoco_loader_class.py to reflect changes in joint configuration handling.

---

Before merging this in the codebase of team-hermes this should be properlu tested also by other team members