### PR TITLE
Add missing-frame site export and configurable MJCF constraints/sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ This repository includes Python scripts that demonstrate how to use the package 
 * `generate_ergoCub_hand.py`: Generates an MJCF model of a single ErgoCub hand (right hand). This script specifically handles adding position servos only for actuated joints and uses equality constraints to simulate hand linkages (a technique also used in the other models). Additionally, it allows you to modify the thumb orientation.
 * `generate_ergoCub_xml.py`: Generates the MJCF model of a robot through the `URDFtoMuJoCoLoader` class, which takes as input the robot urdf, and controlled joints lists informations in the form of `URDFtoMuJoCoLoaderCfg`. The scripts also loades the model in a wrapper called `MujocoWrapper` that handles simple calls to get robot's pose and joints quantities. 
 
+You can configure one or more frame quaternion sensors directly from `URDFtoMuJoCoLoaderCfg` via the `framequat_sensors` field, by providing a list of `FrameQuatSensorCfg` objects. Each sensor requires:
+
+* `objname`
+* `objtype`
+* `name`
+
 All examples load the `package://ergoCub/robots/ergoCubSN001/model.urdf` model, convert it to MJCF format, save the resulting file, and then display the model in a simple MuJoCo viewer window.
 
 ### Codebase Structure

--- a/environment.yaml
+++ b/environment.yaml
@@ -7,3 +7,5 @@ dependencies:
   - mujoco-samples
   - pytest
   - resolve-robotics-uri-py
+  - numpy
+  - scipy

--- a/environment.yaml
+++ b/environment.yaml
@@ -9,3 +9,4 @@ dependencies:
   - resolve-robotics-uri-py
   - numpy
   - scipy
+  - pyyaml

--- a/examples/generate_ergoCub_xml.py
+++ b/examples/generate_ergoCub_xml.py
@@ -12,7 +12,7 @@ from mujoco_urdf_loader import (
 )
 from mujoco_urdf_loader.urdf_fcn import get_mesh_path
 
-controlled_joints = [
+observed_joints = [
     "l_hip_pitch",
     "r_hip_pitch",
     "torso_roll",
@@ -41,11 +41,16 @@ controlled_joints = [
     "r_elbow",
 ]
 
-control_modes = [ControlMode.TORQUE] * len(controlled_joints)
-stiffness = [0.0] * len(controlled_joints)
-damping = [0.0] * len(controlled_joints)
+control_modes = [ControlMode.TORQUE] * len(observed_joints)
+stiffness = [0.0] * len(observed_joints)
+damping = [0.0] * len(observed_joints)
 
-cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping)
+cfg = URDFtoMuJoCoLoaderCfg(
+    observed_joints=observed_joints,
+    control_modes=control_modes,
+    stiffness=stiffness,
+    damping=damping,
+)
 
 urdf_string = str(
     rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN002/model.urdf")

--- a/mujoco_urdf_loader/__init__.py
+++ b/mujoco_urdf_loader/__init__.py
@@ -4,5 +4,6 @@ from .loader import (
     GyroSensorCfg,
     URDFtoMuJoCoLoader,
     URDFtoMuJoCoLoaderCfg,
+    CameraCfg,
 )
 from .wrapper import MujocoWrapper

--- a/mujoco_urdf_loader/__init__.py
+++ b/mujoco_urdf_loader/__init__.py
@@ -1,2 +1,8 @@
-from .loader import URDFtoMuJoCoLoader, URDFtoMuJoCoLoaderCfg, ControlMode
+from .loader import (
+    ControlMode,
+    FrameQuatSensorCfg,
+    GyroSensorCfg,
+    URDFtoMuJoCoLoader,
+    URDFtoMuJoCoLoaderCfg,
+)
 from .wrapper import MujocoWrapper

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -5,6 +5,8 @@ from enum import Enum
 from typing import List, Union
 
 import idyntree.bindings as idyn
+import numpy as np
+from scipy.spatial.transform import Rotation
 
 from mujoco_urdf_loader.generator import load_urdf_into_mjcf
 from mujoco_urdf_loader.mjcf_fcn import (
@@ -31,6 +33,7 @@ class URDFtoMuJoCoLoaderCfg:
     control_modes: Union[None, List[ControlMode]] = None
     stiffness: Union[None, List[float]] = None
     damping: Union[None, List[float]] = None
+    all_missing_joints_as_sites: bool = False
 
 
 class URDFtoMuJoCoLoader:
@@ -62,15 +65,233 @@ class URDFtoMuJoCoLoader:
         Returns:
             str: The URDF string.
         """
+        original_urdf = ET.parse(urdf_path).getroot()
+        original_urdf = remove_gazebo_elements(original_urdf)
+
         urdf_string = URDFtoMuJoCoLoader.simplify_urdf(urdf_path, cfg.controlled_joints, cfg.stiffness, cfg.damping)
-        urdf_string = remove_gazebo_elements(urdf_string)
-        urdf_string = add_mujoco_element(urdf_string, mesh_path)
-        mjcf = load_urdf_into_mjcf(urdf_string)
+        reduced_urdf = remove_gazebo_elements(urdf_string)
+        urdf_for_mjcf = add_mujoco_element(reduced_urdf, mesh_path)
+        mjcf = load_urdf_into_mjcf(urdf_for_mjcf)
         mjcf = separate_left_right_collision_groups(mjcf)
-        return URDFtoMuJoCoLoader(mjcf, cfg)
+
+        # Use the reduced URDF (from iDynTree) for computing site transforms.
+        # iDynTree modifies joint origins when merging links during model
+        # reduction, so the reduced URDF has origins consistent with the MJCF
+        # body frames produced by MuJoCo.
+        missing_joint_sites = URDFtoMuJoCoLoader.get_missing_joint_sites(
+            reduced_urdf,
+            mjcf,
+            controlled_joints=cfg.controlled_joints,
+            all_missing_joints_as_sites=cfg.all_missing_joints_as_sites,
+        )
+
+        loader = URDFtoMuJoCoLoader(mjcf, cfg)
+        loader.add_sites_for_missing_joints(missing_joint_sites)
+        return loader
 
     @staticmethod
-    def simplify_urdf(urdf_path: str, joints: List[str], stiffness: List[float] = None, damping: List[float] = None):
+    def get_missing_joint_sites(
+        robot_urdf: ET.Element,
+        mjcf: ET.Element,
+        controlled_joints: List[str] = None,
+        all_missing_joints_as_sites: bool = False,
+    ) -> List[dict]:
+        """Extract metadata for URDF links missing as bodies in MJCF.
+
+        Links can disappear from the MJCF for two reasons:
+        1. MuJoCo lumps fixed-joint child bodies into their parents.
+        2. iDynTree removes non-fixed joints not in the controlled list during
+           model reduction, and their child links are merged too.
+
+        This method identifies all such missing child links and builds site
+        descriptors so that their frames can be recovered as MuJoCo sites.
+
+        Args:
+            robot_urdf (ET.Element): The URDF root element.
+            mjcf (ET.Element): The MJCF root element.
+            controlled_joints (List[str]): The list of controlled joint names.
+                Used only for context; detection is based on comparing all URDF
+                links against MJCF bodies.
+            all_missing_joints_as_sites (bool): If True, enable site generation
+                for the missing links.
+
+        Returns:
+            List[dict]: Site descriptors with link name, parent/child links and origin.
+        """
+        if not all_missing_joints_as_sites:
+            return []
+
+        if controlled_joints is None:
+            controlled_joints = []
+
+        all_joint_elements = robot_urdf.findall(".//joint")
+
+        # Collect all URDF link names
+        urdf_link_names = {
+            link.attrib["name"]
+            for link in robot_urdf.findall(".//link")
+            if "name" in link.attrib
+        }
+
+        # Collect MJCF body names
+        mjcf_body_names = {
+            body.attrib["name"]
+            for body in mjcf.findall(".//body")
+            if "name" in body.attrib
+        }
+
+        # Map each child link to its parent joint (needed for origin + ancestor walk-up)
+        joint_by_child_link = {}
+        for joint in all_joint_elements:
+            child = joint.find("child")
+            if child is not None and "link" in child.attrib:
+                joint_by_child_link[child.attrib["link"]] = joint
+
+        # Find all URDF links that have no corresponding body in MJCF
+        missing_links = {}
+        for link_name in urdf_link_names:
+            if link_name not in mjcf_body_names:
+                joint = joint_by_child_link.get(link_name)
+                if joint is not None:
+                    missing_links[link_name] = joint
+
+        fixed_joint_sites = []
+        for missing_link_name, joint in missing_links.items():
+
+            parent_link = joint.find("parent").attrib["link"]
+            child_link = missing_link_name
+            origin = joint.find("origin")
+            xyz = origin.attrib.get("xyz", "0 0 0") if origin is not None else "0 0 0"
+            rpy = origin.attrib.get("rpy", "0 0 0") if origin is not None else "0 0 0"
+
+            # Build all ancestor-link candidates with transform from ancestor link frame
+            # to the fixed-joint site frame. This is needed when MuJoCo lumps nested
+            # fixed joints and intermediate bodies disappear.
+            ancestor_candidates = []
+            current_link = child_link
+            current_rot_to_site = URDFtoMuJoCoLoader.identity_rot()
+            current_pos_to_site = np.zeros(3)
+
+            ancestor_candidates.append(
+                {
+                    "link": current_link,
+                    "xyz": URDFtoMuJoCoLoader.vec_to_str(current_pos_to_site),
+                    "quat": URDFtoMuJoCoLoader.rot_to_quat_str(current_rot_to_site),
+                }
+            )
+
+            while current_link in joint_by_child_link:
+                parent_joint = joint_by_child_link[current_link]
+                parent_link_candidate = parent_joint.find("parent").attrib["link"]
+                parent_origin = parent_joint.find("origin")
+                parent_xyz = (
+                    parent_origin.attrib.get("xyz", "0 0 0")
+                    if parent_origin is not None
+                    else "0 0 0"
+                )
+                parent_rpy = (
+                    parent_origin.attrib.get("rpy", "0 0 0")
+                    if parent_origin is not None
+                    else "0 0 0"
+                )
+
+                rot_parent_current = URDFtoMuJoCoLoader.urdf_rpy_to_rot(parent_rpy)
+                pos_parent_current = URDFtoMuJoCoLoader.str_to_vec(parent_xyz)
+
+                current_pos_to_site = URDFtoMuJoCoLoader.compose_pos(
+                    rot_parent_current,
+                    pos_parent_current,
+                    current_pos_to_site,
+                )
+                current_rot_to_site = URDFtoMuJoCoLoader.compose_rot(
+                    rot_parent_current,
+                    current_rot_to_site,
+                )
+
+                ancestor_candidates.append(
+                    {
+                        "link": parent_link_candidate,
+                        "xyz": URDFtoMuJoCoLoader.vec_to_str(current_pos_to_site),
+                        "quat": URDFtoMuJoCoLoader.rot_to_quat_str(current_rot_to_site),
+                    }
+                )
+
+                current_link = parent_link_candidate
+
+            fixed_joint_sites.append(
+                {
+                    "name": missing_link_name,
+                    "parent_link": parent_link,
+                    "child_link": child_link,
+                    "xyz": xyz,
+                    "rpy": rpy,
+                    "ancestor_candidates": ancestor_candidates,
+                }
+            )
+
+        return fixed_joint_sites
+
+    @staticmethod
+    def urdf_rpy_to_quat(rpy: str) -> str:
+        """Convert URDF RPY (extrinsic XYZ) to MuJoCo quaternion (w x y z)."""
+        rot = URDFtoMuJoCoLoader.urdf_rpy_to_rot(rpy)
+        return URDFtoMuJoCoLoader.rot_to_quat_str(rot)
+
+    @staticmethod
+    def identity_rot() -> np.ndarray:
+        """Return a 3x3 identity rotation matrix."""
+        return np.eye(3)
+
+    @staticmethod
+    def str_to_vec(xyz: str) -> np.ndarray:
+        """Parse a space-separated string into a numpy array."""
+        return np.array(list(map(float, xyz.split())))
+
+    @staticmethod
+    def vec_to_str(vec: np.ndarray) -> str:
+        """Format a 3-element vector as a space-separated string."""
+        return f"{vec[0]} {vec[1]} {vec[2]}"
+
+    @staticmethod
+    def compose_rot(r_ab: np.ndarray, r_bc: np.ndarray) -> np.ndarray:
+        """Compose two rotation matrices: R_ac = R_ab @ R_bc."""
+        return r_ab @ r_bc
+
+    @staticmethod
+    def compose_pos(
+        r_ab: np.ndarray,
+        p_ab: np.ndarray,
+        p_bc: np.ndarray,
+    ) -> np.ndarray:
+        """Compose positions: p_ac = p_ab + R_ab @ p_bc."""
+        return p_ab + r_ab @ p_bc
+
+    @staticmethod
+    def urdf_rpy_to_rot(rpy: str) -> np.ndarray:
+        """URDF RPY (fixed-axis / extrinsic XYZ) to 3x3 rotation matrix via scipy."""
+        angles = list(map(float, rpy.split()))  # [roll, pitch, yaw]
+        return Rotation.from_euler("xyz", angles, degrees=False).as_matrix()
+
+    @staticmethod
+    def rot_to_quat_str(rot: np.ndarray) -> str:
+        """Convert a 3x3 rotation matrix to a MuJoCo quaternion string (w x y z)."""
+        quat = URDFtoMuJoCoLoader.rot_to_quat(rot)
+        return f"{quat[0]} {quat[1]} {quat[2]} {quat[3]}"
+
+    @staticmethod
+    def rot_to_quat(rot: np.ndarray) -> np.ndarray:
+        """Convert a 3x3 rotation matrix to quaternion [w, x, y, z] (MuJoCo convention)."""
+        # scipy returns [x, y, z, w]
+        xyzw = Rotation.from_matrix(np.asarray(rot)).as_quat()
+        return np.array([xyzw[3], xyzw[0], xyzw[1], xyzw[2]])
+
+    @staticmethod
+    def simplify_urdf(
+        urdf_path: str,
+        joints: List[str],
+        stiffness: List[float] = None,
+        damping: List[float] = None,
+    ):
         """
         Simplify the URDF using iDynTree.
 
@@ -201,7 +422,62 @@ class URDFtoMuJoCoLoader:
             if joint_element is not None:
                 self.add_actuator(controlled_joint, self.control_mode[controlled_joint])
             else:
-                raise ValueError(f"Joint {controlled_joint} not found in the MJCF model.")
+                raise ValueError(
+                    f"Joint {controlled_joint} not found in the MJCF model."
+                )
+
+    def add_sites_for_missing_joints(self, fixed_joint_sites: List[dict]):
+        """Add one MJCF site for each configured missing URDF joint.
+
+        The site is attached to the fixed joint child link body when available.
+        If the child body is not present in MJCF, the site is attached to the
+        parent link body at the URDF joint origin.
+        """
+        for fixed_joint_site in fixed_joint_sites:
+            site_name = fixed_joint_site["child_link"]
+
+            # Skip if site already exists
+            if self.mjcf.find(f".//site[@name='{site_name}']") is not None:
+                continue
+
+            candidates = fixed_joint_site.get("ancestor_candidates")
+            if not candidates:
+                candidates = [
+                    {
+                        "link": fixed_joint_site["child_link"],
+                        "xyz": "0 0 0",
+                        "quat": "1 0 0 0",
+                    },
+                    {
+                        "link": fixed_joint_site["parent_link"],
+                        "xyz": fixed_joint_site["xyz"],
+                        "quat": self.urdf_rpy_to_quat(fixed_joint_site["rpy"]),
+                    },
+                ]
+
+            attached = False
+            for candidate in candidates:
+                body = self.mjcf.find(f".//body[@name='{candidate['link']}']")
+                if body is None:
+                    continue
+
+                ET.SubElement(
+                    body,
+                    "site",
+                    {
+                        "name": site_name,
+                        "pos": candidate["xyz"],
+                        "quat": candidate["quat"],
+                    },
+                )
+                attached = True
+                break
+
+            if not attached:
+                raise ValueError(
+                    f"Cannot create site for fixed joint {site_name}: "
+                    "no surviving ancestor body found in MJCF."
+                )
 
     def get_mjcf(self):
         """
@@ -212,11 +488,18 @@ class URDFtoMuJoCoLoader:
         """
         return self.mjcf
 
-    def get_mjcf_string(self):
+    def get_mjcf_string(self, pretty: bool = False):
         """
         Get the Mujoco XML string.
+
+        Args:
+            pretty (bool): If True, return an indented, human-readable XML string.
 
         Returns:
             str: The Mujoco XML string.
         """
-        return ET.tostring(self.mjcf, encoding="unicode", method="xml")
+        mjcf = self.mjcf
+        if pretty:
+            mjcf = ET.fromstring(ET.tostring(self.mjcf, encoding="unicode", method="xml"))
+            ET.indent(mjcf, space="  ")
+        return ET.tostring(mjcf, encoding="unicode", method="xml")

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -2,7 +2,7 @@ import dataclasses
 import tempfile
 import xml.etree.ElementTree as ET
 from enum import Enum
-from typing import List, Union
+from typing import Any, Dict, List, Union
 
 import idyntree.bindings as idyn
 import numpy as np
@@ -13,6 +13,8 @@ from mujoco_urdf_loader.mjcf_fcn import (
     add_position_actuator,
     add_torque_actuator,
     separate_left_right_collision_groups,
+    add_framequat_sensor,
+    add_gyro_sensor,
 )
 from mujoco_urdf_loader.urdf_fcn import (
     add_mujoco_element,
@@ -28,6 +30,19 @@ class ControlMode(Enum):
 
 
 @dataclasses.dataclass
+class FrameQuatSensorCfg:
+    objname: str
+    objtype: str = "site"
+    name: str = None
+
+
+@dataclasses.dataclass
+class GyroSensorCfg:
+    site: str
+    name: str = None
+
+
+@dataclasses.dataclass
 class URDFtoMuJoCoLoaderCfg:
     controlled_joints: List[str]
     control_modes: Union[None, List[ControlMode]] = None
@@ -35,6 +50,8 @@ class URDFtoMuJoCoLoaderCfg:
     damping: Union[None, List[float]] = None
     armature: Union[None, List[float]] = None
     all_missing_joints_as_sites: bool = False
+    framequat_sensors_cfg: Union[None, List[Union[FrameQuatSensorCfg, Dict[str, Any]]]] = None
+    gyro_sensors_cfg: Union[None, List[Union[GyroSensorCfg, Dict[str, Any]]]] = None
 
 
 class URDFtoMuJoCoLoader:
@@ -89,7 +106,86 @@ class URDFtoMuJoCoLoader:
         loader = URDFtoMuJoCoLoader(mjcf, cfg)
         loader.set_armature(cfg.armature)
         loader.add_sites_for_missing_joints(missing_joint_sites)
+        loader.add_framequat_sensors(cfg.framequat_sensors_cfg)
+        loader.add_gyro_sensors(cfg.gyro_sensors_cfg)
         return loader
+
+    @staticmethod
+    def _normalize_framequat_sensor_cfg(
+        sensor_cfg: Union[FrameQuatSensorCfg, Dict[str, Any]],
+    ) -> FrameQuatSensorCfg:
+        if isinstance(sensor_cfg, FrameQuatSensorCfg):
+            return sensor_cfg
+
+        if not isinstance(sensor_cfg, dict):
+            raise TypeError(
+                "Each framequat sensor configuration must be a FrameQuatSensorCfg "
+                "or a dict with keys objname, objtype (or obtype), and name."
+            )
+
+        objname = sensor_cfg.get("objname")
+        objtype = sensor_cfg.get("objtype", sensor_cfg.get("obtype"))
+        name = sensor_cfg.get("name")
+
+        if objname is None or objtype is None or name is None:
+            raise ValueError(
+                "Each framequat sensor requires objname, objtype (or obtype), and name."
+            )
+
+        return FrameQuatSensorCfg(objname=objname, objtype=objtype, name=name)
+
+    def add_framequat_sensors(
+        self,
+        framequat_sensors_cfg: Union[None, List[Union[FrameQuatSensorCfg, Dict[str, Any]]]] = None,
+    ):
+        if framequat_sensors_cfg is None:
+            # skip adding sensors if no configuration is provided
+            return
+
+        for sensor_cfg in framequat_sensors_cfg:
+            normalized_cfg = self._normalize_framequat_sensor_cfg(sensor_cfg)
+            add_framequat_sensor(
+                self.mjcf,
+                objname=normalized_cfg.objname,
+                objtype=normalized_cfg.objtype,
+                name=normalized_cfg.name,
+            )
+
+    @staticmethod
+    def _normalize_gyro_sensor_cfg(
+        sensor_cfg: Union[GyroSensorCfg, Dict[str, Any]],
+    ) -> GyroSensorCfg:
+        if isinstance(sensor_cfg, GyroSensorCfg):
+            return sensor_cfg
+
+        if not isinstance(sensor_cfg, dict):
+            raise TypeError(
+                "Each gyro sensor configuration must be a GyroSensorCfg "
+                "or a dict with keys site and name."
+            )
+
+        site = sensor_cfg.get("site", sensor_cfg.get("objname"))
+        name = sensor_cfg.get("name")
+
+        if site is None:
+            raise ValueError("Each gyro sensor requires site.")
+
+        return GyroSensorCfg(site=site, name=name)
+
+    def add_gyro_sensors(
+        self,
+        gyro_sensors_cfg: Union[None, List[Union[GyroSensorCfg, Dict[str, Any]]]] = None,
+    ):
+        if gyro_sensors_cfg is None:
+            return
+
+        for sensor_cfg in gyro_sensors_cfg:
+            normalized_cfg = self._normalize_gyro_sensor_cfg(sensor_cfg)
+            add_gyro_sensor(
+                self.mjcf,
+                site=normalized_cfg.site,
+                name=normalized_cfg.name,
+            )
 
     @staticmethod
     def get_missing_joint_sites(

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -21,7 +21,6 @@ from mujoco_urdf_loader.mjcf_fcn import (
 )
 from mujoco_urdf_loader.urdf_fcn import (
     add_mujoco_element,
-    get_mesh_path,
     remove_gazebo_elements,
     detect_spherical_joint_groups,
     collapse_spherical_revolute_triplets,
@@ -61,10 +60,13 @@ class EqualityConstraintCfg:
 
 @dataclasses.dataclass
 class URDFtoMuJoCoLoaderCfg:
-    controlled_joints: List[str]
+    observed_joints: Union[None, List[str]] = None
+    actuated_joints: Union[None, List[str]] = None
     control_modes: Union[None, List[ControlMode]] = None
     stiffness: Union[None, List[float]] = None
     damping: Union[None, List[float]] = None
+    joint_damping: Union[None, List[float]] = None
+    joint_frictionloss: Union[None, List[float]] = None
     armature: Union[None, List[float]] = None
     all_missing_joints_as_sites: bool = False
     framequat_sensors_cfg: Union[None, List[Union[FrameQuatSensorCfg, Dict[str, Any]]]] = None
@@ -83,15 +85,232 @@ class URDFtoMuJoCoLoader:
 
         Args:
             mjcf (str): The MuJoCo string.
-            joints (List[str]): The list of joints to command.
+            cfg (URDFtoMuJoCoLoaderCfg): Loader configuration.
         """
+        normalized_cfg = self._normalize_cfg(cfg)
+
         self.mjcf = mjcf
-        self.controlled_joints = cfg.controlled_joints
+        self.observed_joints = normalized_cfg.observed_joints
+        self.actuated_joints = normalized_cfg.actuated_joints
+
+        self.control_mode = {
+            joint: mode
+            for joint, mode in zip(self.actuated_joints, normalized_cfg.control_modes)
+        }
+
+        self.set_observed_joint_dynamics(
+            damping=normalized_cfg.joint_damping,
+            frictionloss=normalized_cfg.joint_frictionloss,
+        )
+
+        self.set_actuated_joints(
+            normalized_cfg.actuated_joints,
+            stiffness=normalized_cfg.stiffness,
+            damping=normalized_cfg.damping,
+        )
+
+    @staticmethod
+    def _normalize_cfg(cfg: URDFtoMuJoCoLoaderCfg) -> URDFtoMuJoCoLoaderCfg:
+        """Normalize and validate joint/control related arrays."""
+        observed_joints = cfg.observed_joints
+
+        if observed_joints is None:
+            raise ValueError("observed_joints must be provided.")
+        observed_joints = list(observed_joints)
+
+        actuated_joints = (
+            list(cfg.actuated_joints)
+            if cfg.actuated_joints is not None
+            else list(observed_joints)
+        )
+
+        observed_set = set(observed_joints)
+        invalid_actuated = [j for j in actuated_joints if j not in observed_set]
+        if invalid_actuated:
+            raise ValueError(
+                "actuated_joints must be a subset of observed_joints. "
+                f"Invalid entries: {invalid_actuated}"
+            )
+
         if cfg.control_modes is None:
-            self.control_mode = {joint: ControlMode.TORQUE for joint in cfg.controlled_joints}
+            control_modes = [ControlMode.TORQUE] * len(actuated_joints)
         else:
-            self.control_mode = {joint: mode for joint, mode in zip(cfg.controlled_joints, cfg.control_modes)}
-        self.set_controlled_joints(cfg.controlled_joints)
+            if len(cfg.control_modes) != len(actuated_joints):
+                raise ValueError(
+                    f"Length of control_modes ({len(cfg.control_modes)}) must match "
+                    f"the number of actuated_joints ({len(actuated_joints)})."
+                )
+            control_modes = []
+            for mode in cfg.control_modes:
+                if isinstance(mode, ControlMode):
+                    control_modes.append(mode)
+                elif isinstance(mode, str):
+                    mode_upper = mode.upper()
+                    if mode_upper in ControlMode.__members__:
+                        control_modes.append(ControlMode[mode_upper])
+                    else:
+                        try:
+                            control_modes.append(ControlMode(mode.lower()))
+                        except ValueError as exc:
+                            raise ValueError(
+                                f"Unsupported control mode: {mode}"
+                            ) from exc
+                else:
+                    raise TypeError(
+                        "Each control mode must be a ControlMode enum or string."
+                    )
+
+        stiffness = list(cfg.stiffness) if cfg.stiffness is not None else None
+        damping = list(cfg.damping) if cfg.damping is not None else None
+
+        has_position = any(mode == ControlMode.POSITION for mode in control_modes)
+        if has_position:
+            if stiffness is None:
+                raise ValueError(
+                    "stiffness is required when any actuator uses POSITION control mode."
+                )
+            if damping is None:
+                raise ValueError(
+                    "damping is required when any actuator uses POSITION control mode."
+                )
+
+        if stiffness is not None and len(stiffness) != len(actuated_joints):
+            raise ValueError(
+                f"Length of stiffness ({len(stiffness)}) must match "
+                f"the number of actuated_joints ({len(actuated_joints)})."
+            )
+
+        if damping is not None and len(damping) != len(actuated_joints):
+            raise ValueError(
+                f"Length of damping ({len(damping)}) must match "
+                f"the number of actuated_joints ({len(actuated_joints)})."
+            )
+
+        joint_damping = (
+            list(cfg.joint_damping) if cfg.joint_damping is not None else None
+        )
+        if joint_damping is not None and len(joint_damping) != len(observed_joints):
+            raise ValueError(
+                f"Length of joint_damping ({len(joint_damping)}) must match "
+                f"the number of observed_joints ({len(observed_joints)})."
+            )
+
+        joint_frictionloss = (
+            list(cfg.joint_frictionloss)
+            if cfg.joint_frictionloss is not None
+            else None
+        )
+        if joint_frictionloss is not None and len(joint_frictionloss) != len(observed_joints):
+            raise ValueError(
+                f"Length of joint_frictionloss ({len(joint_frictionloss)}) must match "
+                f"the number of observed_joints ({len(observed_joints)})."
+            )
+
+        armature = list(cfg.armature) if cfg.armature is not None else None
+        normalized_armature = None
+        if armature is not None:
+            if len(armature) == len(actuated_joints):
+                # Canonical: one armature value per actuated joint.
+                normalized_armature = list(armature)
+            elif len(armature) == len(observed_joints):
+                # Also accept one value per observed joint and project by name to
+                # the actuated subset.
+                observed_armature = {
+                    joint_name: value
+                    for joint_name, value in zip(observed_joints, armature)
+                }
+                normalized_armature = [
+                    observed_armature[joint_name] for joint_name in actuated_joints
+                ]
+            else:
+                raise ValueError(
+                    f"Length of armature ({len(armature)}) must match "
+                    f"the number of actuated_joints ({len(actuated_joints)}) "
+                    f"or observed_joints ({len(observed_joints)})."
+                )
+
+        return URDFtoMuJoCoLoaderCfg(
+            observed_joints=list(observed_joints),
+            actuated_joints=list(actuated_joints),
+            control_modes=list(control_modes),
+            stiffness=stiffness,
+            damping=damping,
+            joint_damping=joint_damping,
+            joint_frictionloss=joint_frictionloss,
+            armature=normalized_armature,
+            all_missing_joints_as_sites=cfg.all_missing_joints_as_sites,
+            framequat_sensors_cfg=cfg.framequat_sensors_cfg,
+            gyro_sensors_cfg=cfg.gyro_sensors_cfg,
+            cameras_cfg=cfg.cameras_cfg,
+            equality_constraints_cfg=cfg.equality_constraints_cfg,
+            ball_joint_damping=cfg.ball_joint_damping,
+            ball_joint_armature=cfg.ball_joint_armature,
+            ball_joint_frictionloss=cfg.ball_joint_frictionloss,
+        )
+
+    @staticmethod
+    def _filter_cfg_for_removed_joints(
+        cfg: URDFtoMuJoCoLoaderCfg, removed_joints: set
+    ) -> URDFtoMuJoCoLoaderCfg:
+        if not removed_joints:
+            return cfg
+
+        filtered_observed_indices = [
+            i for i, joint in enumerate(cfg.observed_joints) if joint not in removed_joints
+        ]
+        filtered_observed = [cfg.observed_joints[i] for i in filtered_observed_indices]
+
+        filtered_actuated_indices = [
+            i for i, joint in enumerate(cfg.actuated_joints) if joint not in removed_joints
+        ]
+        filtered_actuated = [cfg.actuated_joints[i] for i in filtered_actuated_indices]
+
+        filtered_control_modes = [cfg.control_modes[i] for i in filtered_actuated_indices]
+
+        filtered_stiffness = (
+            [cfg.stiffness[i] for i in filtered_actuated_indices]
+            if cfg.stiffness is not None
+            else None
+        )
+        filtered_damping = (
+            [cfg.damping[i] for i in filtered_actuated_indices]
+            if cfg.damping is not None
+            else None
+        )
+        filtered_joint_damping = (
+            [cfg.joint_damping[i] for i in filtered_observed_indices]
+            if cfg.joint_damping is not None
+            else None
+        )
+        filtered_joint_frictionloss = (
+            [cfg.joint_frictionloss[i] for i in filtered_observed_indices]
+            if cfg.joint_frictionloss is not None
+            else None
+        )
+        filtered_armature = (
+            [cfg.armature[i] for i in filtered_actuated_indices]
+            if cfg.armature is not None
+            else None
+        )
+
+        return URDFtoMuJoCoLoaderCfg(
+            observed_joints=filtered_observed,
+            actuated_joints=filtered_actuated,
+            control_modes=filtered_control_modes,
+            stiffness=filtered_stiffness,
+            damping=filtered_damping,
+            joint_damping=filtered_joint_damping,
+            joint_frictionloss=filtered_joint_frictionloss,
+            armature=filtered_armature,
+            all_missing_joints_as_sites=cfg.all_missing_joints_as_sites,
+            framequat_sensors_cfg=cfg.framequat_sensors_cfg,
+            gyro_sensors_cfg=cfg.gyro_sensors_cfg,
+            cameras_cfg=cfg.cameras_cfg,
+            equality_constraints_cfg=cfg.equality_constraints_cfg,
+            ball_joint_damping=cfg.ball_joint_damping,
+            ball_joint_armature=cfg.ball_joint_armature,
+            ball_joint_frictionloss=cfg.ball_joint_frictionloss,
+        )
 
     @staticmethod
     def load_urdf(urdf_path: str, mesh_path: str, cfg: URDFtoMuJoCoLoaderCfg):
@@ -100,29 +319,35 @@ class URDFtoMuJoCoLoader:
 
         Args:
             urdf_path (Path): The URDF file path.
-            cfg (URDFtoMuJoCoLoaderCfg): The configuration containing the controlled joints, control modes, stiffness and damping.
+            cfg (URDFtoMuJoCoLoaderCfg): The loader configuration.
 
         Returns:
-            str: The URDF string.
+            URDFtoMuJoCoLoader: The initialized loader instance.
         """
-        original_urdf = ET.parse(urdf_path).getroot()
-        original_urdf = remove_gazebo_elements(original_urdf)
+        normalized_cfg = URDFtoMuJoCoLoader._normalize_cfg(cfg)
 
-        urdf_string = URDFtoMuJoCoLoader.simplify_urdf(urdf_path, cfg.controlled_joints, cfg.stiffness, cfg.damping)
+        urdf_string = URDFtoMuJoCoLoader.simplify_urdf(
+            urdf_path,
+            normalized_cfg.observed_joints,
+            None,
+            None,
+        )
         reduced_urdf = remove_gazebo_elements(urdf_string)
 
         # --- Spherical joint handling ---
         # Detect triplets of revolute joints that represent spherical joints
         # (iDynTree convention: 3 revolute joints with x/y/z axes + 2 dummy links)
-        spherical_groups = detect_spherical_joint_groups(cfg.controlled_joints)
+        spherical_groups = detect_spherical_joint_groups(normalized_cfg.observed_joints)
         ball_joint_map = {}
         if spherical_groups:
             reduced_urdf, ball_joint_map = collapse_spherical_revolute_triplets(
                 reduced_urdf, spherical_groups
             )
-            print(f"Collapsed {len(spherical_groups)} spherical joint group(s) "
-                  f"into ball joint placeholders: "
-                  f"{[g['base_name'] for g in spherical_groups]}")
+            print(
+                f"Collapsed {len(spherical_groups)} spherical joint group(s) "
+                "into ball joint placeholders: "
+                f"{[g['base_name'] for g in spherical_groups]}"
+            )
 
         urdf_for_mjcf = add_mujoco_element(reduced_urdf, mesh_path)
         mjcf = load_urdf_into_mjcf(urdf_for_mjcf)
@@ -131,56 +356,25 @@ class URDFtoMuJoCoLoader:
         # Convert placeholder hinge joints to MuJoCo ball joints
         if ball_joint_map:
             convert_hinge_to_ball_joints(
-                mjcf, ball_joint_map,
-                damping=cfg.ball_joint_damping,
-                armature=cfg.ball_joint_armature,
-                frictionloss=cfg.ball_joint_frictionloss,  # use damping value for frictionloss as well for stability
+                mjcf,
+                ball_joint_map,
+                damping=normalized_cfg.ball_joint_damping,
+                armature=normalized_cfg.ball_joint_armature,
+                frictionloss=normalized_cfg.ball_joint_frictionloss,
             )
 
         # Build the set of spherical joint names (all 3 axes) for filtering
         spherical_joint_names = set()
         for group in spherical_groups:
-            spherical_joint_names.update([
-                group["joint_x"], group["joint_y"], group["joint_z"]
-            ])
+            spherical_joint_names.update(
+                [group["joint_x"], group["joint_y"], group["joint_z"]]
+            )
 
-        # Create a filtered config that excludes the spherical revolute joints
-        # (ball joints are passive and don't need actuators)
-        if spherical_joint_names:
-            filtered_indices = [
-                i for i, j in enumerate(cfg.controlled_joints)
-                if j not in spherical_joint_names
-            ]
-            filtered_joints = [cfg.controlled_joints[i] for i in filtered_indices]
-            filtered_control_modes = (
-                [cfg.control_modes[i] for i in filtered_indices]
-                if cfg.control_modes is not None else None
-            )
-            filtered_stiffness = (
-                [cfg.stiffness[i] for i in filtered_indices]
-                if cfg.stiffness is not None else None
-            )
-            filtered_damping = (
-                [cfg.damping[i] for i in filtered_indices]
-                if cfg.damping is not None else None
-            )
-            filtered_armature = (
-                [cfg.armature[i] for i in filtered_indices]
-                if cfg.armature is not None else None
-            )
-            mjcf_cfg = URDFtoMuJoCoLoaderCfg(
-                controlled_joints=filtered_joints,
-                control_modes=filtered_control_modes,
-                stiffness=filtered_stiffness,
-                damping=filtered_damping,
-                armature=filtered_armature,
-                all_missing_joints_as_sites=cfg.all_missing_joints_as_sites,
-                framequat_sensors_cfg=cfg.framequat_sensors_cfg,
-                gyro_sensors_cfg=cfg.gyro_sensors_cfg,
-                equality_constraints_cfg=cfg.equality_constraints_cfg,
-            )
-        else:
-            mjcf_cfg = cfg
+        # Ball-joint triplets are passive: remove them from observed + actuated
+        # vectors before adding actuators and setting per-joint values.
+        mjcf_cfg = URDFtoMuJoCoLoader._filter_cfg_for_removed_joints(
+            normalized_cfg, spherical_joint_names
+        )
 
         # Use the reduced URDF (from iDynTree) for computing site transforms.
         # iDynTree modifies joint origins when merging links during model
@@ -189,17 +383,17 @@ class URDFtoMuJoCoLoader:
         missing_joint_sites = URDFtoMuJoCoLoader.get_missing_joint_sites(
             reduced_urdf,
             mjcf,
-            controlled_joints=mjcf_cfg.controlled_joints,
+            observed_joints=mjcf_cfg.observed_joints,
             all_missing_joints_as_sites=mjcf_cfg.all_missing_joints_as_sites,
         )
 
         loader = URDFtoMuJoCoLoader(mjcf, mjcf_cfg)
         loader.set_armature(mjcf_cfg.armature)
         loader.add_sites_for_missing_joints(missing_joint_sites)
-        loader.add_framequat_sensors(cfg.framequat_sensors_cfg)
-        loader.add_gyro_sensors(cfg.gyro_sensors_cfg)
-        loader.add_cameras(cfg.cameras_cfg)
-        loader.add_equality_constraints(cfg.equality_constraints_cfg)
+        loader.add_framequat_sensors(mjcf_cfg.framequat_sensors_cfg)
+        loader.add_gyro_sensors(mjcf_cfg.gyro_sensors_cfg)
+        loader.add_cameras(mjcf_cfg.cameras_cfg)
+        loader.add_equality_constraints(mjcf_cfg.equality_constraints_cfg)
         return loader
 
     @staticmethod
@@ -381,7 +575,7 @@ class URDFtoMuJoCoLoader:
     def get_missing_joint_sites(
         robot_urdf: ET.Element,
         mjcf: ET.Element,
-        controlled_joints: List[str] = None,
+        observed_joints: List[str] = None,
         all_missing_joints_as_sites: bool = False,
     ) -> List[dict]:
         """Extract metadata for URDF links missing as bodies in MJCF.
@@ -397,7 +591,7 @@ class URDFtoMuJoCoLoader:
         Args:
             robot_urdf (ET.Element): The URDF root element.
             mjcf (ET.Element): The MJCF root element.
-            controlled_joints (List[str]): The list of controlled joint names.
+            observed_joints (List[str]): The list of observed joint names.
                 Used only for context; detection is based on comparing all URDF
                 links against MJCF bodies.
             all_missing_joints_as_sites (bool): If True, enable site generation
@@ -409,8 +603,8 @@ class URDFtoMuJoCoLoader:
         if not all_missing_joints_as_sites:
             return []
 
-        if controlled_joints is None:
-            controlled_joints = []
+        if observed_joints is None:
+            observed_joints = []
 
         all_joint_elements = robot_urdf.findall(".//joint")
 
@@ -661,25 +855,60 @@ class URDFtoMuJoCoLoader:
             raise ValueError("No fixed joint found that can be modified to floating.")
 
     def set_armature(self, armature: Union[None, List[float]]):
-        """Set the armature attribute on each controlled joint in the MJCF model.
+        """Set the armature attribute on each actuated joint in the MJCF model.
 
         Args:
-            armature (List[float] | None): Armature values, one per controlled joint.
+            armature (List[float] | None): Armature values, one per actuated joint.
                 If None, no armature attribute is set.
         """
         if armature is None:
             return
 
-        if len(armature) != len(self.controlled_joints):
+        if len(armature) != len(self.actuated_joints):
             raise ValueError(
                 f"Length of armature ({len(armature)}) must match "
-                f"the number of controlled joints ({len(self.controlled_joints)})."
+                f"the number of actuated_joints ({len(self.actuated_joints)})."
             )
 
-        for joint_name, value in zip(self.controlled_joints, armature):
+        for joint_name, value in zip(self.actuated_joints, armature):
             joint_elem = self.mjcf.find(f".//joint[@name='{joint_name}']")
             if joint_elem is not None:
                 joint_elem.set("armature", str(value))
+
+    def set_observed_joint_dynamics(
+        self,
+        damping: Union[None, List[float]] = None,
+        frictionloss: Union[None, List[float]] = None,
+    ):
+        """Set damping/frictionloss attributes on observed joints.
+
+        Args:
+            damping (List[float] | None): Per-observed-joint damping values.
+            frictionloss (List[float] | None): Per-observed-joint frictionloss values.
+        """
+        if damping is None and frictionloss is None:
+            return
+
+        if damping is not None and len(damping) != len(self.observed_joints):
+            raise ValueError(
+                f"Length of joint_damping ({len(damping)}) must match "
+                f"the number of observed_joints ({len(self.observed_joints)})."
+            )
+
+        if frictionloss is not None and len(frictionloss) != len(self.observed_joints):
+            raise ValueError(
+                f"Length of joint_frictionloss ({len(frictionloss)}) must match "
+                f"the number of observed_joints ({len(self.observed_joints)})."
+            )
+
+        for index, joint_name in enumerate(self.observed_joints):
+            joint_elem = self.mjcf.find(f".//joint[@name='{joint_name}']")
+            if joint_elem is None:
+                continue
+            if damping is not None:
+                joint_elem.set("damping", str(float(damping[index])))
+            if frictionloss is not None:
+                joint_elem.set("frictionloss", str(float(frictionloss[index])))
 
     def set_control_mode(self, joint: Union[str, List[str]], mode: ControlMode):
         """
@@ -697,18 +926,48 @@ class URDFtoMuJoCoLoader:
         else:
             raise ValueError("joint must be a string or a list of strings.")
 
-    def add_actuator(self, joint: str, control_mode: ControlMode):
+    def add_actuator(
+        self,
+        joint: str,
+        control_mode: ControlMode,
+        stiffness: Union[None, float] = None,
+        damping: Union[None, float] = None,
+    ):
         """
         Add an actuator to the MJCF model.
 
         Args:
             joint (str): The joint name.
             control_mode (ControlMode): The control mode.
+            stiffness (float | None): Position gain used as kp for position mode.
+            damping (float | None): Joint damping applied for position mode.
         """
         if control_mode == ControlMode.POSITION:
+            if stiffness is None:
+                raise ValueError(
+                    f"POSITION control for joint {joint} requires stiffness (kp)."
+                )
+            if damping is None:
+                raise ValueError(
+                    f"POSITION control for joint {joint} requires damping."
+                )
+
             joint_mjcf = self.mjcf.find(f".//joint[@name='{joint}']")
+            if joint_mjcf is None:
+                raise ValueError(f"Joint {joint} not found in the MJCF model.")
+            if "range" not in joint_mjcf.attrib:
+                raise ValueError(
+                    f"Joint {joint} is missing range, required for position control."
+                )
+
             ctrlrange = list(map(float, joint_mjcf.attrib["range"].split()))
-            add_position_actuator(self.mjcf, joint=joint, ctrlrange=ctrlrange)
+            add_position_actuator(
+                self.mjcf,
+                joint=joint,
+                ctrlrange=ctrlrange,
+                kp=float(stiffness),
+            )
+            joint_mjcf.set("damping", str(float(damping)))
         elif control_mode == ControlMode.TORQUE:
             add_torque_actuator(self.mjcf, joint=joint, ctrlrange=None)
         elif control_mode == ControlMode.VELOCITY:
@@ -716,24 +975,44 @@ class URDFtoMuJoCoLoader:
         else:
             raise ValueError("Control mode not recognized.")
 
-    def set_controlled_joints(self, joints: List[str]):
-        """
-        Set the controlled joints.
+    def set_actuated_joints(
+        self,
+        joints: List[str],
+        stiffness: Union[None, List[float]] = None,
+        damping: Union[None, List[float]] = None,
+    ):
+        """Set actuated joints and add actuators according to per-joint modes."""
+        self.actuated_joints = list(joints)
+        joint_elements = {
+            joint.attrib["name"]: joint for joint in self.mjcf.findall(".//joint")
+        }
 
-        Args:
-            joints (List[str]): The list of joints.
-        """
-        self.controlled_joints = joints
-        joint_elements = {joint.attrib["name"]: joint for joint in self.mjcf.findall(".//joint")}
+        if stiffness is not None and len(stiffness) != len(self.actuated_joints):
+            raise ValueError(
+                f"Length of stiffness ({len(stiffness)}) must match "
+                f"the number of actuated_joints ({len(self.actuated_joints)})."
+            )
 
-        for controlled_joint in self.controlled_joints:
-            joint_element = joint_elements.get(controlled_joint)
-            if joint_element is not None:
-                self.add_actuator(controlled_joint, self.control_mode[controlled_joint])
-            else:
-                raise ValueError(
-                    f"Joint {controlled_joint} not found in the MJCF model."
-                )
+        if damping is not None and len(damping) != len(self.actuated_joints):
+            raise ValueError(
+                f"Length of damping ({len(damping)}) must match "
+                f"the number of actuated_joints ({len(self.actuated_joints)})."
+            )
+
+        for i, actuated_joint in enumerate(self.actuated_joints):
+            joint_element = joint_elements.get(actuated_joint)
+            if joint_element is None:
+                raise ValueError(f"Joint {actuated_joint} not found in the MJCF model.")
+
+            if actuated_joint not in self.control_mode:
+                self.control_mode[actuated_joint] = ControlMode.TORQUE
+
+            self.add_actuator(
+                actuated_joint,
+                self.control_mode[actuated_joint],
+                stiffness=(stiffness[i] if stiffness is not None else None),
+                damping=(damping[i] if damping is not None else None),
+            )
 
     def add_sites_for_missing_joints(self, fixed_joint_sites: List[dict]):
         """Add one MJCF site for each configured missing URDF joint.

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -33,6 +33,7 @@ class URDFtoMuJoCoLoaderCfg:
     control_modes: Union[None, List[ControlMode]] = None
     stiffness: Union[None, List[float]] = None
     damping: Union[None, List[float]] = None
+    armature: Union[None, List[float]] = None
     all_missing_joints_as_sites: bool = False
 
 
@@ -86,6 +87,7 @@ class URDFtoMuJoCoLoader:
         )
 
         loader = URDFtoMuJoCoLoader(mjcf, cfg)
+        loader.set_armature(cfg.armature)
         loader.add_sites_for_missing_joints(missing_joint_sites)
         return loader
 
@@ -371,6 +373,27 @@ class URDFtoMuJoCoLoader:
 
         if not fixed_joint_found:
             raise ValueError("No fixed joint found that can be modified to floating.")
+
+    def set_armature(self, armature: Union[None, List[float]]):
+        """Set the armature attribute on each controlled joint in the MJCF model.
+
+        Args:
+            armature (List[float] | None): Armature values, one per controlled joint.
+                If None, no armature attribute is set.
+        """
+        if armature is None:
+            return
+
+        if len(armature) != len(self.controlled_joints):
+            raise ValueError(
+                f"Length of armature ({len(armature)}) must match "
+                f"the number of controlled joints ({len(self.controlled_joints)})."
+            )
+
+        for joint_name, value in zip(self.controlled_joints, armature):
+            joint_elem = self.mjcf.find(f".//joint[@name='{joint_name}']")
+            if joint_elem is not None:
+                joint_elem.set("armature", str(value))
 
     def set_control_mode(self, joint: Union[str, List[str]], mode: ControlMode):
         """

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -2,7 +2,7 @@ import dataclasses
 import tempfile
 import xml.etree.ElementTree as ET
 from enum import Enum
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import idyntree.bindings as idyn
 import numpy as np
@@ -45,18 +45,24 @@ class GyroSensorCfg:
     site: str
     name: str = None
 
+
 @dataclasses.dataclass
 class CameraCfg:
     site: str
     fovy: float
     name: str
 
+
 @dataclasses.dataclass
 class EqualityConstraintCfg:
     """Configuration for a connect/weld equality constraint between two sites."""
+
     site1: str
     site2: str
     constraint_type: str = "connect"
+    solimp: Optional[List[float]] = None
+    solref: Optional[List[float]] = None
+
 
 @dataclasses.dataclass
 class URDFtoMuJoCoLoaderCfg:
@@ -69,10 +75,14 @@ class URDFtoMuJoCoLoaderCfg:
     joint_frictionloss: Union[None, List[float]] = None
     armature: Union[None, List[float]] = None
     all_missing_joints_as_sites: bool = False
-    framequat_sensors_cfg: Union[None, List[Union[FrameQuatSensorCfg, Dict[str, Any]]]] = None
+    framequat_sensors_cfg: Union[
+        None, List[Union[FrameQuatSensorCfg, Dict[str, Any]]]
+    ] = None
     gyro_sensors_cfg: Union[None, List[Union[GyroSensorCfg, Dict[str, Any]]]] = None
     cameras_cfg: Union[None, List[Union[CameraCfg, Dict[str, Any]]]] = None
-    equality_constraints_cfg: Union[None, List[Union[EqualityConstraintCfg, Dict[str, Any]]]] = None
+    equality_constraints_cfg: Union[
+        None, List[Union[EqualityConstraintCfg, Dict[str, Any]]]
+    ] = None
     ball_joint_damping: float = 0.0
     ball_joint_armature: float = 0.0
     ball_joint_frictionloss: float = 0.0
@@ -196,11 +206,11 @@ class URDFtoMuJoCoLoader:
             )
 
         joint_frictionloss = (
-            list(cfg.joint_frictionloss)
-            if cfg.joint_frictionloss is not None
-            else None
+            list(cfg.joint_frictionloss) if cfg.joint_frictionloss is not None else None
         )
-        if joint_frictionloss is not None and len(joint_frictionloss) != len(observed_joints):
+        if joint_frictionloss is not None and len(joint_frictionloss) != len(
+            observed_joints
+        ):
             raise ValueError(
                 f"Length of joint_frictionloss ({len(joint_frictionloss)}) must match "
                 f"the number of observed_joints ({len(observed_joints)})."
@@ -256,16 +266,22 @@ class URDFtoMuJoCoLoader:
             return cfg
 
         filtered_observed_indices = [
-            i for i, joint in enumerate(cfg.observed_joints) if joint not in removed_joints
+            i
+            for i, joint in enumerate(cfg.observed_joints)
+            if joint not in removed_joints
         ]
         filtered_observed = [cfg.observed_joints[i] for i in filtered_observed_indices]
 
         filtered_actuated_indices = [
-            i for i, joint in enumerate(cfg.actuated_joints) if joint not in removed_joints
+            i
+            for i, joint in enumerate(cfg.actuated_joints)
+            if joint not in removed_joints
         ]
         filtered_actuated = [cfg.actuated_joints[i] for i in filtered_actuated_indices]
 
-        filtered_control_modes = [cfg.control_modes[i] for i in filtered_actuated_indices]
+        filtered_control_modes = [
+            cfg.control_modes[i] for i in filtered_actuated_indices
+        ]
 
         filtered_stiffness = (
             [cfg.stiffness[i] for i in filtered_actuated_indices]
@@ -422,7 +438,9 @@ class URDFtoMuJoCoLoader:
 
     def add_framequat_sensors(
         self,
-        framequat_sensors_cfg: Union[None, List[Union[FrameQuatSensorCfg, Dict[str, Any]]]] = None,
+        framequat_sensors_cfg: Union[
+            None, List[Union[FrameQuatSensorCfg, Dict[str, Any]]]
+        ] = None,
     ):
         if framequat_sensors_cfg is None:
             # skip adding sensors if no configuration is provided
@@ -460,7 +478,9 @@ class URDFtoMuJoCoLoader:
 
     def add_gyro_sensors(
         self,
-        gyro_sensors_cfg: Union[None, List[Union[GyroSensorCfg, Dict[str, Any]]]] = None,
+        gyro_sensors_cfg: Union[
+            None, List[Union[GyroSensorCfg, Dict[str, Any]]]
+        ] = None,
     ):
         if gyro_sensors_cfg is None:
             return
@@ -491,7 +511,9 @@ class URDFtoMuJoCoLoader:
         fovy = camera_cfg.get("fovy")
 
         if name is None or site is None:
-            raise ValueError("Each camera configuration requires name and site (or link).")
+            raise ValueError(
+                "Each camera configuration requires name and site (or link)."
+            )
 
         return CameraCfg(name=name, site=site, fovy=fovy)
 
@@ -527,6 +549,9 @@ class URDFtoMuJoCoLoader:
         site1 = eq_cfg.get("site1")
         site2 = eq_cfg.get("site2")
         constraint_type = eq_cfg.get("constraint_type", "connect")
+        # get solimp and solref if provided, otherwise default to None
+        solimp = eq_cfg.get("solimp")
+        solref = eq_cfg.get("solref")
 
         if site1 is None or site2 is None:
             raise ValueError(
@@ -534,7 +559,11 @@ class URDFtoMuJoCoLoader:
             )
 
         return EqualityConstraintCfg(
-            site1=site1, site2=site2, constraint_type=constraint_type,
+            site1=site1,
+            site2=site2,
+            constraint_type=constraint_type,
+            solimp=solimp,
+            solref=solref,
         )
 
     def add_equality_constraints(
@@ -551,24 +580,33 @@ class URDFtoMuJoCoLoader:
         Args:
             equality_constraints_cfg: List of ``EqualityConstraintCfg``
                 dataclasses or dicts with keys ``site1``, ``site2``, and
-                optionally ``constraint_type`` (default ``"connect"``).
+                optionally ``constraint_type`` (default ``"connect"``), ``solimp``, and ``solref``.
                 If ``None``, no constraints are added.
         """
         if equality_constraints_cfg is None:
             return
 
-        # Group by constraint_type so we can call the helper once per type
-        by_type: Dict[str, List[tuple]] = {}
+        # Group by (constraint_type, solimp, solref) so each call to the helper
+        # can pass homogeneous solver parameters.
+        by_group: Dict[tuple, List[tuple]] = {}
         for cfg in equality_constraints_cfg:
             normalized = self._normalize_equality_constraint_cfg(cfg)
-            ctype = normalized.constraint_type
-            by_type.setdefault(ctype, []).append(
+            group_key = (
+                normalized.constraint_type,
+                tuple(normalized.solimp) if normalized.solimp is not None else None,
+                tuple(normalized.solref) if normalized.solref is not None else None,
+            )
+            by_group.setdefault(group_key, []).append(
                 (normalized.site1, normalized.site2)
             )
 
-        for constraint_type, site_pairs in by_type.items():
+        for (constraint_type, solimp, solref), site_pairs in by_group.items():
             add_equality_constraints_for_sites(
-                self.mjcf, site_pairs, constraint_type=constraint_type,
+                self.mjcf,
+                site_pairs,
+                constraint_type=constraint_type,
+                solimp=list(solimp) if solimp is not None else None,
+                solref=list(solref) if solref is not None else None,
             )
 
     @staticmethod
@@ -790,7 +828,9 @@ class URDFtoMuJoCoLoader:
         # Load the URDF model
         model_loader = idyn.ModelLoader()
         if not model_loader.loadReducedModelFromFile(urdf_path, joints):
-            raise ValueError(f"Error loading the URDF model from {urdf_path}. Check the file path or if the joints are correct.")
+            raise ValueError(
+                f"Error loading the URDF model from {urdf_path}. Check the file path or if the joints are correct."
+            )
         model = model_loader.model()
 
         if stiffness is not None:
@@ -804,7 +844,6 @@ class URDFtoMuJoCoLoader:
                 joint = model.getJoint(i)
                 for dof in range(joint.getNrOfDOFs()):
                     joint.setDamping(dof, damping[i])
-
 
         # Save the simplified model
         model_saver = idyn.ModelExporter()
@@ -1088,6 +1127,8 @@ class URDFtoMuJoCoLoader:
         """
         mjcf = self.mjcf
         if pretty:
-            mjcf = ET.fromstring(ET.tostring(self.mjcf, encoding="unicode", method="xml"))
+            mjcf = ET.fromstring(
+                ET.tostring(self.mjcf, encoding="unicode", method="xml")
+            )
             ET.indent(mjcf, space="  ")
         return ET.tostring(mjcf, encoding="unicode", method="xml")

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -188,6 +188,7 @@ class URDFtoMuJoCoLoader:
         loader.add_sites_for_missing_joints(missing_joint_sites)
         loader.add_framequat_sensors(cfg.framequat_sensors_cfg)
         loader.add_gyro_sensors(cfg.gyro_sensors_cfg)
+        loader.add_cameras(cfg.cameras_cfg)
         return loader
 
     @staticmethod

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -15,11 +15,14 @@ from mujoco_urdf_loader.mjcf_fcn import (
     separate_left_right_collision_groups,
     add_framequat_sensor,
     add_gyro_sensor,
+    convert_hinge_to_ball_joints,
 )
 from mujoco_urdf_loader.urdf_fcn import (
     add_mujoco_element,
     get_mesh_path,
     remove_gazebo_elements,
+    detect_spherical_joint_groups,
+    collapse_spherical_revolute_triplets,
 )
 
 
@@ -52,6 +55,9 @@ class URDFtoMuJoCoLoaderCfg:
     all_missing_joints_as_sites: bool = False
     framequat_sensors_cfg: Union[None, List[Union[FrameQuatSensorCfg, Dict[str, Any]]]] = None
     gyro_sensors_cfg: Union[None, List[Union[GyroSensorCfg, Dict[str, Any]]]] = None
+    ball_joint_damping: float = 0.0
+    ball_joint_armature: float = 0.0
+    ball_joint_frictionloss: float = 0.0
 
 
 class URDFtoMuJoCoLoader:
@@ -88,9 +94,76 @@ class URDFtoMuJoCoLoader:
 
         urdf_string = URDFtoMuJoCoLoader.simplify_urdf(urdf_path, cfg.controlled_joints, cfg.stiffness, cfg.damping)
         reduced_urdf = remove_gazebo_elements(urdf_string)
+
+        # --- Spherical joint handling ---
+        # Detect triplets of revolute joints that represent spherical joints
+        # (iDynTree convention: 3 revolute joints with x/y/z axes + 2 dummy links)
+        spherical_groups = detect_spherical_joint_groups(cfg.controlled_joints)
+        ball_joint_map = {}
+        if spherical_groups:
+            reduced_urdf, ball_joint_map = collapse_spherical_revolute_triplets(
+                reduced_urdf, spherical_groups
+            )
+            print(f"Collapsed {len(spherical_groups)} spherical joint group(s) "
+                  f"into ball joint placeholders: "
+                  f"{[g['base_name'] for g in spherical_groups]}")
+
         urdf_for_mjcf = add_mujoco_element(reduced_urdf, mesh_path)
         mjcf = load_urdf_into_mjcf(urdf_for_mjcf)
         mjcf = separate_left_right_collision_groups(mjcf)
+
+        # Convert placeholder hinge joints to MuJoCo ball joints
+        if ball_joint_map:
+            convert_hinge_to_ball_joints(
+                mjcf, ball_joint_map,
+                damping=cfg.ball_joint_damping,
+                armature=cfg.ball_joint_armature,
+                frictionloss=cfg.ball_joint_frictionloss,  # use damping value for frictionloss as well for stability
+            )
+
+        # Build the set of spherical joint names (all 3 axes) for filtering
+        spherical_joint_names = set()
+        for group in spherical_groups:
+            spherical_joint_names.update([
+                group["joint_x"], group["joint_y"], group["joint_z"]
+            ])
+
+        # Create a filtered config that excludes the spherical revolute joints
+        # (ball joints are passive and don't need actuators)
+        if spherical_joint_names:
+            filtered_indices = [
+                i for i, j in enumerate(cfg.controlled_joints)
+                if j not in spherical_joint_names
+            ]
+            filtered_joints = [cfg.controlled_joints[i] for i in filtered_indices]
+            filtered_control_modes = (
+                [cfg.control_modes[i] for i in filtered_indices]
+                if cfg.control_modes is not None else None
+            )
+            filtered_stiffness = (
+                [cfg.stiffness[i] for i in filtered_indices]
+                if cfg.stiffness is not None else None
+            )
+            filtered_damping = (
+                [cfg.damping[i] for i in filtered_indices]
+                if cfg.damping is not None else None
+            )
+            filtered_armature = (
+                [cfg.armature[i] for i in filtered_indices]
+                if cfg.armature is not None else None
+            )
+            mjcf_cfg = URDFtoMuJoCoLoaderCfg(
+                controlled_joints=filtered_joints,
+                control_modes=filtered_control_modes,
+                stiffness=filtered_stiffness,
+                damping=filtered_damping,
+                armature=filtered_armature,
+                all_missing_joints_as_sites=cfg.all_missing_joints_as_sites,
+                framequat_sensors_cfg=cfg.framequat_sensors_cfg,
+                gyro_sensors_cfg=cfg.gyro_sensors_cfg,
+            )
+        else:
+            mjcf_cfg = cfg
 
         # Use the reduced URDF (from iDynTree) for computing site transforms.
         # iDynTree modifies joint origins when merging links during model
@@ -99,15 +172,15 @@ class URDFtoMuJoCoLoader:
         missing_joint_sites = URDFtoMuJoCoLoader.get_missing_joint_sites(
             reduced_urdf,
             mjcf,
-            controlled_joints=cfg.controlled_joints,
-            all_missing_joints_as_sites=cfg.all_missing_joints_as_sites,
+            controlled_joints=mjcf_cfg.controlled_joints,
+            all_missing_joints_as_sites=mjcf_cfg.all_missing_joints_as_sites,
         )
 
-        loader = URDFtoMuJoCoLoader(mjcf, cfg)
-        loader.set_armature(cfg.armature)
+        loader = URDFtoMuJoCoLoader(mjcf, mjcf_cfg)
+        loader.set_armature(mjcf_cfg.armature)
         loader.add_sites_for_missing_joints(missing_joint_sites)
-        loader.add_framequat_sensors(cfg.framequat_sensors_cfg)
-        loader.add_gyro_sensors(cfg.gyro_sensors_cfg)
+        loader.add_framequat_sensors(mjcf_cfg.framequat_sensors_cfg)
+        loader.add_gyro_sensors(mjcf_cfg.gyro_sensors_cfg)
         return loader
 
     @staticmethod

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -848,6 +848,10 @@ class URDFtoMuJoCoLoader:
         # Save the simplified model
         model_saver = idyn.ModelExporter()
         model_saver.init(model)
+        export_opts = idyn.ModelExporterOptions()
+        export_opts.baseLink = model.getLinkName(model.getDefaultBaseLink())
+        export_opts.exportFirstBaseLinkAdditionalFrameAsFakeURDFBase = False
+        model_saver.setExportingOptions(export_opts)
 
         with tempfile.NamedTemporaryFile(delete=False) as temp:
             temp_path = temp.name
@@ -863,10 +867,14 @@ class URDFtoMuJoCoLoader:
     @staticmethod
     def connect_root_to_world(root):
         """
-        Connect the root link to the world.
+        Connect the root link to the world via a floating joint.
+
+        If the root link is already ``world``, the first fixed joint from
+        ``world`` is converted to floating.  Otherwise a new ``world`` link
+        and a floating joint are inserted at the beginning of the URDF.
 
         Args:
-            root (ET.Element): The root element.
+            root (ET.Element): The root element of the URDF XML.
         """
 
         # Find all the links and joints in the URDF
@@ -874,24 +882,56 @@ class URDFtoMuJoCoLoader:
         joints = root.findall(".//joint")
         # Find child and parent links for each joint
         child_links = {joint.find("child").attrib["link"] for joint in joints}
-        parent_links = {joint.find("parent").attrib["link"] for joint in joints}
-        # The root link is a parent link that is not a child link
+        # The root link is a link that is never a child of any joint
         root_link = next(link for link in links if link not in child_links)
-        # Find the joint that has the root link as parent
-        fixed_joint_found = False
-        for joint in joints:
-            parent_link = joint.find("parent").attrib["link"]
-            if parent_link == root_link:
-                # Check if the joint is fixed
-                if joint.attrib["type"] == "fixed":
-                    # Change the joint type to floating
+
+        if root_link == "world":
+            # The URDF already has a world link as root; convert the first
+            # fixed joint from world to floating.
+            for joint in joints:
+                parent_link = joint.find("parent").attrib["link"]
+                if parent_link == "world" and joint.attrib["type"] == "fixed":
                     joint.attrib["type"] = "floating"
                     print(f"Modified joint {joint.attrib['name']} to type floating.")
-                    fixed_joint_found = True
-                break
+                    return
+            raise ValueError(
+                "Root link is 'world' but no fixed joint from 'world' was found."
+            )
 
-        if not fixed_joint_found:
-            raise ValueError("No fixed joint found that can be modified to floating.")
+        # Root link is not world — insert a world link and floating joint.
+        # Elements must appear before any joint that references them for
+        # MuJoCo's URDF parser, so we insert at position 0.
+
+        # If a "world" link already exists as a child (e.g. iDynTree exported
+        # it as an additional frame), remove it and its parent joint to avoid
+        # circular dependencies.
+        if "world" in links:
+            for joint in list(root.findall(".//joint")):
+                child_el = joint.find("child")
+                if child_el is not None and child_el.attrib.get("link") == "world":
+                    root.remove(joint)
+                    break
+            root.remove(links["world"])
+
+        world_link = ET.Element("link")
+        world_link.set("name", "world")
+        root.insert(0, world_link)
+
+        floating_joint = ET.Element("joint")
+        floating_joint.set("name", "floating_base_joint")
+        floating_joint.set("type", "floating")
+        origin = ET.SubElement(floating_joint, "origin")
+        origin.set("xyz", "0 0 0")
+        origin.set("rpy", "0 0 0")
+        parent_elem = ET.SubElement(floating_joint, "parent")
+        parent_elem.set("link", "world")
+        child_elem = ET.SubElement(floating_joint, "child")
+        child_elem.set("link", root_link)
+        root.insert(1, floating_joint)
+
+        print(
+            f"Added floating joint 'floating_base_joint' from 'world' to '{root_link}'."
+        )
 
     def set_armature(self, armature: Union[None, List[float]]):
         """Set the armature attribute on each actuated joint in the MJCF model.

--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -15,6 +15,7 @@ from mujoco_urdf_loader.mjcf_fcn import (
     separate_left_right_collision_groups,
     add_framequat_sensor,
     add_gyro_sensor,
+    add_camera_to_site,
 )
 from mujoco_urdf_loader.urdf_fcn import (
     add_mujoco_element,
@@ -41,6 +42,11 @@ class GyroSensorCfg:
     site: str
     name: str = None
 
+@dataclasses.dataclass
+class CameraCfg:
+    site: str
+    fovy: float
+    name: str
 
 @dataclasses.dataclass
 class URDFtoMuJoCoLoaderCfg:
@@ -52,7 +58,7 @@ class URDFtoMuJoCoLoaderCfg:
     all_missing_joints_as_sites: bool = False
     framequat_sensors_cfg: Union[None, List[Union[FrameQuatSensorCfg, Dict[str, Any]]]] = None
     gyro_sensors_cfg: Union[None, List[Union[GyroSensorCfg, Dict[str, Any]]]] = None
-
+    cameras_cfg: Union[None, List[Union[CameraCfg, Dict[str, Any]]]] = None
 
 class URDFtoMuJoCoLoader:
     def __init__(self, mjcf: str, cfg: URDFtoMuJoCoLoaderCfg):
@@ -108,6 +114,7 @@ class URDFtoMuJoCoLoader:
         loader.add_sites_for_missing_joints(missing_joint_sites)
         loader.add_framequat_sensors(cfg.framequat_sensors_cfg)
         loader.add_gyro_sensors(cfg.gyro_sensors_cfg)
+        loader.add_cameras(cfg.cameras_cfg)
         return loader
 
     @staticmethod
@@ -185,6 +192,44 @@ class URDFtoMuJoCoLoader:
                 self.mjcf,
                 site=normalized_cfg.site,
                 name=normalized_cfg.name,
+            )
+
+    @staticmethod
+    def _normalize_camera_cfg(
+        camera_cfg: Union[CameraCfg, Dict[str, Any]],
+    ) -> CameraCfg:
+        if isinstance(camera_cfg, CameraCfg):
+            return camera_cfg
+
+        if not isinstance(camera_cfg, dict):
+            raise TypeError(
+                "Each camera configuration must be a CameraCfg "
+                "or a dict with keys name, site (or link), and fovy."
+            )
+
+        name = camera_cfg.get("name")
+        site = camera_cfg.get("site", camera_cfg.get("link"))
+        fovy = camera_cfg.get("fovy")
+
+        if name is None or site is None:
+            raise ValueError("Each camera configuration requires name and site (or link).")
+
+        return CameraCfg(name=name, site=site, fovy=fovy)
+
+    def add_cameras(
+        self,
+        camera_cfg: Union[None, List[Union[CameraCfg, Dict[str, Any]]]] = None,
+    ):
+        if camera_cfg is None:
+            return
+
+        for camera in camera_cfg:
+            normalized_cfg = self._normalize_camera_cfg(camera)
+            add_camera_to_site(
+                self.mjcf,
+                name=normalized_cfg.name,
+                site=normalized_cfg.site,
+                fovy=normalized_cfg.fovy,
             )
 
     @staticmethod

--- a/mujoco_urdf_loader/mjcf_fcn.py
+++ b/mujoco_urdf_loader/mjcf_fcn.py
@@ -175,6 +175,53 @@ def add_joint_vel_sensor(mjcf: ET.Element, joint: str, name: str = None) -> ET.E
 
     return mjcf
 
+def add_gyro_sensor(mjcf: ET.Element, site: str, name: str = None) -> ET.Element:
+    """Add a gyroscope sensor to the body.
+
+    Args:
+        mjcf (ET.Element): The mjcf file.
+        site (str): The site to add the sensor to.
+        name (str): The name of the sensor (default: f"{site}_gyro").
+    """
+
+    # check if there already is a sensor element in the mjcf
+    if mjcf.find(".//sensor") is None:
+        sensors = ET.Element("sensor")
+        mjcf.append(sensors)
+    else:
+        sensors = mjcf.find(".//sensor")
+
+    # create the gyroscope sensor
+    gyro = ET.SubElement(sensors, "gyro")
+    gyro.set("name", name if name is not None else f"{site}_gyro")
+    gyro.set("site", site)
+
+    return mjcf
+
+def add_framequat_sensor(mjcf: ET.Element, objname: str, objtype: str = 'site', name: str = None) -> ET.Element:
+    """Add a frame quaternion sensor to the body.
+
+    Args:
+        mjcf (ET.Element): The mjcf file.
+        site (str): The site to add the sensor to.
+        name (str): The name of the sensor (default: f"{site}_framequat").
+    """
+
+    # check if there already is a sensor element in the mjcf
+    if mjcf.find(".//sensor") is None:
+        sensors = ET.Element("sensor")
+        mjcf.append(sensors)
+    else:
+        sensors = mjcf.find(".//sensor")
+
+    # create the frame quaternion sensor
+    framequat = ET.SubElement(sensors, "framequat")
+    framequat.set("name", name if name is not None else f"{objname}_framequat")
+    framequat.set("objtype", objtype)
+    framequat.set("objname", objname)
+
+    return mjcf
+
 
 def add_joint_eq(
     mjcf: ET.Element, 

--- a/mujoco_urdf_loader/mjcf_fcn.py
+++ b/mujoco_urdf_loader/mjcf_fcn.py
@@ -1,5 +1,6 @@
 import xml.etree.ElementTree as ET
 from typing import List
+from scipy.spatial.transform import Rotation
 
 
 def add_new_worldbody(
@@ -197,6 +198,62 @@ def add_gyro_sensor(mjcf: ET.Element, site: str, name: str = None) -> ET.Element
     gyro.set("site", site)
 
     return mjcf
+
+def add_camera_to_site(mjcf: ET.Element, name: str, site: str, fovy: float) -> ET.Element:
+    """Add a camera tag to the site.
+
+    Args:
+        mjcf (ET.Element): The mjcf file.
+        name (str): The name of the camera.
+        site (str): The site to add the camera tag to.
+        fovy (float): The field of view of the camera (deg).
+    """
+    # look for the site in the mjcf file and retrieve the position and orientation of the site
+    site_element = mjcf.find(f".//site[@name='{site}']")
+    if site_element is None:
+        raise ValueError(f"Site {site} not found in the mjcf file.")
+    pos = site_element.attrib["pos"]
+    quat = site_element.attrib["quat"]
+
+    q_site_wxyz = list(map(float, quat.split()))
+    if len(q_site_wxyz) != 4:
+        raise ValueError("Quaternion must have exactly 4 components in [w x y z] format.")
+
+    # scipy uses [x, y, z, w], MuJoCo uses [w, x, y, z]
+    r_site = Rotation.from_quat([q_site_wxyz[1], q_site_wxyz[2], q_site_wxyz[3], q_site_wxyz[0]])
+    # MuJoCo cameras look along the local -Z axis, while site/tool frames are
+    # typically defined with +Z as forward. Rotate 180° about X so the camera
+    # optical axis aligns with the intended site forward direction.
+    r_x180 = Rotation.from_euler("x", 180, degrees=True)
+    r_camera = r_site * r_x180
+    q_camera_xyzw = r_camera.as_quat()
+    camera_quat = f"{q_camera_xyzw[3]} {q_camera_xyzw[0]} {q_camera_xyzw[1]} {q_camera_xyzw[2]}"
+
+    # create the camera tag as a sibling right after the site element
+    camera = ET.Element("camera")
+    camera.set("name", name)
+    camera.set("pos", pos)
+    camera.set("quat", camera_quat)
+    camera.set("fovy", str(fovy))
+
+    # xml.etree.ElementTree.Element has no addnext(); find parent and insert manually
+    parent = None
+    for elem in mjcf.iter():
+        for child in list(elem):
+            if child is site_element:
+                parent = elem
+                break
+        if parent is not None:
+            break
+
+    if parent is None:
+        raise ValueError(f"Parent of site {site} not found in the mjcf file.")
+
+    children = list(parent)
+    site_idx = children.index(site_element)
+    parent.insert(site_idx + 1, camera)
+    return mjcf
+
 
 def add_framequat_sensor(mjcf: ET.Element, objname: str, objtype: str = 'site', name: str = None) -> ET.Element:
     """Add a frame quaternion sensor to the body.

--- a/mujoco_urdf_loader/mjcf_fcn.py
+++ b/mujoco_urdf_loader/mjcf_fcn.py
@@ -177,6 +177,7 @@ def add_joint_vel_sensor(mjcf: ET.Element, joint: str, name: str = None) -> ET.E
 
     return mjcf
 
+
 def add_gyro_sensor(mjcf: ET.Element, site: str, name: str = None) -> ET.Element:
     """Add a gyroscope sensor to the body.
 
@@ -200,7 +201,10 @@ def add_gyro_sensor(mjcf: ET.Element, site: str, name: str = None) -> ET.Element
 
     return mjcf
 
-def add_camera_to_site(mjcf: ET.Element, name: str, site: str, fovy: float) -> ET.Element:
+
+def add_camera_to_site(
+    mjcf: ET.Element, name: str, site: str, fovy: float
+) -> ET.Element:
     """Add a camera tag to the site.
 
     Args:
@@ -218,17 +222,23 @@ def add_camera_to_site(mjcf: ET.Element, name: str, site: str, fovy: float) -> E
 
     q_site_wxyz = list(map(float, quat.split()))
     if len(q_site_wxyz) != 4:
-        raise ValueError("Quaternion must have exactly 4 components in [w x y z] format.")
+        raise ValueError(
+            "Quaternion must have exactly 4 components in [w x y z] format."
+        )
 
     # scipy uses [x, y, z, w], MuJoCo uses [w, x, y, z]
-    r_site = Rotation.from_quat([q_site_wxyz[1], q_site_wxyz[2], q_site_wxyz[3], q_site_wxyz[0]])
+    r_site = Rotation.from_quat(
+        [q_site_wxyz[1], q_site_wxyz[2], q_site_wxyz[3], q_site_wxyz[0]]
+    )
     # MuJoCo cameras look along the local -Z axis, while site/tool frames are
     # typically defined with +Z as forward. Rotate 180° about X so the camera
     # optical axis aligns with the intended site forward direction.
     r_x180 = Rotation.from_euler("x", 180, degrees=True)
     r_camera = r_site * r_x180
     q_camera_xyzw = r_camera.as_quat()
-    camera_quat = f"{q_camera_xyzw[3]} {q_camera_xyzw[0]} {q_camera_xyzw[1]} {q_camera_xyzw[2]}"
+    camera_quat = (
+        f"{q_camera_xyzw[3]} {q_camera_xyzw[0]} {q_camera_xyzw[1]} {q_camera_xyzw[2]}"
+    )
 
     # create the camera tag as a sibling right after the site element
     camera = ET.Element("camera")
@@ -256,7 +266,9 @@ def add_camera_to_site(mjcf: ET.Element, name: str, site: str, fovy: float) -> E
     return mjcf
 
 
-def add_framequat_sensor(mjcf: ET.Element, objname: str, objtype: str = 'site', name: str = None) -> ET.Element:
+def add_framequat_sensor(
+    mjcf: ET.Element, objname: str, objtype: str = "site", name: str = None
+) -> ET.Element:
     """Add a frame quaternion sensor to the body.
 
     Args:
@@ -372,6 +384,7 @@ def set_collision_groups(
 
     return mjcf
 
+
 def update_meshdir(mjcf: ET.Element, meshdir: str) -> ET.Element:
     """Set the meshdir in the mjcf file.
 
@@ -386,6 +399,7 @@ def update_meshdir(mjcf: ET.Element, meshdir: str) -> ET.Element:
     compiler.set("meshdir", meshdir)
 
     return mjcf
+
 
 def separate_left_right_collision_groups(
     mjcf: ET.Element,
@@ -591,8 +605,13 @@ def convert_hinge_to_ball_joints(
         joint_elem.set("frictionloss", str(frictionloss))
     return mjcf
 
+
 def add_equality_constraints_for_sites(
-    mjcf: ET.Element, site_pairs: List[tuple], constraint_type: str = "connect"
+    mjcf: ET.Element,
+    site_pairs: List[tuple],
+    constraint_type: str = "connect",
+    solimp: List[float] = None,
+    solref: List[float] = None,
 ) -> ET.Element:
     """
     Add equality constraints between pairs of sites in MJCF.
@@ -601,6 +620,8 @@ def add_equality_constraints_for_sites(
         mjcf (ET.Element): The MJCF file as ElementTree.
         site_pairs (List[tuple]): List of tuples with (site1_name, site2_name) to connect.
         constraint_type (str): Type of constraint - "connect" or "weld" (default: "connect").
+        solimp (List[float], optional): Solver impedance parameters for the constraint.
+        solref (List[float], optional): Solver reference parameters for the constraint.
 
     Returns:
         ET.Element: The modified MJCF file.
@@ -626,6 +647,10 @@ def add_equality_constraints_for_sites(
             constraint = ET.SubElement(equality, "connect")
             constraint.set("site1", site1)
             constraint.set("site2", site2)
+            if solimp is not None:
+                constraint.set("solimp", " ".join(map(str, solimp)))
+            if solref is not None:
+                constraint.set("solref", " ".join(map(str, solref)))
         elif constraint_type == "weld":
             # Weld constraint references bodies
             # Find parent bodies of the sites
@@ -645,6 +670,10 @@ def add_equality_constraints_for_sites(
             constraint = ET.SubElement(equality, "weld")
             constraint.set("body1", body1)
             constraint.set("body2", body2)
+            if solimp is not None:
+                constraint.set("solimp", " ".join(map(str, solimp)))
+            if solref is not None:
+                constraint.set("solref", " ".join(map(str, solref)))
         else:
             raise ValueError(f"Unknown constraint type: {constraint_type}")
 

--- a/mujoco_urdf_loader/mjcf_fcn.py
+++ b/mujoco_urdf_loader/mjcf_fcn.py
@@ -1,5 +1,5 @@
 import xml.etree.ElementTree as ET
-from typing import List
+from typing import Dict, List
 
 
 def add_new_worldbody(
@@ -457,4 +457,64 @@ def add_sphere(
     geom.set("rgba", f"{rgba[0]} {rgba[1]} {rgba[2]} {rgba[3]}")
     geom.set("mass", f"{mass}")
 
+    return mjcf
+
+
+def convert_hinge_to_ball_joints(
+    mjcf: ET.Element,
+    ball_joint_map: Dict[str, str],
+    damping: float = 0.01,
+    armature: float = 0.001,
+    frictionloss: float = 0.001,
+) -> ET.Element:
+    """Convert placeholder hinge joints into MuJoCo ball joints.
+
+    After collapsing 3-revolute spherical triplets in the URDF, MuJoCo creates
+    regular hinge joints for them.  This function post-processes the MJCF to
+    turn those hinges into ``type="ball"`` joints, removes hinge-only
+    attributes, and sets damping / armature for numerical stability.
+
+    Args:
+        mjcf: The MJCF root element (modified in-place).
+        ball_joint_map: Mapping from the placeholder joint name (the former
+            ``_x`` revolute joint name) to the spherical group base name.
+            Produced by
+            :func:`~mujoco_urdf_loader.urdf_fcn.collapse_spherical_revolute_triplets`.
+        damping: Viscous damping coefficient applied to each ball joint.
+            A small positive value prevents unconstrained free-spin that
+            causes simulation instability.  Default ``0.01``.
+        armature: Rotor inertia (diagonal) added to each ball joint.
+            Default ``0.001``.
+        frictionloss: Friction loss applied to each ball joint.
+            Default ``0.001``.
+
+    Returns:
+        The modified MJCF element.
+
+    Raises:
+        ValueError: If a placeholder joint name is not found in the MJCF.
+    """
+    for placeholder_name, base_name in ball_joint_map.items():
+        joint_elem = mjcf.find(f".//joint[@name='{placeholder_name}']")
+        if joint_elem is None:
+            raise ValueError(
+                f"Placeholder joint '{placeholder_name}' for spherical group "
+                f"'{base_name}' not found in the MJCF model."
+            )
+
+        # Rename and switch type
+        joint_elem.set("name", f"{base_name}_ball")
+        joint_elem.set("type", "ball")
+
+        # Remove attributes that are only meaningful for hinge / slide joints.
+        # ``limited`` / ``range`` from revolute joints are invalid for ball
+        # joints (ball range[0] must be 0 and represents max deflection).
+        for attr in ("axis", "ref", "limited", "range"):
+            if attr in joint_elem.attrib:
+                del joint_elem.attrib[attr]
+
+        # Set damping and armature for numerical stability
+        joint_elem.set("damping", str(damping))
+        joint_elem.set("armature", str(armature))
+        joint_elem.set("frictionloss", str(frictionloss))
     return mjcf

--- a/mujoco_urdf_loader/mjcf_fcn.py
+++ b/mujoco_urdf_loader/mjcf_fcn.py
@@ -371,6 +371,20 @@ def set_collision_groups(
 
     return mjcf
 
+def update_meshdir(mjcf: ET.Element, meshdir: str) -> ET.Element:
+    """Set the meshdir in the mjcf file.
+
+    Args:
+        mjcf (ET.Element): The mjcf file.
+        meshdir (str): The mesh directory to set in the mjcf file.
+    """
+
+    compiler = mjcf.find(".//compiler")
+    if compiler is None:
+        compiler = ET.SubElement(mjcf, "compiler")
+    compiler.set("meshdir", meshdir)
+
+    return mjcf
 
 def separate_left_right_collision_groups(
     mjcf: ET.Element,

--- a/mujoco_urdf_loader/mjcf_fcn.py
+++ b/mujoco_urdf_loader/mjcf_fcn.py
@@ -86,6 +86,7 @@ def add_position_actuator(
 
     return mjcf
 
+
 def add_torque_actuator(
     mjcf: ET.Element,
     joint: str,
@@ -177,12 +178,12 @@ def add_joint_vel_sensor(mjcf: ET.Element, joint: str, name: str = None) -> ET.E
 
 
 def add_joint_eq(
-    mjcf: ET.Element, 
-    joint1: str, 
-    joint2: str, 
-    name: str = None, 
-    multiplier: float = 1.0, 
-    offset: float = 0.0
+    mjcf: ET.Element,
+    joint1: str,
+    joint2: str,
+    name: str = None,
+    multiplier: float = 1.0,
+    offset: float = 0.0,
 ) -> ET.Element:
     """Add a joint equality constraint between two joints.
 
@@ -409,5 +410,69 @@ def add_sphere(
     geom.set("size", f"{size}")
     geom.set("rgba", f"{rgba[0]} {rgba[1]} {rgba[2]} {rgba[3]}")
     geom.set("mass", f"{mass}")
+
+    return mjcf
+
+
+def add_equality_constraints_for_sites(
+    mjcf: ET.Element, site_pairs: List[tuple], constraint_type: str = "connect"
+) -> ET.Element:
+    """
+    Add equality constraints between pairs of sites in MJCF.
+
+    Args:
+        mjcf (ET.Element): The MJCF file as ElementTree.
+        site_pairs (List[tuple]): List of tuples with (site1_name, site2_name) to connect.
+        constraint_type (str): Type of constraint - "connect" or "weld" (default: "connect").
+
+    Returns:
+        ET.Element: The modified MJCF file.
+    """
+    # Find or create the equality element
+    equality = mjcf.find("equality")
+    if equality is None:
+        equality = ET.SubElement(mjcf, "equality")
+
+    for site1, site2 in site_pairs:
+        # Verify both sites exist
+        site1_elem = mjcf.find(f".//site[@name='{site1}']")
+        site2_elem = mjcf.find(f".//site[@name='{site2}']")
+
+        if site1_elem is None:
+            raise ValueError(f"Site {site1} not found in MJCF")
+        if site2_elem is None:
+            raise ValueError(f"Site {site2} not found in MJCF")
+
+        # Create the equality constraint
+        if constraint_type == "connect":
+            # Connect constraint directly references sites (no anchor needed for sites)
+            constraint = ET.SubElement(equality, "connect")
+            constraint.set("site1", site1)
+            constraint.set("site2", site2)
+        elif constraint_type == "weld":
+            # Weld constraint references bodies
+            # Find parent bodies of the sites
+            body1 = None
+            body2 = None
+            for body in mjcf.findall(".//body"):
+                if body.find(f".//site[@name='{site1}']") is not None:
+                    body1 = body.attrib.get("name")
+                if body.find(f".//site[@name='{site2}']") is not None:
+                    body2 = body.attrib.get("name")
+
+            if body1 is None or body2 is None:
+                raise ValueError(
+                    f"Could not find parent bodies for sites {site1} and {site2}"
+                )
+
+            constraint = ET.SubElement(equality, "weld")
+            constraint.set("body1", body1)
+            constraint.set("body2", body2)
+        else:
+            raise ValueError(f"Unknown constraint type: {constraint_type}")
+
+        print(
+            f"Created {constraint_type} equality constraint between {site1} and {site2}"
+        )
 
     return mjcf

--- a/mujoco_urdf_loader/urdf_fcn.py
+++ b/mujoco_urdf_loader/urdf_fcn.py
@@ -1,7 +1,8 @@
 import copy
+import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import List
+from typing import Dict, List, Tuple
 
 import resolve_robotics_uri_py as rru
 
@@ -186,3 +187,135 @@ def get_joint_couplings(robot_urdf: ET.Element) -> dict:
             }
 
     return joint_couplings
+
+
+def detect_spherical_joint_groups(
+    controlled_joints: List[str],
+    rev_joint_prefix: str = "spherical_rev_",
+) -> List[Dict]:
+    """Detect groups of 3 revolute joints that represent spherical joints.
+
+    The iDynTree convention encodes a spherical joint as three consecutive
+    revolute joints named ``{rev_joint_prefix}{base_name}_x``,
+    ``{rev_joint_prefix}{base_name}_y``, ``{rev_joint_prefix}{base_name}_z``.
+
+    Args:
+        controlled_joints: List of joint names (from config).
+        rev_joint_prefix: Naming prefix used for the revolute triplet
+            (default: ``"spherical_rev_"``).
+
+    Returns:
+        List of dicts, each with keys:
+        - ``base_name`` (str): e.g. ``"r_motor_rod_in"``
+        - ``joint_x``, ``joint_y``, ``joint_z`` (str): full joint names
+    """
+    suffix_re = re.compile(
+        rf"^{re.escape(rev_joint_prefix)}(.+)_(x|y|z)$"
+    )
+
+    # Collect base_name -> {axis: joint_name}
+    candidates: Dict[str, Dict[str, str]] = {}
+    for jname in controlled_joints:
+        m = suffix_re.match(jname)
+        if m:
+            base_name, axis = m.group(1), m.group(2)
+            candidates.setdefault(base_name, {})[axis] = jname
+
+    groups = []
+    for base_name, axes in candidates.items():
+        if {"x", "y", "z"} <= set(axes):
+            groups.append(
+                {
+                    "base_name": base_name,
+                    "joint_x": axes["x"],
+                    "joint_y": axes["y"],
+                    "joint_z": axes["z"],
+                }
+            )
+    return groups
+
+
+def collapse_spherical_revolute_triplets(
+    robot_urdf: ET.Element,
+    spherical_groups: List[Dict],
+    fake_link_prefix: str = "spherical_fake_",
+) -> Tuple[ET.Element, Dict[str, str]]:
+    """Collapse 3-revolute spherical joint triplets into single placeholder joints.
+
+    For each detected spherical group, this function:
+    1. Removes the two zero-mass dummy links (``{fake_link_prefix}{base_name}_link1``
+       and ``_link2``).
+    2. Removes the ``_y`` and ``_z`` revolute joints.
+    3. Rewrites the ``_x`` joint so its ``<child>`` points directly to the
+       final child link (the child of the ``_z`` joint) and changes its type
+       to ``"continuous"`` (unlimited hinge).
+
+    The caller should later convert the resulting hinge joint into a MuJoCo
+    ``ball`` joint in the MJCF post-processing step.
+
+    Args:
+        robot_urdf: URDF root element (modified **in-place** and also returned).
+        spherical_groups: Output of :func:`detect_spherical_joint_groups`.
+        fake_link_prefix: Prefix used for dummy link names.
+
+    Returns:
+        Tuple of (modified URDF element, mapping from placeholder joint name
+        to ``base_name``).
+    """
+    urdf = copy.deepcopy(robot_urdf)
+    ball_joint_map: Dict[str, str] = {}
+
+    # Index joints and links for fast lookup
+    joints_by_name = {j.attrib["name"]: j for j in urdf.findall(".//joint")}
+    links_by_name = {l.attrib["name"]: l for l in urdf.findall(".//link")}
+
+    for group in spherical_groups:
+        base_name = group["base_name"]
+        jx_name = group["joint_x"]
+        jy_name = group["joint_y"]
+        jz_name = group["joint_z"]
+
+        jx = joints_by_name.get(jx_name)
+        jy = joints_by_name.get(jy_name)
+        jz = joints_by_name.get(jz_name)
+
+        if jx is None or jy is None or jz is None:
+            raise ValueError(
+                f"Spherical group '{base_name}': could not find all three "
+                f"revolute joints ({jx_name}, {jy_name}, {jz_name}) in the URDF."
+            )
+
+        # The final child is the child of the _z joint (e.g. r_rod_in)
+        final_child = jz.find("child").attrib["link"]
+
+        # Dummy link names
+        dummy_link1 = f"{fake_link_prefix}{base_name}_link1"
+        dummy_link2 = f"{fake_link_prefix}{base_name}_link2"
+
+        # --- Remove dummy links ---
+        for dname in (dummy_link1, dummy_link2):
+            link_elem = links_by_name.get(dname)
+            if link_elem is not None:
+                urdf.remove(link_elem)
+
+        # --- Remove _y and _z joints ---
+        for jname in (jy_name, jz_name):
+            joint_elem = joints_by_name.get(jname)
+            if joint_elem is not None:
+                urdf.remove(joint_elem)
+
+        # --- Rewrite _x joint as placeholder continuous joint ---
+        jx.attrib["type"] = "continuous"
+        jx.find("child").set("link", final_child)
+        # Remove axis element (ball joints are axis-free)
+        axis_elem = jx.find("axis")
+        if axis_elem is not None:
+            jx.remove(axis_elem)
+        # Remove dynamics if present (not needed for placeholder)
+        dynamics_elem = jx.find("dynamics")
+        if dynamics_elem is not None:
+            jx.remove(dynamics_elem)
+
+        ball_joint_map[jx_name] = base_name
+
+    return urdf, ball_joint_map

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,10 +1,12 @@
-version: 5
+version: 6
 environments:
   all:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -268,7 +270,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: ./
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
@@ -521,7 +524,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ace-8.0.1-h00cdb27_0.conda
@@ -719,7 +723,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ace-8.0.1-he0c23c2_0.conda
@@ -898,12 +903,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl
+      - pypi: ./
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1029,7 +1037,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: ./
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
@@ -1153,7 +1162,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
@@ -1228,7 +1238,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hf1e84b2_0.conda
@@ -1295,12 +1306,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl
+      - pypi: ./
   development:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1446,7 +1460,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: ./
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
@@ -1590,7 +1605,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
@@ -1685,7 +1701,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hf1e84b2_0.conda
@@ -1773,12 +1790,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl
+      - pypi: ./
   testing:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2023,7 +2043,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: ./
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
@@ -2257,7 +2278,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ace-8.0.1-h00cdb27_0.conda
@@ -2436,7 +2458,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ace-8.0.1-he0c23c2_0.conda
@@ -2596,27 +2619,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
-      - pypi: .
+      - pypi: https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl
+      - pypi: ./
 packages:
-- kind: conda
-  name: _libgcc_mutex
-  version: '0.1'
-  build: conda_forge
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
   license: None
   purls: []
   size: 2562
   timestamp: 1578324546067
-- kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_kmp_llvm
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
   build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
   sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
   md5: 562b26ba2e19059551a811e72ab7f793
   depends:
@@ -2627,13 +2641,8 @@ packages:
   purls: []
   size: 5744
   timestamp: 1650742457817
-- kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_kmp_llvm
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
   build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
   sha256: 7ef8a15d19133d82014945d3b7fd3bb4202b51c06a5522bf99e13c731f2396c3
   md5: 98a1185182fec3c434069fa74e6473d6
   depends:
@@ -2643,13 +2652,7 @@ packages:
   purls: []
   size: 5802
   timestamp: 1650742448370
-- kind: conda
-  name: absl-py
-  version: 2.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.1.0-pyhd8ed1ab_0.conda
   sha256: 6c84575fe0c3a860c7b6a52cb36dc548c838503c8da0f950a63a64c29b443937
   md5: 035d1d58677c13ec93122d9eb6b8803b
   depends:
@@ -2660,27 +2663,7 @@ packages:
   - pkg:pypi/absl-py?source=hash-mapping
   size: 107266
   timestamp: 1705494755555
-- kind: conda
-  name: ace
-  version: 8.0.1
-  build: h00cdb27_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ace-8.0.1-h00cdb27_0.conda
-  sha256: 48df3d15ec38ca23e09bf0f15f1852c9646c26880ca2ddec8437e196ef1d1870
-  md5: 2eb7794e38928e7a4fe8cfcf0bb52e1b
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: DOC
-  purls: []
-  size: 1824080
-  timestamp: 1722623136969
-- kind: conda
-  name: ace
-  version: 8.0.1
-  build: he02047a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ace-8.0.1-he02047a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ace-8.0.1-he02047a_0.conda
   sha256: 287025e0deee445b3e6fc849852466a153dcdceba81824536647e75d64b22017
   md5: 8cbfcc4b8e11a401ed8400c4d0145fea
   depends:
@@ -2691,12 +2674,27 @@ packages:
   purls: []
   size: 5449099
   timestamp: 1722622759964
-- kind: conda
-  name: ace
-  version: 8.0.1
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ace-8.0.1-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-8.0.1-hf9b3779_0.conda
+  sha256: d60b603ac170c8907623252792ff3cfa5e75b2bff0e7378243d74527da645e7a
+  md5: c9db7894fbe35f235d75aded931010ac
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: DOC
+  purls: []
+  size: 5338955
+  timestamp: 1722626386604
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ace-8.0.1-h00cdb27_0.conda
+  sha256: 48df3d15ec38ca23e09bf0f15f1852c9646c26880ca2ddec8437e196ef1d1870
+  md5: 2eb7794e38928e7a4fe8cfcf0bb52e1b
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: DOC
+  purls: []
+  size: 1824080
+  timestamp: 1722623136969
+- conda: https://conda.anaconda.org/conda-forge/win-64/ace-8.0.1-he0c23c2_0.conda
   sha256: 7bdd85ba11690416f29200421a7b546884896c4bdff0a4f9e2fbe24292e692d6
   md5: 0382a1b8ce5bc60a11a8510dc20c44f8
   depends:
@@ -2707,27 +2705,7 @@ packages:
   purls: []
   size: 2005656
   timestamp: 1722623567537
-- kind: conda
-  name: ace
-  version: 8.0.1
-  build: hf9b3779_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ace-8.0.1-hf9b3779_0.conda
-  sha256: d60b603ac170c8907623252792ff3cfa5e75b2bff0e7378243d74527da645e7a
-  md5: c9db7894fbe35f235d75aded931010ac
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: DOC
-  purls: []
-  size: 5338955
-  timestamp: 1722626386604
-- kind: conda
-  name: alsa-lib
-  version: 1.2.12
-  build: h4ab18f5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.12-h4ab18f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.12-h4ab18f5_0.conda
   sha256: 64b95dd06d7ca6b54cea03b02da8f1657b9899ca376d0ca7b47823064f55fb16
   md5: 7ed427f0871fd41cb1d9c17727c17589
   depends:
@@ -2737,12 +2715,7 @@ packages:
   purls: []
   size: 555868
   timestamp: 1718118368236
-- kind: conda
-  name: alsa-lib
-  version: 1.2.12
-  build: h68df207_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.12-h68df207_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.12-h68df207_0.conda
   sha256: 40328d34c61f6e37873828566c9b4f704a11223a0577511226b5287803e69661
   md5: 65448d015f05afb3c68ea92d0483a466
   depends:
@@ -2752,32 +2725,7 @@ packages:
   purls: []
   size: 585566
   timestamp: 1718118473054
-- kind: conda
-  name: ampl-mp
-  version: 3.1.0
-  build: h05efe27_1006
-  build_number: 1006
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-mp-3.1.0-h05efe27_1006.tar.bz2
-  sha256: f178cb90d1fb76453a712573c4229de353962e21b53be47f5d10f66af9226bad
-  md5: 4bd9e551560df784b4c998f56cc83b4a
-  depends:
-  - libgcc-ng >=9.4.0
-  - libgfortran-ng
-  - libgfortran5 >=9.4.0
-  - libstdcxx-ng >=9.4.0
-  - unixodbc >=2.3.9,<2.4.0a0
-  license: HPND
-  purls: []
-  size: 1275764
-  timestamp: 1645060845399
-- kind: conda
-  name: ampl-mp
-  version: 3.1.0
-  build: h2cc385e_1006
-  build_number: 1006
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ampl-mp-3.1.0-h2cc385e_1006.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ampl-mp-3.1.0-h2cc385e_1006.tar.bz2
   sha256: ff6e942d6490496d98d670f783275078d2a30c694202304ecd49fb759b93c07f
   md5: 6c2f16f5650a7c66ffdfee57b890ea06
   depends:
@@ -2790,13 +2738,20 @@ packages:
   purls: []
   size: 1137486
   timestamp: 1645057516176
-- kind: conda
-  name: ampl-mp
-  version: 3.1.0
-  build: hbec66e7_1006
-  build_number: 1006
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ampl-mp-3.1.0-h05efe27_1006.tar.bz2
+  sha256: f178cb90d1fb76453a712573c4229de353962e21b53be47f5d10f66af9226bad
+  md5: 4bd9e551560df784b4c998f56cc83b4a
+  depends:
+  - libgcc-ng >=9.4.0
+  - libgfortran-ng
+  - libgfortran5 >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  - unixodbc >=2.3.9,<2.4.0a0
+  license: HPND
+  purls: []
+  size: 1275764
+  timestamp: 1645060845399
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
   sha256: 781ef33b48e2b9687dce2019db411994fea44e56c2d0265e197c3acb19bbefa2
   md5: 39bd6ea77989a38b163b971a54bb1aba
   depends:
@@ -2808,28 +2763,7 @@ packages:
   purls: []
   size: 991108
   timestamp: 1645057976681
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: h7bae524_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
-  sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
-  md5: 7adba36492a1bb22d98ffffe4f6fc6de
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 2235747
-  timestamp: 1718551382432
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: hac33072_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
   sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
   md5: 346722a0be40f6edc53f12640d301338
   depends:
@@ -2840,12 +2774,7 @@ packages:
   purls: []
   size: 2706396
   timestamp: 1718551242397
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: hcccb83c_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.9.1-hcccb83c_0.conda
   sha256: ac438ce5d3d3673a9188b535fc7cda413b479f0d52536aeeac1bd82faa656ea0
   md5: cc744ac4efe5bcaa8cca51ff5b850df0
   depends:
@@ -2856,12 +2785,18 @@ packages:
   purls: []
   size: 3250813
   timestamp: 1718551360260
-- kind: conda
-  name: aom
-  version: 3.9.1
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
+  sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
+  md5: 7adba36492a1bb22d98ffffe4f6fc6de
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 2235747
+  timestamp: 1718551382432
+- conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
   sha256: 0524d0c0b61dacd0c22ac7a8067f977b1d52380210933b04141f5099c5b6fec7
   md5: 3d7c14285d3eb3239a76ff79063f27a5
   depends:
@@ -2873,12 +2808,7 @@ packages:
   purls: []
   size: 1958151
   timestamp: 1718551737234
-- kind: conda
-  name: assimp
-  version: 5.4.3
-  build: h8943939_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
   sha256: c9022ee34f756847f48907472514da3395a8c0549679cfd2a1b4f6833dd6298c
   md5: 5546062a59566def2fa6482acf531841
   depends:
@@ -2893,31 +2823,7 @@ packages:
   purls: []
   size: 3535704
   timestamp: 1725086969417
-- kind: conda
-  name: assimp
-  version: 5.4.3
-  build: ha9c0b8d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.4.3-ha9c0b8d_0.conda
-  sha256: d5c348d697abbb824f12bebb8da4de960e0ca2d62350745cfc08da3b984491c4
-  md5: 4f6abafa61c3c6d3ff9a1b012fe2e9fa
-  depends:
-  - __osx >=11.0
-  - libboost >=1.86.0,<1.87.0a0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  - zlib
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 2478543
-  timestamp: 1725087172579
-- kind: conda
-  name: assimp
-  version: 5.4.3
-  build: hdc325bc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/assimp-5.4.3-hdc325bc_0.conda
   sha256: e791fd005b413d1fc7aa7f84d8c83343c64b53ab02e7bd410cb1f2f61789baf9
   md5: 553a8f53d6d599fa15dcbdd95c3c8cee
   depends:
@@ -2931,12 +2837,21 @@ packages:
   purls: []
   size: 3476475
   timestamp: 1725087034438
-- kind: conda
-  name: assimp
-  version: 5.4.3
-  build: hf1e84b2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hf1e84b2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.4.3-ha9c0b8d_0.conda
+  sha256: d5c348d697abbb824f12bebb8da4de960e0ca2d62350745cfc08da3b984491c4
+  md5: 4f6abafa61c3c6d3ff9a1b012fe2e9fa
+  depends:
+  - __osx >=11.0
+  - libboost >=1.86.0,<1.87.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - zlib
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2478543
+  timestamp: 1725087172579
+- conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hf1e84b2_0.conda
   sha256: b3a651af288b4ef41323d1931a3042a050935096575a75e6e0df7f4bb974903a
   md5: af71c63135f00fd8522d5aa729996f98
   depends:
@@ -2951,13 +2866,7 @@ packages:
   purls: []
   size: 11937899
   timestamp: 1725087701414
-- kind: conda
-  name: attr
-  version: 2.5.1
-  build: h166bdaf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
   sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
   md5: d9c69a24ad678ffce24c6543a0176b00
   depends:
@@ -2967,13 +2876,7 @@ packages:
   purls: []
   size: 71042
   timestamp: 1660065501192
-- kind: conda
-  name: attr
-  version: 2.5.1
-  build: h4e544f5_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
   sha256: 2c793b48e835a8fac93f1664c706442972a0206963bf8ca202e83f7f4d29a7d7
   md5: 1ef6c06fec1b6f5ee99ffe2152e53568
   depends:
@@ -2983,12 +2886,7 @@ packages:
   purls: []
   size: 74992
   timestamp: 1660065534958
-- kind: conda
-  name: black
-  version: 24.10.0
-  build: py312h7900ff3_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py312h7900ff3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py312h7900ff3_0.conda
   sha256: 2b4344d18328b3e8fd9b5356f4ee15556779766db8cb21ecf2ff818809773df6
   md5: 2daba153b913b1b901cf61440ad5e019
   depends:
@@ -3005,35 +2903,7 @@ packages:
   - pkg:pypi/black?source=hash-mapping
   size: 390571
   timestamp: 1728503839694
-- kind: conda
-  name: black
-  version: 24.10.0
-  build: py312h81bd7bf_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.10.0-py312h81bd7bf_0.conda
-  sha256: 7e0cd77935e68717506469463546365637abf3f73aa597a890cb5f5ef3c75caf
-  md5: 702d7bf6d22135d3e30811ed9c62bb07
-  depends:
-  - click >=8.0.0
-  - mypy_extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9
-  - platformdirs >=2
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/black?source=hash-mapping
-  size: 392801
-  timestamp: 1728503954904
-- kind: conda
-  name: black
-  version: 24.10.0
-  build: py312h996f985_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/black-24.10.0-py312h996f985_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/black-24.10.0-py312h996f985_0.conda
   sha256: 532784c44c5c4b35f72141183169961f85bc1ba3f3435d6819f7dd1d93043ff2
   md5: 1d107fff2c78b49afedb2a6f8805491b
   depends:
@@ -3051,12 +2921,25 @@ packages:
   - pkg:pypi/black?source=hash-mapping
   size: 392839
   timestamp: 1728503957130
-- kind: conda
-  name: black
-  version: 24.10.0
-  build: py313hfa70ccb_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/black-24.10.0-py313hfa70ccb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.10.0-py312h81bd7bf_0.conda
+  sha256: 7e0cd77935e68717506469463546365637abf3f73aa597a890cb5f5ef3c75caf
+  md5: 702d7bf6d22135d3e30811ed9c62bb07
+  depends:
+  - click >=8.0.0
+  - mypy_extensions >=0.4.3
+  - packaging >=22.0
+  - pathspec >=0.9
+  - platformdirs >=2
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/black?source=hash-mapping
+  size: 392801
+  timestamp: 1728503954904
+- conda: https://conda.anaconda.org/conda-forge/win-64/black-24.10.0-py313hfa70ccb_0.conda
   sha256: 8f99d23fbcf0ce5fe852e2373e154dac8628497fbee15f0f9f4851a2f5ddc30b
   md5: 9e5290e06324d03e6d2e18b410620696
   depends:
@@ -3073,13 +2956,38 @@ packages:
   - pkg:pypi/black?source=hash-mapping
   size: 422911
   timestamp: 1728504578146
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h2466b09_7
-  build_number: 7
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 252783
+  timestamp: 1720974456583
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
+  sha256: 2258b0b33e1cb3a9852d47557984abb6e7ea58e3d7f92706ec1f8e879290c4cb
+  md5: 56398c28220513b9ea13d7b450acfb20
+  depends:
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 189884
+  timestamp: 1720974504976
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 122909
+  timestamp: 1720974522888
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
   sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
   md5: 276e7ffe9ffe39688abc665ef0f45596
   depends:
@@ -3091,92 +2999,7 @@ packages:
   purls: []
   size: 54927
   timestamp: 1720974860185
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h4bc722e_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
-  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
-  md5: 62ee74e96c5ebb0af99386de58cf9553
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  license: bzip2-1.0.6
-  license_family: BSD
-  purls: []
-  size: 252783
-  timestamp: 1720974456583
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h68df207_7
-  build_number: 7
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
-  sha256: 2258b0b33e1cb3a9852d47557984abb6e7ea58e3d7f92706ec1f8e879290c4cb
-  md5: 56398c28220513b9ea13d7b450acfb20
-  depends:
-  - libgcc-ng >=12
-  license: bzip2-1.0.6
-  license_family: BSD
-  purls: []
-  size: 189884
-  timestamp: 1720974504976
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h99b78c6_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
-  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
-  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
-  depends:
-  - __osx >=11.0
-  license: bzip2-1.0.6
-  license_family: BSD
-  purls: []
-  size: 122909
-  timestamp: 1720974522888
-- kind: conda
-  name: c-ares
-  version: 1.34.2
-  build: h7ab814d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.2-h7ab814d_0.conda
-  sha256: 24d53d27397f9c2f0c168992690b5ec1bd62593fb4fc1f1e906ab91b10fd06c3
-  md5: 8a8cfc11064b521bc54bd2d8591cb137
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 177487
-  timestamp: 1729006763496
-- kind: conda
-  name: c-ares
-  version: 1.34.2
-  build: ha64f414_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.2-ha64f414_0.conda
-  sha256: 06f67e6b2c18f1ff79391ffb032c752fcbbf754f6f6e7a786edde6cca1c92791
-  md5: 588af5337614cece17e61b6ac907f812
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 214916
-  timestamp: 1729006632022
-- kind: conda
-  name: c-ares
-  version: 1.34.2
-  build: heb4867d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
   sha256: c2a515e623ac3e17a56027c06098fbd5ab47afefefbd386b4c21289f2ec55139
   md5: 2b780c0338fc0ffa678ac82c54af51fd
   depends:
@@ -3187,143 +3010,56 @@ packages:
   purls: []
   size: 205797
   timestamp: 1729006575652
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: h56e8100_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
-  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
-  md5: 4c4fd67c18619be5aa65dc5b6c72e490
-  license: ISC
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.2-ha64f414_0.conda
+  sha256: 06f67e6b2c18f1ff79391ffb032c752fcbbf754f6f6e7a786edde6cca1c92791
+  md5: 588af5337614cece17e61b6ac907f812
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
   purls: []
-  size: 158773
-  timestamp: 1725019107649
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: hbcca054_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+  size: 214916
+  timestamp: 1729006632022
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.2-h7ab814d_0.conda
+  sha256: 24d53d27397f9c2f0c168992690b5ec1bd62593fb4fc1f1e906ab91b10fd06c3
+  md5: 8a8cfc11064b521bc54bd2d8591cb137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 177487
+  timestamp: 1729006763496
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
   sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
   md5: c27d1c142233b5bc9ca570c6e2e0c244
   license: ISC
   purls: []
   size: 159003
   timestamp: 1725018903918
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: hcefe29a_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.8.30-hcefe29a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.8.30-hcefe29a_0.conda
   sha256: 2a2d827bee3775a85f0f1b2f2089291475c4416336d1b3a8cbce2964db547af8
   md5: 70e57e8f59d2c98f86b49c69e5074be5
   license: ISC
   purls: []
   size: 159106
   timestamp: 1725020043153
-- kind: conda
-  name: ca-certificates
-  version: 2024.8.30
-  build: hf0a4a13_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
   sha256: 2db1733f4b644575dbbdd7994a8f338e6ef937f5ebdb74acd557e9dda0211709
   md5: 40dec13fd8348dbe303e57be74bd3d35
   license: ISC
   purls: []
   size: 158482
   timestamp: 1725019034582
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: h32b962e_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
-  sha256: 127101c9c2d1a56f8791c19141ceff13fd1d1a1da28cfaca549dc99d210cec6a
-  md5: 8f43723a4925c51e55c2d81725a97db4
-  depends:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=75.1,<76.0a0
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.43.4,<1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zlib
-  license: LGPL-2.1-only or MPL-1.1
+- conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
+  md5: 4c4fd67c18619be5aa65dc5b6c72e490
+  license: ISC
   purls: []
-  size: 1516680
-  timestamp: 1721139332360
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: hb4a6bf7_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hb4a6bf7_3.conda
-  sha256: f7603b7f6ee7c6e07c23d77302420194f4ec1b8e8facfff2b6aab17c7988a102
-  md5: 08bd0752f3de8a2d8a35fd012f09531f
-  depends:
-  - __osx >=11.0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=75.1,<76.0a0
-  - libcxx >=16
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.43.4,<1.0a0
-  - zlib
-  license: LGPL-2.1-only or MPL-1.1
-  purls: []
-  size: 899126
-  timestamp: 1721139203735
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: hdb1a16f_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-hdb1a16f_3.conda
-  sha256: 8a747ad6ce32228a85c80bef8ec7387d71f8d2b0bf637edb56ff33e09794c616
-  md5: 080659f02bf2202c57f1cda4f9e51f21
-  depends:
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=75.1,<76.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.43.4,<1.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  - zlib
-  license: LGPL-2.1-only or MPL-1.1
-  purls: []
-  size: 966709
-  timestamp: 1721138947987
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: hebfffa5_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
+  size: 158773
+  timestamp: 1725019107649
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
   sha256: aee5b9e6ef71cdfb2aee9beae3ea91910ca761c01c0ef32052e3f94a252fa173
   md5: fceaedf1cdbcb02df9699a0d9b005292
   depends:
@@ -3349,12 +3085,71 @@ packages:
   purls: []
   size: 983604
   timestamp: 1721138900054
-- kind: conda
-  name: cffi
-  version: 1.17.1
-  build: py312h06ac9bb_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-hdb1a16f_3.conda
+  sha256: 8a747ad6ce32228a85c80bef8ec7387d71f8d2b0bf637edb56ff33e09794c616
+  md5: 080659f02bf2202c57f1cda4f9e51f21
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  purls: []
+  size: 966709
+  timestamp: 1721138947987
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hb4a6bf7_3.conda
+  sha256: f7603b7f6ee7c6e07c23d77302420194f4ec1b8e8facfff2b6aab17c7988a102
+  md5: 08bd0752f3de8a2d8a35fd012f09531f
+  depends:
+  - __osx >=11.0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  purls: []
+  size: 899126
+  timestamp: 1721139203735
+- conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
+  sha256: 127101c9c2d1a56f8791c19141ceff13fd1d1a1da28cfaca549dc99d210cec6a
+  md5: 8f43723a4925c51e55c2d81725a97db4
+  depends:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  purls: []
+  size: 1516680
+  timestamp: 1721139332360
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
   sha256: cba6ea83c4b0b4f5b5dc59cb19830519b28f95d7ebef7c9c5cf1c14843621457
   md5: a861504bbea4161a9170b85d4d2be840
   depends:
@@ -3370,12 +3165,22 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 294403
   timestamp: 1725560714366
-- kind: conda
-  name: cffi
-  version: 1.17.1
-  build: py312h0fad829_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py312h0fad829_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-1.17.1-py312hac81daf_0.conda
+  sha256: 1162e3ca039e7ca7c0e78f0a020ed1bde968096841b663e3f393c966eb82f0f0
+  md5: 1a256e5581b1099e9295cb84d53db3ea
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
+  size: 312892
+  timestamp: 1725561779888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py312h0fad829_0.conda
   sha256: 8d91a0d01358b5c3f20297c6c536c5d24ccd3e0c2ddd37f9d0593d0f0070226f
   md5: 19a5456f72f505881ba493979777b24e
   depends:
@@ -3391,32 +3196,7 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 281206
   timestamp: 1725560813378
-- kind: conda
-  name: cffi
-  version: 1.17.1
-  build: py312hac81daf_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-1.17.1-py312hac81daf_0.conda
-  sha256: 1162e3ca039e7ca7c0e78f0a020ed1bde968096841b663e3f393c966eb82f0f0
-  md5: 1a256e5581b1099e9295cb84d53db3ea
-  depends:
-  - libffi >=3.4,<4.0a0
-  - libgcc >=13
-  - pycparser
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 312892
-  timestamp: 1725561779888
-- kind: conda
-  name: cffi
-  version: 1.17.1
-  build: py313ha7868ed_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py313ha7868ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py313ha7868ed_0.conda
   sha256: b19f581fe423858f1f477c52e10978be324c55ebf2e418308d30d013f4a476ff
   md5: 519a29d7ac273f8c165efc0af099da42
   depends:
@@ -3432,13 +3212,7 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 291828
   timestamp: 1725561211547
-- kind: conda
-  name: cfgv
-  version: 3.3.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
   sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
   md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
   depends:
@@ -3449,13 +3223,7 @@ packages:
   - pkg:pypi/cfgv?source=hash-mapping
   size: 10788
   timestamp: 1629909423398
-- kind: conda
-  name: click
-  version: 8.1.7
-  build: unix_pyh707e725_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
   sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
   md5: f3ad426304898027fc619827ff428eca
   depends:
@@ -3467,13 +3235,7 @@ packages:
   - pkg:pypi/click?source=hash-mapping
   size: 84437
   timestamp: 1692311973840
-- kind: conda
-  name: click
-  version: 8.1.7
-  build: win_pyh7428d3b_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
   sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
   md5: 3549ecbceb6cd77b91a105511b7d0786
   depends:
@@ -3486,13 +3248,7 @@ packages:
   - pkg:pypi/click?source=hash-mapping
   size: 85051
   timestamp: 1692312207348
-- kind: conda
-  name: colorama
-  version: 0.4.6
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
   sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
   md5: 3faab06a954c2a04039983f2c4a50d99
   depends:
@@ -3503,12 +3259,17 @@ packages:
   - pkg:pypi/colorama?source=hash-mapping
   size: 25170
   timestamp: 1666700778190
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
+  md5: 418c6ca5929a611cbd69204907a83995
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 760229
+  timestamp: 1685695754230
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
   sha256: 33fe66d025cf5bac7745196d1a3dd7a437abcf2dbce66043e9745218169f7e17
   md5: 6e5a87182d66b2d1328a96b61ca43a62
   depends:
@@ -3518,12 +3279,7 @@ packages:
   purls: []
   size: 347363
   timestamp: 1685696690003
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: hb547adb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
   sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
   md5: 5a74cdee497e6b65173e10d94582fae6
   license: BSD-2-Clause
@@ -3531,12 +3287,7 @@ packages:
   purls: []
   size: 316394
   timestamp: 1685695959391
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
   sha256: 2aa2083c9c186da7d6f975ccfbef654ed54fff27f4bc321dbcd12cee932ec2c4
   md5: ed2c27bda330e3f0ab41577cf8b9b585
   depends:
@@ -3548,46 +3299,7 @@ packages:
   purls: []
   size: 618643
   timestamp: 1685696352968
-- kind: conda
-  name: dav1d
-  version: 1.2.1
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
-  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
-  md5: 418c6ca5929a611cbd69204907a83995
-  depends:
-  - libgcc-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 760229
-  timestamp: 1685695754230
-- kind: conda
-  name: dbus
-  version: 1.13.6
-  build: h12b9eeb_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
-  sha256: 5fe76bdf27a142cfb9da0fb3197c562e528d2622b573765bee5c9904cf5e6b6b
-  md5: f3d63805602166bac09386741e00935e
-  depends:
-  - expat >=2.4.2,<3.0a0
-  - libgcc-ng >=9.4.0
-  - libglib >=2.70.2,<3.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 672759
-  timestamp: 1640113663539
-- kind: conda
-  name: dbus
-  version: 1.13.6
-  build: h5008d03_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
   sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
   md5: ecfff944ba3960ecb334b9a2663d708d
   depends:
@@ -3599,13 +3311,19 @@ packages:
   purls: []
   size: 618596
   timestamp: 1640112124844
-- kind: conda
-  name: distlib
-  version: 0.3.9
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
+  sha256: 5fe76bdf27a142cfb9da0fb3197c562e528d2622b573765bee5c9904cf5e6b6b
+  md5: f3d63805602166bac09386741e00935e
+  depends:
+  - expat >=2.4.2,<3.0a0
+  - libgcc-ng >=9.4.0
+  - libglib >=2.70.2,<3.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 672759
+  timestamp: 1640113663539
+- conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_0.conda
   sha256: 300b2e714f59403df0560174f5ef6c19db8b4a3b74a7244862cf771f07dee8fb
   md5: fe521c1608280cc2803ebd26dc252212
   depends:
@@ -3616,12 +3334,7 @@ packages:
   - pkg:pypi/distlib?source=hash-mapping
   size: 276214
   timestamp: 1728557312342
-- kind: conda
-  name: double-conversion
-  version: 3.3.0
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
   sha256: 9eee491a73b67fd64379cf715f85f8681568ebc1f02f9e11b4c50d46a3323544
   md5: c2f83a5ddadadcdb08fe05863295ee97
   depends:
@@ -3632,12 +3345,7 @@ packages:
   purls: []
   size: 78645
   timestamp: 1686489937183
-- kind: conda
-  name: double-conversion
-  version: 3.3.0
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
   sha256: 735d40b44a0f39386d1e2988384b6d78a98efd4fa1818e7f2f6fb01f91e16b64
   md5: 1a8bc18b24014167b2184c5afbe6037e
   depends:
@@ -3649,12 +3357,7 @@ packages:
   purls: []
   size: 70425
   timestamp: 1686490368655
-- kind: conda
-  name: eigen
-  version: 3.4.0
-  build: h00ab1b0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
   sha256: 53b15a98aadbe0704479bacaf7a5618fcb32d1577be320630674574241639b34
   md5: b1b879d6d093f55dd40d58b5eb2f0699
   depends:
@@ -3665,27 +3368,7 @@ packages:
   purls: []
   size: 1088433
   timestamp: 1690272126173
-- kind: conda
-  name: eigen
-  version: 3.4.0
-  build: h1995070_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
-  sha256: c20b3677b16d8907343fce68e7c437184fef7f5ed0a765c104b775f8a485c5c9
-  md5: 3691ea3ff568ba38826389bafc717909
-  depends:
-  - libcxx >=15.0.7
-  license: MPL-2.0
-  license_family: MOZILLA
-  purls: []
-  size: 1087751
-  timestamp: 1690275869049
-- kind: conda
-  name: eigen
-  version: 3.4.0
-  build: h2a328a1_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
   sha256: f9c763805938ebaa43183b07caadce8eb3e1af8c21df8792f2793c3dd5210b4e
   md5: 0057b28f7ed26d80bd2277a128f324b2
   depends:
@@ -3696,12 +3379,17 @@ packages:
   purls: []
   size: 1090421
   timestamp: 1690273745233
-- kind: conda
-  name: eigen
-  version: 3.4.0
-  build: h91493d7_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
+  sha256: c20b3677b16d8907343fce68e7c437184fef7f5ed0a765c104b775f8a485c5c9
+  md5: 3691ea3ff568ba38826389bafc717909
+  depends:
+  - libcxx >=15.0.7
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls: []
+  size: 1087751
+  timestamp: 1690275869049
+- conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
   sha256: 633a6a8db1f9a010cb0619f3446fb61f62dea348b09615ffae9744ab1001c24c
   md5: 305b3ca7023ac046b9a42a48661f6512
   depends:
@@ -3713,45 +3401,7 @@ packages:
   purls: []
   size: 1089706
   timestamp: 1690273089254
-- kind: conda
-  name: ergocub-software
-  version: 0.7.5
-  build: h57928b3_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ergocub-software-0.7.5-h57928b3_1.conda
-  sha256: cc1bc91a6a51df12a36a2fb1575db2b823420c14efc90af32a1b2a1db84efcef
-  md5: be2651636208feba2b3c1fedba62567f
-  depends:
-  - libergocub-software 0.7.5 h21e95ee_1
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 8322
-  timestamp: 1726698577318
-- kind: conda
-  name: ergocub-software
-  version: 0.7.5
-  build: h8af1aa0_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ergocub-software-0.7.5-h8af1aa0_1.conda
-  sha256: 900f06f860fdd231d9d538c412284f6126598d97f24e6ae48a6f2bec2992638a
-  md5: d37b2b37b2801a8d56f115b877ce2b6c
-  depends:
-  - libergocub-software 0.7.5 h37d1830_1
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 7926
-  timestamp: 1726697489453
-- kind: conda
-  name: ergocub-software
-  version: 0.7.5
-  build: ha770c72_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ergocub-software-0.7.5-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ergocub-software-0.7.5-ha770c72_1.conda
   sha256: 167a2559bcce7d3c7bbeca03080f8f421e3e6fb53f27b31b025202f68a522e24
   md5: 73fe98f3c69b64e119ba32e67dc517d6
   depends:
@@ -3761,13 +3411,17 @@ packages:
   purls: []
   size: 7901
   timestamp: 1726697336704
-- kind: conda
-  name: ergocub-software
-  version: 0.7.5
-  build: hce30654_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ergocub-software-0.7.5-hce30654_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ergocub-software-0.7.5-h8af1aa0_1.conda
+  sha256: 900f06f860fdd231d9d538c412284f6126598d97f24e6ae48a6f2bec2992638a
+  md5: d37b2b37b2801a8d56f115b877ce2b6c
+  depends:
+  - libergocub-software 0.7.5 h37d1830_1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 7926
+  timestamp: 1726697489453
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ergocub-software-0.7.5-hce30654_1.conda
   sha256: 459f006438e90031d05a0337c7f14e9d1a24f3cf4a175ef1344995834dd4b500
   md5: 0e228bedacf187c291dc8d67adec46b9
   depends:
@@ -3777,13 +3431,17 @@ packages:
   purls: []
   size: 8005
   timestamp: 1726697638102
-- kind: conda
-  name: etils
-  version: 1.10.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/etils-1.10.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/ergocub-software-0.7.5-h57928b3_1.conda
+  sha256: cc1bc91a6a51df12a36a2fb1575db2b823420c14efc90af32a1b2a1db84efcef
+  md5: be2651636208feba2b3c1fedba62567f
+  depends:
+  - libergocub-software 0.7.5 h21e95ee_1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 8322
+  timestamp: 1726698577318
+- conda: https://conda.anaconda.org/conda-forge/noarch/etils-1.10.0-pyhd8ed1ab_0.conda
   sha256: b0bed572d37b302f18745f421c9b23f901a6714730bd2018bf921965653fc072
   md5: 2fd249bf6bb8ff00b520bedfa4531eb6
   depends:
@@ -3794,13 +3452,7 @@ packages:
   - pkg:pypi/etils?source=hash-mapping
   size: 785364
   timestamp: 1729178937043
-- kind: conda
-  name: exceptiongroup
-  version: 1.2.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
   sha256: e0edd30c4b7144406bb4da975e6bb97d6bc9c0e999aa4efe66ae108cada5d5b5
   md5: d02ae936e42063ca46af6cdad2dbd1e0
   depends:
@@ -3810,12 +3462,7 @@ packages:
   - pkg:pypi/exceptiongroup?source=hash-mapping
   size: 20418
   timestamp: 1720869435725
-- kind: conda
-  name: expat
-  version: 2.6.4
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.4-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.4-h5888daf_0.conda
   sha256: 1848c7db9e264e3b8036ee133d570dd880422983cd20dd9585a505289606d276
   md5: 1d6afef758879ef5ee78127eb4cd2c4a
   depends:
@@ -3827,12 +3474,7 @@ packages:
   purls: []
   size: 138145
   timestamp: 1730967050578
-- kind: conda
-  name: expat
-  version: 2.6.4
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.4-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.4-h5ad3122_0.conda
   sha256: 13905ad49c2f43776bac0e464ffd3c9ec10ef35cc7dd7e187af6f66f843fa29a
   md5: e8f1d587055376ea2419cc78696abd0b
   depends:
@@ -3843,107 +3485,7 @@ packages:
   purls: []
   size: 130354
   timestamp: 1730967212801
-- kind: conda
-  name: ffmpeg
-  version: 7.1.0
-  build: gpl_h89ca9b9_703
-  build_number: 703
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-7.1.0-gpl_h89ca9b9_703.conda
-  sha256: a34efc4ef64ab895a9cc61e68a83ce8b31fb5be63ae265a9a3d45fb2632e06f4
-  md5: 1e9cd6a8b46e035522bc0c21f0c47e49
-  depends:
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libopus >=1.3.1,<2.0a0
-  - librsvg >=2.58.4,<3.0a0
-  - libxml2 >=2.13.4,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - svt-av1 >=2.3.0,<2.3.1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - __cuda  >=12.4
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 9985429
-  timestamp: 1730673229363
-- kind: conda
-  name: ffmpeg
-  version: 7.1.0
-  build: gpl_hb5dfa50_703
-  build_number: 703
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-7.1.0-gpl_hb5dfa50_703.conda
-  sha256: 23f0818106ae1383a902d944065f6538a0bf43ebac81853f5e7e6e44df8c3ac6
-  md5: 5cf67e86859e5d31dd6c8969317e558d
-  depends:
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.3,<0.17.4.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libiconv >=1.17,<2.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopus >=1.3.1,<2.0a0
-  - librsvg >=2.58.4,<3.0a0
-  - libstdcxx >=13
-  - libvpx >=1.14.1,<1.15.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxml2 >=2.13.4,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.4.1,<2.4.2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - svt-av1 >=2.3.0,<2.3.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - __cuda  >=12.4
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 9911501
-  timestamp: 1730672295104
-- kind: conda
-  name: ffmpeg
-  version: 7.1.0
-  build: gpl_hbb807a5_703
-  build_number: 703
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_hbb807a5_703.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-7.1.0-gpl_hbb807a5_703.conda
   sha256: b3c25c9eeee63f39ebff7dc1840734aab3e784a084a8352d5099aa9a9c07e42f
   md5: ebcb1e523d36a81af8f0910856c06946
   depends:
@@ -3996,13 +3538,56 @@ packages:
   purls: []
   size: 10317421
   timestamp: 1730672187649
-- kind: conda
-  name: ffmpeg
-  version: 7.1.0
-  build: gpl_hd730352_103
-  build_number: 103
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-7.1.0-gpl_hd730352_103.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-7.1.0-gpl_hb5dfa50_703.conda
+  sha256: 23f0818106ae1383a902d944065f6538a0bf43ebac81853f5e7e6e44df8c3ac6
+  md5: 5cf67e86859e5d31dd6c8969317e558d
+  depends:
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.3,<0.17.4.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopus >=1.3.1,<2.0a0
+  - librsvg >=2.58.4,<3.0a0
+  - libstdcxx >=13
+  - libvpx >=1.14.1,<1.15.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2 >=2.13.4,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - __cuda  >=12.4
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 9911501
+  timestamp: 1730672295104
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-7.1.0-gpl_hd730352_103.conda
   sha256: 5cbb36a536cb7e7089502d654fd827974472f919c3abf3269804aa7172a60b2d
   md5: 17b1018f916e10b3a72c3d01857c4e8a
   depends:
@@ -4047,13 +3632,40 @@ packages:
   purls: []
   size: 9130661
   timestamp: 1730672368509
-- kind: conda
-  name: filelock
-  version: 3.16.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-7.1.0-gpl_h89ca9b9_703.conda
+  sha256: a34efc4ef64ab895a9cc61e68a83ce8b31fb5be63ae265a9a3d45fb2632e06f4
+  md5: 1e9cd6a8b46e035522bc0c21f0c47e49
+  depends:
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libopus >=1.3.1,<2.0a0
+  - librsvg >=2.58.4,<3.0a0
+  - libxml2 >=2.13.4,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - svt-av1 >=2.3.0,<2.3.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - __cuda  >=12.4
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 9985429
+  timestamp: 1730673229363
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_0.conda
   sha256: 1da766da9dba05091af87977922fe60dc7464091a9ccffb3765d403189d39be4
   md5: 916f8ec5dd4128cd5f207a3c4c07b2c6
   depends:
@@ -4063,13 +3675,7 @@ packages:
   - pkg:pypi/filelock?source=hash-mapping
   size: 17357
   timestamp: 1726613593584
-- kind: conda
-  name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  build: hab24e00_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
   license: BSD-3-Clause
@@ -4077,13 +3683,7 @@ packages:
   purls: []
   size: 397370
   timestamp: 1566932522327
-- kind: conda
-  name: font-ttf-inconsolata
-  version: '3.000'
-  build: h77eed37_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
   sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
   md5: 34893075a5c9e55cdafac56607368fc6
   license: OFL-1.1
@@ -4091,13 +3691,7 @@ packages:
   purls: []
   size: 96530
   timestamp: 1620479909603
-- kind: conda
-  name: font-ttf-source-code-pro
-  version: '2.038'
-  build: h77eed37_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
   sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
   md5: 4d59c254e01d9cde7957100457e2d5fb
   license: OFL-1.1
@@ -4105,14 +3699,7 @@ packages:
   purls: []
   size: 700814
   timestamp: 1620479612257
-- kind: conda
-  name: font-ttf-ubuntu
-  version: '0.83'
-  build: h77eed37_3
-  build_number: 3
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
   sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
   md5: 49023d73832ef61042f6a237cb2687e7
   license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
@@ -4120,13 +3707,36 @@ packages:
   purls: []
   size: 1620504
   timestamp: 1727511233259
-- kind: conda
-  name: fontconfig
-  version: 2.15.0
-  build: h1383a14_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.15.0-h1383a14_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+  sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
+  md5: 8f5b0b297b59e1ac160ad4beec99dbee
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 265599
+  timestamp: 1730283881107
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.15.0-h8dda3cd_1.conda
+  sha256: fe023bb8917c8a3138af86ef537b70c8c5d60c44f93946a87d1e8bb1a6634b55
+  md5: 112b71b6af28b47c624bcbeefeea685b
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 277832
+  timestamp: 1730284967179
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.15.0-h1383a14_1.conda
   sha256: f79d3d816fafbd6a2b0f75ebc3251a30d3294b08af9bb747194121f5efa364bc
   md5: 7b29f48742cea5d1ccb5edd839cb5621
   depends:
@@ -4139,13 +3749,7 @@ packages:
   purls: []
   size: 234227
   timestamp: 1730284037572
-- kind: conda
-  name: fontconfig
-  version: 2.15.0
-  build: h765892d_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
   sha256: ed122fc858fb95768ca9ca77e73c8d9ddc21d4b2e13aaab5281e27593e840691
   md5: 9bb0026a2131b09404c59c4290c697cd
   depends:
@@ -4161,54 +3765,7 @@ packages:
   purls: []
   size: 192355
   timestamp: 1730284147944
-- kind: conda
-  name: fontconfig
-  version: 2.15.0
-  build: h7e30c49_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
-  sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
-  md5: 8f5b0b297b59e1ac160ad4beec99dbee
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - freetype >=2.12.1,<3.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libuuid >=2.38.1,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 265599
-  timestamp: 1730283881107
-- kind: conda
-  name: fontconfig
-  version: 2.15.0
-  build: h8dda3cd_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.15.0-h8dda3cd_1.conda
-  sha256: fe023bb8917c8a3138af86ef537b70c8c5d60c44f93946a87d1e8bb1a6634b55
-  md5: 112b71b6af28b47c624bcbeefeea685b
-  depends:
-  - freetype >=2.12.1,<3.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libuuid >=2.38.1,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 277832
-  timestamp: 1730284967179
-- kind: conda
-  name: fonts-conda-ecosystem
-  version: '1'
-  build: '0'
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
   md5: fee5683a3f04bd15cbd8318b096a27ab
   depends:
@@ -4218,13 +3775,7 @@ packages:
   purls: []
   size: 3667
   timestamp: 1566974674465
-- kind: conda
-  name: fonts-conda-forge
-  version: '1'
-  build: '0'
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
   md5: f766549260d6815b0c52253f1fb1bb29
   depends:
@@ -4237,36 +3788,7 @@ packages:
   purls: []
   size: 4102
   timestamp: 1566932280397
-- kind: conda
-  name: freeglut
-  version: 3.2.2
-  build: h5eeb66e_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
-  sha256: 22a2104d5d6573e8445b7f264533bcd7595cff36d2b356cb1925af5ea62b6a47
-  md5: c6c65566e07fec709e1ea4bc95fc56e4
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxfixes
-  - xorg-libxi
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 144992
-  timestamp: 1719014317113
-- kind: conda
-  name: freeglut
-  version: 3.2.2
-  build: ha6d2627_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
   sha256: 676540a8e7f73a894cb1fcb870e7bec623ec1c0a2d277094fd713261a02d8d56
   md5: 84ec3f5b46f3076be49f2cf3f1cfbf02
   depends:
@@ -4283,13 +3805,24 @@ packages:
   purls: []
   size: 144010
   timestamp: 1719014356708
-- kind: conda
-  name: freeglut
-  version: 3.2.2
-  build: he0c23c2_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-he0c23c2_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-h5eeb66e_3.conda
+  sha256: 22a2104d5d6573e8445b7f264533bcd7595cff36d2b356cb1925af5ea62b6a47
+  md5: c6c65566e07fec709e1ea4bc95fc56e4
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes
+  - xorg-libxi
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 144992
+  timestamp: 1719014317113
+- conda: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-he0c23c2_3.conda
   sha256: 8b41913ed6c8c0dadda463a649bc16f45e88faa58553efc6830f4de1138c97f2
   md5: 5872031ef7cba8435ff24af056777473
   depends:
@@ -4301,13 +3834,7 @@ packages:
   purls: []
   size: 111956
   timestamp: 1719014753462
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: h267a509_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
   sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
   md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
   depends:
@@ -4318,13 +3845,18 @@ packages:
   purls: []
   size: 634972
   timestamp: 1694615932610
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: hadb7bae_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
+  sha256: 7af93030f4407f076dce181062360efac2cd54dce863b5d7765287a6f5382537
+  md5: a5ab74c5bd158c3d5532b66d8d83d907
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 642092
+  timestamp: 1694617858496
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
   sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
   md5: e6085e516a3e304ce41a8ee08b9b89ad
   depends:
@@ -4334,13 +3866,7 @@ packages:
   purls: []
   size: 596430
   timestamp: 1694616332835
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: hdaf720e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
   sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
   md5: 3761b23693f768dc75a8fd0a73ca053f
   depends:
@@ -4353,41 +3879,7 @@ packages:
   purls: []
   size: 510306
   timestamp: 1694616398888
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: hf0a5ef3_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
-  sha256: 7af93030f4407f076dce181062360efac2cd54dce863b5d7765287a6f5382537
-  md5: a5ab74c5bd158c3d5532b66d8d83d907
-  depends:
-  - libgcc-ng >=12
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  license: GPL-2.0-only OR FTL
-  purls: []
-  size: 642092
-  timestamp: 1694617858496
-- kind: conda
-  name: fribidi
-  version: 1.0.10
-  build: h27ca646_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
-  sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
-  md5: c64443234ff91d70cb9c7dc926c58834
-  license: LGPL-2.1
-  purls: []
-  size: 60255
-  timestamp: 1604417405528
-- kind: conda
-  name: fribidi
-  version: 1.0.10
-  build: h36c2ea0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
   sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
   md5: ac7bc6a654f8f41b352b38f4051135f8
   depends:
@@ -4396,12 +3888,23 @@ packages:
   purls: []
   size: 114383
   timestamp: 1604416621168
-- kind: conda
-  name: fribidi
-  version: 1.0.10
-  build: h8d14728_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.10-h8d14728_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
+  sha256: bcb5a40f1aaf4ea8cda2fc6b2b12aa336403772121350281ce31fd2d9d3e214e
+  md5: f6c91a43eace6fb926a8730b3b9a8a50
+  depends:
+  - libgcc-ng >=7.5.0
+  license: LGPL-2.1
+  purls: []
+  size: 115689
+  timestamp: 1604417149643
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
+  sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
+  md5: c64443234ff91d70cb9c7dc926c58834
+  license: LGPL-2.1
+  purls: []
+  size: 60255
+  timestamp: 1604417405528
+- conda: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.10-h8d14728_0.tar.bz2
   sha256: e0323e6d7b6047042970812ee810c6b1e1a11a3af4025db26d0965ae5d206104
   md5: 807e81d915f2bb2e49951648615241f6
   depends:
@@ -4411,27 +3914,7 @@ packages:
   purls: []
   size: 64567
   timestamp: 1604417122064
-- kind: conda
-  name: fribidi
-  version: 1.0.10
-  build: hb9de7d4_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
-  sha256: bcb5a40f1aaf4ea8cda2fc6b2b12aa336403772121350281ce31fd2d9d3e214e
-  md5: f6c91a43eace6fb926a8730b3b9a8a50
-  depends:
-  - libgcc-ng >=7.5.0
-  license: LGPL-2.1
-  purls: []
-  size: 115689
-  timestamp: 1604417149643
-- kind: conda
-  name: fsspec
-  version: 2024.10.0
-  build: pyhff2d567_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.10.0-pyhff2d567_0.conda
   sha256: 40bb76981dd49d5869b48925a8975bb7bbe4e33e1e40af4ec06f6bf4a62effd7
   md5: 816dbc4679a64e4417cd1385d661bb31
   depends:
@@ -4442,12 +3925,35 @@ packages:
   - pkg:pypi/fsspec?source=hash-mapping
   size: 134745
   timestamp: 1729608972363
-- kind: conda
-  name: gdk-pixbuf
-  version: 2.42.12
-  build: h7ddc832_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7ddc832_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
+  sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
+  md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 528149
+  timestamp: 1715782983957
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.42.12-ha61d561_0.conda
+  sha256: 608f64aa9cf3085e91da8d417aa7680715130b4da73d8aabc50b19e29de697d2
+  md5: 332ed304e6d1c1333ccbdc0fdd722fe9
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 536613
+  timestamp: 1715784386033
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7ddc832_0.conda
   sha256: 72bcf0a4d3f9aa6d99d7d1d224d19f76ccdb3a4fa85e60f77d17e17985c81bd2
   md5: 151309a7e1eb57a3c2ab8088a1d74f3e
   depends:
@@ -4462,50 +3968,7 @@ packages:
   purls: []
   size: 509570
   timestamp: 1715783199780
-- kind: conda
-  name: gdk-pixbuf
-  version: 2.42.12
-  build: ha61d561_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gdk-pixbuf-2.42.12-ha61d561_0.conda
-  sha256: 608f64aa9cf3085e91da8d417aa7680715130b4da73d8aabc50b19e29de697d2
-  md5: 332ed304e6d1c1333ccbdc0fdd722fe9
-  depends:
-  - libgcc-ng >=12
-  - libglib >=2.80.2,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libtiff >=4.6.0,<4.8.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  purls: []
-  size: 536613
-  timestamp: 1715784386033
-- kind: conda
-  name: gdk-pixbuf
-  version: 2.42.12
-  build: hb9ae30d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
-  sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
-  md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
-  depends:
-  - libgcc-ng >=12
-  - libglib >=2.80.2,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libtiff >=4.6.0,<4.8.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  purls: []
-  size: 528149
-  timestamp: 1715782983957
-- kind: conda
-  name: gdk-pixbuf
-  version: 2.42.12
-  build: hed59a49_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gdk-pixbuf-2.42.12-hed59a49_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdk-pixbuf-2.42.12-hed59a49_0.conda
   sha256: 7a7768a5e65092242071f99b4cafe3e59546f9260ae472d3aa10a9a9aa869c3c
   md5: 350196a65e715882abefffd1a702172d
   depends:
@@ -4522,34 +3985,7 @@ packages:
   purls: []
   size: 523967
   timestamp: 1715783547727
-- kind: conda
-  name: gettext
-  version: 0.22.5
-  build: h0a1ffab_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h0a1ffab_3.conda
-  sha256: 25b0b40329537f374a7394474376b01fd226e31f3ff3aa9254e8d328b23c2145
-  md5: be78ccdd273e43e27e66fc1629df6576
-  depends:
-  - gettext-tools 0.22.5 h0a1ffab_3
-  - libasprintf 0.22.5 h87f4aca_3
-  - libasprintf-devel 0.22.5 h87f4aca_3
-  - libgcc-ng >=12
-  - libgettextpo 0.22.5 h0a1ffab_3
-  - libgettextpo-devel 0.22.5 h0a1ffab_3
-  - libstdcxx-ng >=12
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  purls: []
-  size: 481962
-  timestamp: 1723626297896
-- kind: conda
-  name: gettext
-  version: 0.22.5
-  build: he02047a_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
   sha256: c3d9a453f523acbf2b3e1c82a42edfc7c7111b4686a2180ab48cb9b51a274218
   md5: c7f243bbaea97cd6ea1edd693270100e
   depends:
@@ -4565,29 +4001,22 @@ packages:
   purls: []
   size: 479452
   timestamp: 1723626088190
-- kind: conda
-  name: gettext-tools
-  version: 0.22.5
-  build: h0a1ffab_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h0a1ffab_3.conda
-  sha256: 9846b9d2e3d081cc8cb9ac7800c7e02a7b63bceea8619e0c51cfa271f89afdb2
-  md5: 5fc8dfe3163ead62e0af82d97ce6b486
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h0a1ffab_3.conda
+  sha256: 25b0b40329537f374a7394474376b01fd226e31f3ff3aa9254e8d328b23c2145
+  md5: be78ccdd273e43e27e66fc1629df6576
   depends:
+  - gettext-tools 0.22.5 h0a1ffab_3
+  - libasprintf 0.22.5 h87f4aca_3
+  - libasprintf-devel 0.22.5 h87f4aca_3
   - libgcc-ng >=12
-  license: GPL-3.0-or-later
-  license_family: GPL
+  - libgettextpo 0.22.5 h0a1ffab_3
+  - libgettextpo-devel 0.22.5 h0a1ffab_3
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
   purls: []
-  size: 2954814
-  timestamp: 1723626262722
-- kind: conda
-  name: gettext-tools
-  version: 0.22.5
-  build: he02047a_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
+  size: 481962
+  timestamp: 1723626297896
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
   sha256: 0fd003953ce1ce9f4569458aab9ffaa397e3be2bc069250e2f05fd93b0ad2976
   md5: fcd2016d1d299f654f81021e27496818
   depends:
@@ -4598,13 +4027,17 @@ packages:
   purls: []
   size: 2750908
   timestamp: 1723626056740
-- kind: conda
-  name: gitdb
-  version: 4.0.11
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h0a1ffab_3.conda
+  sha256: 9846b9d2e3d081cc8cb9ac7800c7e02a7b63bceea8619e0c51cfa271f89afdb2
+  md5: 5fc8dfe3163ead62e0af82d97ce6b486
+  depends:
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  purls: []
+  size: 2954814
+  timestamp: 1723626262722
+- conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
   sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
   md5: 623b19f616f2ca0c261441067e18ae40
   depends:
@@ -4616,13 +4049,7 @@ packages:
   - pkg:pypi/gitdb?source=hash-mapping
   size: 52872
   timestamp: 1697791718749
-- kind: conda
-  name: gitpython
-  version: 3.1.43
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
   sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
   md5: 0b2154c1818111e17381b1df5b4b0176
   depends:
@@ -4635,58 +4062,7 @@ packages:
   - pkg:pypi/gitpython?source=hash-mapping
   size: 156827
   timestamp: 1711991122366
-- kind: conda
-  name: glfw
-  version: '3.4'
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.4-h31becfc_0.conda
-  sha256: ec1037514938e6a582998c4f156c7165deb470d964dc2d53717e690ea25a22d3
-  md5: 48479e59b512a1dc883aa8d9ea2e29a6
-  depends:
-  - libgcc-ng >=12
-  - libxkbcommon >=1.6.0,<2.0a0
-  - wayland >=1.22.0,<2.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
-  - xorg-libxinerama >=1.1.5,<1.2.0a0
-  license: Zlib
-  purls: []
-  size: 170592
-  timestamp: 1708788896757
-- kind: conda
-  name: glfw
-  version: '3.4'
-  build: h93a5062_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.4-h93a5062_0.conda
-  sha256: fd01d62b690e42adf9b9d3fd7f4bbe7185dd8d9fa60aca315137f0367e9c989d
-  md5: b7bf4ccb27f1e75c9292a218974dcfac
-  license: Zlib
-  purls: []
-  size: 113768
-  timestamp: 1708789054033
-- kind: conda
-  name: glfw
-  version: '3.4'
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glfw-3.4-hcfcfb64_0.conda
-  sha256: f7759a2d1e473d36b39a65096c1b0660fe3574b7aa8fa330ef13626926292d13
-  md5: 5d41478e933d70273686b267827d2ae6
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Zlib
-  purls: []
-  size: 118348
-  timestamp: 1708789270458
-- kind: conda
-  name: glfw
-  version: '3.4'
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.4-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glfw-3.4-hd590300_0.conda
   sha256: 852298b9d1b6e58d8653d943049f7bce0ef3774c87fccd5ac1e8b04d5d702d40
   md5: 4c7a044d25e000fef39b77c10a102ea1
   depends:
@@ -4699,12 +4075,38 @@ packages:
   purls: []
   size: 167421
   timestamp: 1708788896752
-- kind: conda
-  name: glib
-  version: 2.82.2
-  build: h44428e9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.82.2-h44428e9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glfw-3.4-h31becfc_0.conda
+  sha256: ec1037514938e6a582998c4f156c7165deb470d964dc2d53717e690ea25a22d3
+  md5: 48479e59b512a1dc883aa8d9ea2e29a6
+  depends:
+  - libgcc-ng >=12
+  - libxkbcommon >=1.6.0,<2.0a0
+  - wayland >=1.22.0,<2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxinerama >=1.1.5,<1.2.0a0
+  license: Zlib
+  purls: []
+  size: 170592
+  timestamp: 1708788896757
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glfw-3.4-h93a5062_0.conda
+  sha256: fd01d62b690e42adf9b9d3fd7f4bbe7185dd8d9fa60aca315137f0367e9c989d
+  md5: b7bf4ccb27f1e75c9292a218974dcfac
+  license: Zlib
+  purls: []
+  size: 113768
+  timestamp: 1708789054033
+- conda: https://conda.anaconda.org/conda-forge/win-64/glfw-3.4-hcfcfb64_0.conda
+  sha256: f7759a2d1e473d36b39a65096c1b0660fe3574b7aa8fa330ef13626926292d13
+  md5: 5d41478e933d70273686b267827d2ae6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  purls: []
+  size: 118348
+  timestamp: 1708789270458
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.82.2-h44428e9_0.conda
   sha256: f89540cbca9d981fd65d2f3913e8aaa3fe30bc76aa0f70015be4a2169539025b
   md5: f19f985ab043e8843045410f3b99de8a
   depends:
@@ -4717,12 +4119,35 @@ packages:
   purls: []
   size: 602771
   timestamp: 1729191500463
-- kind: conda
-  name: glib
-  version: 2.82.2
-  build: h7025463_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.82.2-h7025463_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.82.2-hc486b8e_0.conda
+  sha256: 5735b3f53735ea78c0d7e98b112488576f03bcbf85fb7e5b0deb05dd35ea08b1
+  md5: 395da692fd81ebafd8c969683bb2bf41
+  depends:
+  - glib-tools 2.82.2 h78ca943_0
+  - libffi >=3.4,<4.0a0
+  - libglib 2.82.2 hc486b8e_0
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 616163
+  timestamp: 1729191610267
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.82.2-hb1db9eb_0.conda
+  sha256: 14efe746ba95154a89208e8478b71fb12ba5f25815029803d30196e561b9d94a
+  md5: 0642d868967b66fc7f0a5fda24bd7ac2
+  depends:
+  - glib-tools 2.82.2 h25d4a46_0
+  - libffi >=3.4,<4.0a0
+  - libglib 2.82.2 h07bd6cf_0
+  - libintl >=0.22.5,<1.0a0
+  - libintl-devel
+  - packaging
+  - python *
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 585193
+  timestamp: 1729191888264
+- conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.82.2-h7025463_0.conda
   sha256: 68632bb5aec001fcd09b7f9ea415fab09ad479eb640fb667141cbb747a8d48b5
   md5: c295bf0ccb6823efdf40ebc5992384c4
   depends:
@@ -4740,50 +4165,28 @@ packages:
   purls: []
   size: 573556
   timestamp: 1729192350624
-- kind: conda
-  name: glib
-  version: 2.82.2
-  build: hb1db9eb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.82.2-hb1db9eb_0.conda
-  sha256: 14efe746ba95154a89208e8478b71fb12ba5f25815029803d30196e561b9d94a
-  md5: 0642d868967b66fc7f0a5fda24bd7ac2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.2-h4833e2c_0.conda
+  sha256: 4d6d7175a841be9dd25f5041c9b9419b25f4f5e8de8f289b3c7914a76f5a24d4
+  md5: 12859f91830f58b1803e32846651c6f6
   depends:
-  - glib-tools 2.82.2 h25d4a46_0
-  - libffi >=3.4,<4.0a0
-  - libglib 2.82.2 h07bd6cf_0
-  - libintl >=0.22.5,<1.0a0
-  - libintl-devel
-  - packaging
-  - python *
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libglib 2.82.2 h2ff4ddf_0
   license: LGPL-2.1-or-later
   purls: []
-  size: 585193
-  timestamp: 1729191888264
-- kind: conda
-  name: glib
-  version: 2.82.2
-  build: hc486b8e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.82.2-hc486b8e_0.conda
-  sha256: 5735b3f53735ea78c0d7e98b112488576f03bcbf85fb7e5b0deb05dd35ea08b1
-  md5: 395da692fd81ebafd8c969683bb2bf41
+  size: 114038
+  timestamp: 1729191458625
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.82.2-h78ca943_0.conda
+  sha256: 4f8eaa6d7fe07a6e6bc06787256a416b14d4ed424474b11875d0ca7aeff1256c
+  md5: 3053283d0c0e78ab5935c9e17f803358
   depends:
-  - glib-tools 2.82.2 h78ca943_0
-  - libffi >=3.4,<4.0a0
+  - libgcc >=13
   - libglib 2.82.2 hc486b8e_0
-  - packaging
-  - python *
   license: LGPL-2.1-or-later
   purls: []
-  size: 616163
-  timestamp: 1729191610267
-- kind: conda
-  name: glib-tools
-  version: 2.82.2
-  build: h25d4a46_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.82.2-h25d4a46_0.conda
+  size: 126325
+  timestamp: 1729191584153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.82.2-h25d4a46_0.conda
   sha256: e9855cc94eb05894255811e070adefe158acf7e03e62b223cc27615a5b7bfcbd
   md5: a2a75ed0bf49f94478d356424f158c61
   depends:
@@ -4794,12 +4197,7 @@ packages:
   purls: []
   size: 99919
   timestamp: 1729191855779
-- kind: conda
-  name: glib-tools
-  version: 2.82.2
-  build: h4394cf3_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.82.2-h4394cf3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.82.2-h4394cf3_0.conda
   sha256: 2c502b66fb68ed3dd4ce9f8121ae8f613df08a83c354c55435994dd9a8ee780a
   md5: 5aa50df298dca67e20ad24c622d1a27c
   depends:
@@ -4812,76 +4210,7 @@ packages:
   purls: []
   size: 96434
   timestamp: 1729192296587
-- kind: conda
-  name: glib-tools
-  version: 2.82.2
-  build: h4833e2c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.82.2-h4833e2c_0.conda
-  sha256: 4d6d7175a841be9dd25f5041c9b9419b25f4f5e8de8f289b3c7914a76f5a24d4
-  md5: 12859f91830f58b1803e32846651c6f6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libglib 2.82.2 h2ff4ddf_0
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 114038
-  timestamp: 1729191458625
-- kind: conda
-  name: glib-tools
-  version: 2.82.2
-  build: h78ca943_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.82.2-h78ca943_0.conda
-  sha256: 4f8eaa6d7fe07a6e6bc06787256a416b14d4ed424474b11875d0ca7aeff1256c
-  md5: 3053283d0c0e78ab5935c9e17f803358
-  depends:
-  - libgcc >=13
-  - libglib 2.82.2 hc486b8e_0
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 126325
-  timestamp: 1729191584153
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h0a1ffab_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
-  sha256: a5e341cbf797c65d2477b27d99091393edbaa5178c7d69b7463bb105b0488e69
-  md5: 7cbfb3a8bb1b78a7f5518654ac6725ad
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  purls: []
-  size: 417323
-  timestamp: 1718980707330
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: h7bae524_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
-  sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
-  md5: eed7278dfbab727b56f2c0b64330814b
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  purls: []
-  size: 365188
-  timestamp: 1718981343258
-- kind: conda
-  name: gmp
-  version: 6.3.0
-  build: hac33072_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
   sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
   md5: c94a5994ef49749880a8139cf9afcbe1
   depends:
@@ -4891,30 +4220,27 @@ packages:
   purls: []
   size: 460055
   timestamp: 1718980856608
-- kind: conda
-  name: graphite2
-  version: 1.3.13
-  build: h2f0025b_1003
-  build_number: 1003
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h2f0025b_1003.conda
-  sha256: c7585e1fb536120583790080f3b3875c04d5f2d64eafbc87e9aa39895e4118c0
-  md5: f33009add6a08358bc12d114ceec1304
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
+  sha256: a5e341cbf797c65d2477b27d99091393edbaa5178c7d69b7463bb105b0488e69
+  md5: 7cbfb3a8bb1b78a7f5518654ac6725ad
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  license: LGPL-2.0-or-later
-  license_family: LGPL
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
   purls: []
-  size: 99453
-  timestamp: 1711634223220
-- kind: conda
-  name: graphite2
-  version: 1.3.13
-  build: h59595ed_1003
-  build_number: 1003
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
+  size: 417323
+  timestamp: 1718980707330
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+  sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
+  md5: eed7278dfbab727b56f2c0b64330814b
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  purls: []
+  size: 365188
+  timestamp: 1718981343258
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
   sha256: 0595b009f20f8f60f13a6398e7cdcbd2acea5f986633adcf85f5a2283c992add
   md5: f87c7b7c2cb45f323ffbce941c78ab7c
   depends:
@@ -4925,13 +4251,28 @@ packages:
   purls: []
   size: 96855
   timestamp: 1711634169756
-- kind: conda
-  name: graphite2
-  version: 1.3.13
-  build: h63175ca_1003
-  build_number: 1003
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h2f0025b_1003.conda
+  sha256: c7585e1fb536120583790080f3b3875c04d5f2d64eafbc87e9aa39895e4118c0
+  md5: f33009add6a08358bc12d114ceec1304
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 99453
+  timestamp: 1711634223220
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
+  sha256: 2eadafbfc52f5e7df3da3c3b7e5bbe34d970bea1d645ffe60b0b1c3a216657f5
+  md5: 339991336eeddb70076d8ca826dac625
+  depends:
+  - libcxx >=16
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 79774
+  timestamp: 1711634444608
+- conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
   sha256: 25040a4f371b9b51663f546bac620122c237fa1d5d32968e21b0751af9b7f56f
   md5: 3194499ee7d1a67404a87d0eefdd92c6
   depends:
@@ -4943,28 +4284,7 @@ packages:
   purls: []
   size: 95406
   timestamp: 1711634622644
-- kind: conda
-  name: graphite2
-  version: 1.3.13
-  build: hebf3989_1003
-  build_number: 1003
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
-  sha256: 2eadafbfc52f5e7df3da3c3b7e5bbe34d970bea1d645ffe60b0b1c3a216657f5
-  md5: 339991336eeddb70076d8ca826dac625
-  depends:
-  - libcxx >=16
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 79774
-  timestamp: 1711634444608
-- kind: conda
-  name: gst-plugins-base
-  version: 1.24.7
-  build: h0a52356_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.7-h0a52356_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.7-h0a52356_0.conda
   sha256: 6606a2686c0aed281a60fb546703e62c66ea9afa1e46adcca5eb428a3ff67f9e
   md5: d368425fbd031a2f8e801a40c3415c72
   depends:
@@ -4991,12 +4311,7 @@ packages:
   purls: []
   size: 2822378
   timestamp: 1725536496791
-- kind: conda
-  name: gst-plugins-base
-  version: 1.24.7
-  build: h570c1df_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.7-h570c1df_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.24.7-h570c1df_0.conda
   sha256: d6db93e096d0213dd14004a0bd084f11b2d5af4a35a7ac319611c2885f87dc28
   md5: 8d35b3a3d8b4a85ab93ab40314c9246a
   depends:
@@ -5022,35 +4337,7 @@ packages:
   purls: []
   size: 2761700
   timestamp: 1725540779840
-- kind: conda
-  name: gst-plugins-base
-  version: 1.24.7
-  build: hb0a98b8_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.7-hb0a98b8_0.conda
-  sha256: c8951e6af014cdeff2de740d1e6e4781ac6813853739c56c6e07266e7aefcf28
-  md5: 92edfae477856e97db6c2610dea95bb1
-  depends:
-  - gstreamer 1.24.7 h5006eae_0
-  - libglib >=2.80.3,<3.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libogg >=1.3.5,<1.4.0a0
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 2061727
-  timestamp: 1725537068521
-- kind: conda
-  name: gst-plugins-base
-  version: 1.24.7
-  build: hb49d354_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.24.7-hb49d354_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.24.7-hb49d354_0.conda
   sha256: 56b84bf80b6301e715312e6c1b8c44b2e2f0821854b1d05ec065b59bf38adad1
   md5: 3dfb86c12a1bc38d03be9f52225b8ef7
   depends:
@@ -5069,12 +4356,40 @@ packages:
   purls: []
   size: 1962829
   timestamp: 1725536921391
-- kind: conda
-  name: gstreamer
-  version: 1.24.7
-  build: h37d20eb_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.7-h37d20eb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.7-hb0a98b8_0.conda
+  sha256: c8951e6af014cdeff2de740d1e6e4781ac6813853739c56c6e07266e7aefcf28
+  md5: 92edfae477856e97db6c2610dea95bb1
+  depends:
+  - gstreamer 1.24.7 h5006eae_0
+  - libglib >=2.80.3,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 2061727
+  timestamp: 1725537068521
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.7-hf3bb09a_0.conda
+  sha256: 9c059cc7dcb2732da8face18b1c0351da148ef26db0563fed08e818ea0515bb1
+  md5: c78bc4ef0afb3cd2365d9973c71fc876
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - glib >=2.80.3,<3.0a0
+  - libgcc >=13
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx >=13
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 2023966
+  timestamp: 1725536373253
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.24.7-h37d20eb_0.conda
   sha256: 85a9acd103a2477506c3c92b27dcd4ec5f77bab353fa7a33817f0894bb11a824
   md5: c672dd04a62139ba21f2ba130b88f235
   depends:
@@ -5088,12 +4403,22 @@ packages:
   purls: []
   size: 2027297
   timestamp: 1725538984316
-- kind: conda
-  name: gstreamer
-  version: 1.24.7
-  build: h5006eae_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.7-h5006eae_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.24.7-hc3f5269_0.conda
+  sha256: 414b1919b746ace641e8cc1eae99ee0bf616a62da2851e248cb04413dcc496b0
+  md5: 51a487eebf20e94bec393d83901ca5eb
+  depends:
+  - __osx >=11.0
+  - glib >=2.80.3,<3.0a0
+  - libcxx >=17
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 1347352
+  timestamp: 1725536657414
+- conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.7-h5006eae_0.conda
   sha256: bd3ad109ef3e2e49da8710ff49378b3fa5da916aa2351d932d1b9018b7123512
   md5: 58e1df95fdab219039e39033302771e8
   depends:
@@ -5109,120 +4434,7 @@ packages:
   purls: []
   size: 2022487
   timestamp: 1725536894511
-- kind: conda
-  name: gstreamer
-  version: 1.24.7
-  build: hc3f5269_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.24.7-hc3f5269_0.conda
-  sha256: 414b1919b746ace641e8cc1eae99ee0bf616a62da2851e248cb04413dcc496b0
-  md5: 51a487eebf20e94bec393d83901ca5eb
-  depends:
-  - __osx >=11.0
-  - glib >=2.80.3,<3.0a0
-  - libcxx >=17
-  - libglib >=2.80.3,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libintl >=0.22.5,<1.0a0
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 1347352
-  timestamp: 1725536657414
-- kind: conda
-  name: gstreamer
-  version: 1.24.7
-  build: hf3bb09a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.7-hf3bb09a_0.conda
-  sha256: 9c059cc7dcb2732da8face18b1c0351da148ef26db0563fed08e818ea0515bb1
-  md5: c78bc4ef0afb3cd2365d9973c71fc876
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - glib >=2.80.3,<3.0a0
-  - libgcc >=13
-  - libglib >=2.80.3,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libstdcxx >=13
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 2023966
-  timestamp: 1725536373253
-- kind: conda
-  name: harfbuzz
-  version: 9.0.0
-  build: h2bedf89_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
-  sha256: 20f42ec76e075902c22c1f8ddc71fb88eff0b93e74f5705c1e72220030965810
-  md5: 254f119aaed2c0be271c1114ae18d09b
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=75.1,<76.0a0
-  - libglib >=2.80.3,<3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 1095620
-  timestamp: 1721187287831
-- kind: conda
-  name: harfbuzz
-  version: 9.0.0
-  build: h997cde5_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-9.0.0-h997cde5_1.conda
-  sha256: 5f78f5dcbbfef59b3549ecb6cc2fa9de7b22abda7c8afaf0fa787ceea37a914f
-  md5: 50f6825d3c4a6fca6fefdefa98081554
-  depends:
-  - __osx >=11.0
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=75.1,<76.0a0
-  - libcxx >=16
-  - libglib >=2.80.3,<3.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 1317509
-  timestamp: 1721186764931
-- kind: conda
-  name: harfbuzz
-  version: 9.0.0
-  build: hbf49d6b_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-9.0.0-hbf49d6b_1.conda
-  sha256: 7496782c3bc0ebbb4de9bc92a3111f42b8a57417fa31ecb87058f250215fabc9
-  md5: ceb458f664cab8550fcd74fff26451db
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=75.1,<76.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.3,<3.0a0
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 1614644
-  timestamp: 1721188789883
-- kind: conda
-  name: harfbuzz
-  version: 9.0.0
-  build: hda332d3_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
   sha256: 973afa37840b4e55e2540018902255cfb0d953aaed6353bb83a4d120f5256767
   md5: 76b32dcf243444aea9c6b804bcfa40b8
   depends:
@@ -5239,36 +4451,56 @@ packages:
   purls: []
   size: 1603653
   timestamp: 1721186240105
-- kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_h13f6c1a_103
-  build_number: 103
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.4-nompi_h13f6c1a_103.conda
-  sha256: 5cfbcaf9cd0c38fd9c97ea923cf1ec9720889d61092009bb6310b13328bdc934
-  md5: be63ad231183d7ebd7b7d0d46145a800
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-9.0.0-hbf49d6b_1.conda
+  sha256: 7496782c3bc0ebbb4de9bc92a3111f42b8a57417fa31ecb87058f250215fabc9
+  md5: ceb458f664cab8550fcd74fff26451db
   depends:
-  - libaec >=1.1.3,<2.0a0
-  - libcurl >=8.10.1,<9.0a0
-  - libgcc >=13
-  - libgfortran
-  - libgfortran5 >=13.3.0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
   purls: []
-  size: 4018790
-  timestamp: 1730836761211
-- kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_h2d575fe_103
-  build_number: 103
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_103.conda
+  size: 1614644
+  timestamp: 1721188789883
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-9.0.0-h997cde5_1.conda
+  sha256: 5f78f5dcbbfef59b3549ecb6cc2fa9de7b22abda7c8afaf0fa787ceea37a914f
+  md5: 50f6825d3c4a6fca6fefdefa98081554
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1317509
+  timestamp: 1721186764931
+- conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
+  sha256: 20f42ec76e075902c22c1f8ddc71fb88eff0b93e74f5705c1e72220030965810
+  md5: 254f119aaed2c0be271c1114ae18d09b
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=75.1,<76.0a0
+  - libglib >=2.80.3,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1095620
+  timestamp: 1721187287831
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.4-nompi_h2d575fe_103.conda
   sha256: 50bcd6cd6e8853321e87d359571d187f8e18fa1c73b711074e551417c2163483
   md5: f8416d7ff13707bd8eb75d6b8235857e
   depends:
@@ -5286,13 +4518,24 @@ packages:
   purls: []
   size: 3940636
   timestamp: 1730830832687
-- kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_ha698983_103
-  build_number: 103
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_ha698983_103.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.4-nompi_h13f6c1a_103.conda
+  sha256: 5cfbcaf9cd0c38fd9c97ea923cf1ec9720889d61092009bb6310b13328bdc934
+  md5: be63ad231183d7ebd7b7d0d46145a800
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.10.1,<9.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 4018790
+  timestamp: 1730836761211
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.4-nompi_ha698983_103.conda
   sha256: 01c2792588db2ac16e758a2898e4ec40955a2abcbc30f0212b7a669e1d094cae
   md5: b779eb51bbfdf8d1b4539199b76839b4
   depends:
@@ -5309,13 +4552,7 @@ packages:
   purls: []
   size: 3495866
   timestamp: 1730831045992
-- kind: conda
-  name: hdf5
-  version: 1.14.4
-  build: nompi_hd5d9e70_103
-  build_number: 103
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_103.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.4-nompi_hd5d9e70_103.conda
   sha256: c7fefe41464651e807f61d42803a670f25dbe0cb59677af97b9dda3e8cb675fd
   md5: 6d72be86cae448cfc7bf93d51cd642bb
   depends:
@@ -5331,12 +4568,7 @@ packages:
   purls: []
   size: 2049966
   timestamp: 1730830694091
-- kind: conda
-  name: icu
-  version: '75.1'
-  build: he02047a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
   sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
   md5: 8b189310083baabfb622af68fd9d3ae3
   depends:
@@ -5348,12 +4580,28 @@ packages:
   purls: []
   size: 12129203
   timestamp: 1720853576813
-- kind: conda
-  name: icu
-  version: '75.1'
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
+  sha256: 813298f2e54ef087dbfc9cc2e56e08ded41de65cff34c639cc8ba4e27e4540c9
+  md5: 268203e8b983fddb6412b36f2024e75c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12282786
+  timestamp: 1720853454991
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
+  md5: 5eb22c1d7b3fc4abb50d92d621583137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 11857802
+  timestamp: 1720853997952
+- conda: https://conda.anaconda.org/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
   sha256: 1d04369a1860a1e9e371b9fc82dd0092b616adcf057d6c88371856669280e920
   md5: 8579b6bb8d18be7c0b27fb08adeeeb40
   depends:
@@ -5365,44 +4613,7 @@ packages:
   purls: []
   size: 14544252
   timestamp: 1720853966338
-- kind: conda
-  name: icu
-  version: '75.1'
-  build: hf9b3779_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
-  sha256: 813298f2e54ef087dbfc9cc2e56e08ded41de65cff34c639cc8ba4e27e4540c9
-  md5: 268203e8b983fddb6412b36f2024e75c
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 12282786
-  timestamp: 1720853454991
-- kind: conda
-  name: icu
-  version: '75.1'
-  build: hfee45f7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
-  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
-  md5: 5eb22c1d7b3fc4abb50d92d621583137
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 11857802
-  timestamp: 1720853997952
-- kind: conda
-  name: identify
-  version: 2.6.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.1-pyhd8ed1ab_0.conda
   sha256: dc752392f327e64e32bc3122758b2d8951aec9d6e6aa888463c73d18a10e3c56
   md5: 43f629202f9eec21be5f71171fb5daf8
   depends:
@@ -5414,12 +4625,7 @@ packages:
   - pkg:pypi/identify?source=hash-mapping
   size: 78078
   timestamp: 1726369674008
-- kind: conda
-  name: idyntree
-  version: 13.1.1
-  build: py312h4ad8b1d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/idyntree-13.1.1-py312h4ad8b1d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/idyntree-13.1.1-py312h4ad8b1d_0.conda
   sha256: e1f00d458395bf9138962770b6b95640f253cb7fb940cd7ca090061b4c7bfc37
   md5: d4059079c0384df380c365131802064b
   depends:
@@ -5446,40 +4652,7 @@ packages:
   - pkg:pypi/idyntree?source=hash-mapping
   size: 2507605
   timestamp: 1730199409180
-- kind: conda
-  name: idyntree
-  version: 13.1.1
-  build: py312ha285fbb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/idyntree-13.1.1-py312ha285fbb_0.conda
-  sha256: f7d30839c6e31d7884e9847f809205eec8f46373c21769cd0b45bec191f9c921
-  md5: ca61c65ad2cc61e51cafb9888ba7300a
-  depends:
-  - __osx >=11.0
-  - assimp >=5.4.3,<5.4.4.0a0
-  - glfw >=3.4,<4.0a0
-  - ipopt >=3.14.16,<3.14.17.0a0
-  - irrlicht >=1.8.5,<1.9.0a0
-  - libcxx >=17
-  - libosqp >=0.6.3,<0.6.4.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - numpy >=1.19,<3
-  - osqp-eigen >=0.8.1,<0.8.2.0a0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/idyntree?source=hash-mapping
-  size: 2060294
-  timestamp: 1730199659209
-- kind: conda
-  name: idyntree
-  version: 13.1.1
-  build: py312hdab362b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/idyntree-13.1.1-py312hdab362b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/idyntree-13.1.1-py312hdab362b_0.conda
   sha256: fb13b2d44f39e3d0bcfae70012e595e0e0d9c9d203646474f7093ff339c2e358
   md5: 712dec851dee23c3fa32539c0b00e41f
   depends:
@@ -5506,12 +4679,30 @@ packages:
   - pkg:pypi/idyntree?source=hash-mapping
   size: 2296689
   timestamp: 1730199677830
-- kind: conda
-  name: idyntree
-  version: 13.1.1
-  build: py313hd874cfe_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/idyntree-13.1.1-py313hd874cfe_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/idyntree-13.1.1-py312ha285fbb_0.conda
+  sha256: f7d30839c6e31d7884e9847f809205eec8f46373c21769cd0b45bec191f9c921
+  md5: ca61c65ad2cc61e51cafb9888ba7300a
+  depends:
+  - __osx >=11.0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - glfw >=3.4,<4.0a0
+  - ipopt >=3.14.16,<3.14.17.0a0
+  - irrlicht >=1.8.5,<1.9.0a0
+  - libcxx >=17
+  - libosqp >=0.6.3,<0.6.4.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - numpy >=1.19,<3
+  - osqp-eigen >=0.8.1,<0.8.2.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/idyntree?source=hash-mapping
+  size: 2060294
+  timestamp: 1730199659209
+- conda: https://conda.anaconda.org/conda-forge/win-64/idyntree-13.1.1-py313hd874cfe_0.conda
   sha256: cf58bfa3b57c32f8c736693524c54d65c5e8dbbd6e06f91ed48273265438c669
   md5: ac7adcef4e8af7bc59495e77dfd21440
   depends:
@@ -5534,29 +4725,7 @@ packages:
   - pkg:pypi/idyntree?source=hash-mapping
   size: 7263546
   timestamp: 1730199774118
-- kind: conda
-  name: imath
-  version: 3.1.12
-  build: h025cafa_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.12-h025cafa_0.conda
-  sha256: 8fcf6c3bf91993451412c0003b92044c9fc7980fe3f178ab3260f90ac4099072
-  md5: b7e259bd81b5a7432ca045083959b83a
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 153017
-  timestamp: 1725971790238
-- kind: conda
-  name: imath
-  version: 3.1.12
-  build: h7955e40_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.1.12-h7955e40_0.conda
   sha256: 4d8d07a4d5079d198168b44556fb86d094e6a716e8979b25a9f6c9c610e9fe56
   md5: 37f5e1ab0db3691929f37dee78335d1b
   depends:
@@ -5569,12 +4738,31 @@ packages:
   purls: []
   size: 159630
   timestamp: 1725971591485
-- kind: conda
-  name: imath
-  version: 3.1.12
-  build: hbb528cf_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.12-hbb528cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.12-hf428078_0.conda
+  sha256: ad8f18472425da83ba0e9324ab715f5d232cece8b0efaf218bd2ea9e1b6adb6d
+  md5: ae8535ff689663fe430bec00be24a854
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 153368
+  timestamp: 1725971683794
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/imath-3.1.12-h025cafa_0.conda
+  sha256: 8fcf6c3bf91993451412c0003b92044c9fc7980fe3f178ab3260f90ac4099072
+  md5: b7e259bd81b5a7432ca045083959b83a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 153017
+  timestamp: 1725971790238
+- conda: https://conda.anaconda.org/conda-forge/win-64/imath-3.1.12-hbb528cf_0.conda
   sha256: 184c796615cebaa73246f351144f164ee7b61ea809e4ba3c5d98fa9ca333e058
   md5: c25af729c8c1c41f96202f8a96652bbe
   depends:
@@ -5587,30 +4775,7 @@ packages:
   purls: []
   size: 160408
   timestamp: 1725972042635
-- kind: conda
-  name: imath
-  version: 3.1.12
-  build: hf428078_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/imath-3.1.12-hf428078_0.conda
-  sha256: ad8f18472425da83ba0e9324ab715f5d232cece8b0efaf218bd2ea9e1b6adb6d
-  md5: ae8535ff689663fe430bec00be24a854
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 153368
-  timestamp: 1725971683794
-- kind: conda
-  name: importlib_resources
-  version: 6.4.5
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_0.conda
   sha256: 2cb9db3e40033c3df72d3defc678a012840378fd55a67e4351363d4b321a0dc1
   md5: c808991d29b9838fb4d96ce8267ec9ec
   depends:
@@ -5624,13 +4789,7 @@ packages:
   - pkg:pypi/importlib-resources?source=hash-mapping
   size: 32725
   timestamp: 1725921462405
-- kind: conda
-  name: iniconfig
-  version: 2.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
   sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
   md5: f800d2da156d08e289b14e87e43c1ae5
   depends:
@@ -5641,13 +4800,7 @@ packages:
   - pkg:pypi/iniconfig?source=hash-mapping
   size: 11101
   timestamp: 1673103208955
-- kind: conda
-  name: intel-openmp
-  version: 2024.2.1
-  build: h57928b3_1083
-  build_number: 1083
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
   sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
   md5: 2d89243bfb53652c182a7c73182cce4f
   license: LicenseRef-IntelSimplifiedSoftwareOct2022
@@ -5655,13 +4808,7 @@ packages:
   purls: []
   size: 1852356
   timestamp: 1723739573141
-- kind: conda
-  name: ipopt
-  version: 3.14.16
-  build: h122424a_10
-  build_number: 10
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.16-h122424a_10.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ipopt-3.14.16-h122424a_10.conda
   sha256: b146808eccf916f3186de8926be4ca14bca6d20d6e5fcde4454cae6f1de9d9eb
   md5: 4ebce336fae43577731ad413e94a6bfa
   depends:
@@ -5679,13 +4826,7 @@ packages:
   purls: []
   size: 1030827
   timestamp: 1727440696766
-- kind: conda
-  name: ipopt
-  version: 3.14.16
-  build: h202260e_10
-  build_number: 10
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.16-h202260e_10.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ipopt-3.14.16-h202260e_10.conda
   sha256: 69fdeaab6a2528ef37cb8aebfeac7466e79a533f945d83ac56bab0deb642154c
   md5: b841bdb9ade7994c1a58b00790852046
   depends:
@@ -5702,13 +4843,7 @@ packages:
   purls: []
   size: 1028588
   timestamp: 1727440811283
-- kind: conda
-  name: ipopt
-  version: 3.14.16
-  build: h920a7db_10
-  build_number: 10
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.16-h920a7db_10.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ipopt-3.14.16-h920a7db_10.conda
   sha256: cbc2874efb6ef04c81eced387238ad1247174eee5859c68a7dca881eaef65027
   md5: 1e2c514b61859c1b37e680c20893c283
   depends:
@@ -5724,13 +4859,7 @@ packages:
   purls: []
   size: 758539
   timestamp: 1727440718510
-- kind: conda
-  name: ipopt
-  version: 3.14.16
-  build: hfa42872_10
-  build_number: 10
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.16-hfa42872_10.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/ipopt-3.14.16-hfa42872_10.conda
   sha256: 041ed2b02518d06811391e797cc8a6d071cf9a802b746ebc58265642be3670a0
   md5: dd8754f62da46096a67bf87a7c6f00b6
   depends:
@@ -5745,62 +4874,7 @@ packages:
   purls: []
   size: 908450
   timestamp: 1727441201593
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: h20dfb44_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h20dfb44_5.conda
-  sha256: aa2de7c7d1e924437438e57b5141a407bfd6a7c69ebedeb4d9f6cd07e683f724
-  md5: 662cf5b69d72c77dc16f6e30df616cc2
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - sdl >=1.2.68,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Zlib
-  purls: []
-  size: 1142127
-  timestamp: 1724165302309
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: hc10942e_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/irrlicht-1.8.5-hc10942e_5.conda
-  sha256: ebe591797abc39462aec98f0eb7b037b71d13c3c14f645bcf20d576c2141025c
-  md5: 6806a2ea18a227f4db840b23df88f1d0
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libgl >=1.7.0,<2.0a0
-  - libglu
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  - sdl >=1.2.68,<1.3.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxxf86vm >=1.1.5,<2.0a0
-  license: Zlib
-  purls: []
-  size: 1906014
-  timestamp: 1724165028021
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: hcce6d95_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/irrlicht-1.8.5-hcce6d95_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/irrlicht-1.8.5-hcce6d95_5.conda
   sha256: 72aa5d6348eeed5b8f6df1c711757c31dab061c9a355a72cc18ea4c77527a475
   md5: bd78280d5c89a7377e5b79d491aca6cb
   depends:
@@ -5822,13 +4896,28 @@ packages:
   purls: []
   size: 1947728
   timestamp: 1724164975931
-- kind: conda
-  name: irrlicht
-  version: 1.8.5
-  build: hdfd4c6d_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-hdfd4c6d_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/irrlicht-1.8.5-hc10942e_5.conda
+  sha256: ebe591797abc39462aec98f0eb7b037b71d13c3c14f645bcf20d576c2141025c
+  md5: 6806a2ea18a227f4db840b23df88f1d0
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libgl >=1.7.0,<2.0a0
+  - libglu
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxxf86vm >=1.1.5,<2.0a0
+  license: Zlib
+  purls: []
+  size: 1906014
+  timestamp: 1724165028021
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/irrlicht-1.8.5-hdfd4c6d_5.conda
   sha256: f13abda30c917f95b012a4552f84f505ce662ddcff0a563e39f0e60b9bc131ea
   md5: 2011bfec6849090eef9ca0e9b75abc66
   depends:
@@ -5845,13 +4934,23 @@ packages:
   purls: []
   size: 1202474
   timestamp: 1724165134357
-- kind: conda
-  name: isort
-  version: 5.13.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/irrlicht-1.8.5-h20dfb44_5.conda
+  sha256: aa2de7c7d1e924437438e57b5141a407bfd6a7c69ebedeb4d9f6cd07e683f724
+  md5: 662cf5b69d72c77dc16f6e30df616cc2
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Zlib
+  purls: []
+  size: 1142127
+  timestamp: 1724165302309
+- conda: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_0.conda
   sha256: 78a7e2037029366d2149f73c8d02e93cac903d535e208cc4517808b0b42e85f2
   md5: 1d25ed2b95b92b026aaa795eabec8d91
   depends:
@@ -5863,12 +4962,7 @@ packages:
   - pkg:pypi/isort?source=hash-mapping
   size: 73783
   timestamp: 1702518633821
-- kind: conda
-  name: jasper
-  version: 4.2.4
-  build: h536e39c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.4-h536e39c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.4-h536e39c_0.conda
   sha256: 0a5ca92ea0261f435c27a3c3c5c5bc5e8b4b1af1343b21ef0cbc7c33b62f5239
   md5: 9518ab7016cf4564778aef08b6bd8792
   depends:
@@ -5880,27 +4974,7 @@ packages:
   purls: []
   size: 675951
   timestamp: 1714298705230
-- kind: conda
-  name: jasper
-  version: 4.2.4
-  build: h6c4e4ef_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.4-h6c4e4ef_0.conda
-  sha256: 9c874070f201b64d7ca02b59f1348354ae1c834e969cb83259133bb0406ee7fa
-  md5: 9019e1298c84b0185a60c62741d720dd
-  depends:
-  - __osx >=11.0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  license: JasPer-2.0
-  purls: []
-  size: 583310
-  timestamp: 1714298773123
-- kind: conda
-  name: jasper
-  version: 4.2.4
-  build: ha25e7e8_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.4-ha25e7e8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.4-ha25e7e8_0.conda
   sha256: 01cf16b5df4f685ea5952498d2d3cc0bd9ef54460adfed28a43b6fe05e4743e8
   md5: f888b2805a130afa6f6657acc5afaa1a
   depends:
@@ -5912,12 +4986,17 @@ packages:
   purls: []
   size: 707709
   timestamp: 1714298735485
-- kind: conda
-  name: jasper
-  version: 4.2.4
-  build: hcb1a123_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.4-hcb1a123_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.4-h6c4e4ef_0.conda
+  sha256: 9c874070f201b64d7ca02b59f1348354ae1c834e969cb83259133bb0406ee7fa
+  md5: 9019e1298c84b0185a60c62741d720dd
+  depends:
+  - __osx >=11.0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  purls: []
+  size: 583310
+  timestamp: 1714298773123
+- conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.4-hcb1a123_0.conda
   sha256: ecddfba94b78849dbde3c73fffb7877e9f1e7a8c1a71786135538af0c524b49b
   md5: 94e32e7c907c6c80c0d0db4c8b163baf
   depends:
@@ -5930,12 +5009,7 @@ packages:
   purls: []
   size: 442367
   timestamp: 1714299052957
-- kind: conda
-  name: keyutils
-  version: 1.6.1
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
   sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
   md5: 30186d27e2c9fa62b45fb1476b7200e3
   depends:
@@ -5944,12 +5018,7 @@ packages:
   purls: []
   size: 117831
   timestamp: 1646151697040
-- kind: conda
-  name: keyutils
-  version: 1.6.1
-  build: h4e544f5_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
   sha256: 6d4233d97a9b38acbb26e1268bcf8c10a8e79c2aed7e5a385ec3769967e3e65b
   md5: 1f24853e59c68892452ef94ddd8afd4b
   depends:
@@ -5958,12 +5027,7 @@ packages:
   purls: []
   size: 112327
   timestamp: 1646166857935
-- kind: conda
-  name: khronos-opencl-icd-loader
-  version: 2024.05.08
-  build: hc70643c_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2024.05.08-hc70643c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2024.05.08-hc70643c_0.conda
   sha256: 701357f02926bef5cb6d060a5471d50dc6528500fd045805ea785398fbb6d6d2
   md5: 22b22ac3be757e10705caa3b5f321e0d
   depends:
@@ -5975,51 +5039,7 @@ packages:
   purls: []
   size: 87736
   timestamp: 1727732609299
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h237132a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
-  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
-  md5: c6dc8a0fdec13a0565936655c33069a1
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.3.1,<4.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 1155530
-  timestamp: 1719463474401
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h50a48e9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
-  sha256: 0ec272afcf7ea7fbf007e07a3b4678384b7da4047348107b2ae02630a570a815
-  md5: 29c10432a2ca1472b53f299ffb2ffa37
-  depends:
-  - keyutils >=1.6.1,<2.0a0
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.3.1,<4.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 1474620
-  timestamp: 1719463205834
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h659f571_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
   sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
   md5: 3f43953b7d3fb3aaa1d0d0723d91e368
   depends:
@@ -6034,12 +5054,36 @@ packages:
   purls: []
   size: 1370023
   timestamp: 1719463201255
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: hdf4eb48_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
+  sha256: 0ec272afcf7ea7fbf007e07a3b4678384b7da4047348107b2ae02630a570a815
+  md5: 29c10432a2ca1472b53f299ffb2ffa37
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1474620
+  timestamp: 1719463205834
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
+  md5: c6dc8a0fdec13a0565936655c33069a1
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1155530
+  timestamp: 1719463474401
+- conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
   sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
   md5: 31aec030344e962fbd7dbbbbd68e60a9
   depends:
@@ -6052,13 +5096,7 @@ packages:
   purls: []
   size: 712034
   timestamp: 1719463874284
-- kind: conda
-  name: lame
-  version: '3.100'
-  build: h166bdaf_1003
-  build_number: 1003
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
   sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
   md5: a8832b479f93521a9e7b5b743803be51
   depends:
@@ -6068,27 +5106,7 @@ packages:
   purls: []
   size: 508258
   timestamp: 1664996250081
-- kind: conda
-  name: lame
-  version: '3.100'
-  build: h1a8c8d9_1003
-  build_number: 1003
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
-  sha256: f40ce7324b2cf5338b766d4cdb8e0453e4156a4f83c2f31bbfff750785de304c
-  md5: bff0e851d66725f78dc2fd8b032ddb7e
-  license: LGPL-2.0-only
-  license_family: LGPL
-  purls: []
-  size: 528805
-  timestamp: 1664996399305
-- kind: conda
-  name: lame
-  version: '3.100'
-  build: h4e544f5_1003
-  build_number: 1003
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
   sha256: 2502904a42df6d94bd743f7b73915415391dd6d31d5f50cb57c0a54a108e7b0a
   md5: ab05bcf82d8509b4243f07e93bada144
   depends:
@@ -6098,13 +5116,15 @@ packages:
   purls: []
   size: 604863
   timestamp: 1664997611416
-- kind: conda
-  name: ld_impl_linux-64
-  version: '2.43'
-  build: h712a8e2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
+  sha256: f40ce7324b2cf5338b766d4cdb8e0453e4156a4f83c2f31bbfff750785de304c
+  md5: bff0e851d66725f78dc2fd8b032ddb7e
+  license: LGPL-2.0-only
+  license_family: LGPL
+  purls: []
+  size: 528805
+  timestamp: 1664996399305
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
   sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
   md5: 048b02e3962f066da18efe3a21b77672
   depends:
@@ -6116,13 +5136,7 @@ packages:
   purls: []
   size: 669211
   timestamp: 1729655358674
-- kind: conda
-  name: ld_impl_linux-aarch64
-  version: '2.43'
-  build: h80caac9_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.43-h80caac9_2.conda
   sha256: 80ec7e8f006196808fac5bd4b3773a652847f97bbf08044cd87731424ac64f8b
   md5: fcbde5ea19d55468953bf588770c0501
   constrains:
@@ -6132,12 +5146,7 @@ packages:
   purls: []
   size: 698245
   timestamp: 1729655345825
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h27087fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
   sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
   md5: 76bbff344f0134279f225174e9064c8f
   depends:
@@ -6148,12 +5157,7 @@ packages:
   purls: []
   size: 281798
   timestamp: 1657977462600
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h4de3ea5_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
   sha256: 2d09ef9b7796d83364957e420b41c32d94e628c3f0520b61c332518a7b5cd586
   md5: 1a0ffc65e03ce81559dbcb0695ad1476
   depends:
@@ -6164,12 +5168,17 @@ packages:
   purls: []
   size: 262096
   timestamp: 1657978241894
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 215721
+  timestamp: 1657977558796
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
   sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
   md5: 1900cb3cab5055833cfddb0ba233b074
   depends:
@@ -6180,28 +5189,7 @@ packages:
   purls: []
   size: 194365
   timestamp: 1657977692274
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h9a09cb3_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
-  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
-  md5: de462d5aacda3b30721b512c5da4e742
-  depends:
-  - libcxx >=13.0.1
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 215721
-  timestamp: 1657977558796
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_h5888daf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240722.0-cxx17_h5888daf_1.conda
   sha256: 8f91429091183c26950f1e7ffa730e8632f0627ba35d2fccd71df31628c9b4e5
   md5: e1f604644fe8d78e22660e2fec6756bc
   depends:
@@ -6216,13 +5204,7 @@ packages:
   purls: []
   size: 1310521
   timestamp: 1727295454064
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_h5ad3122_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240722.0-cxx17_h5ad3122_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20240722.0-cxx17_h5ad3122_1.conda
   sha256: 590e47dce38031a8893e70491f3b71e214de7781cab53b6f017aa6f6841cb076
   md5: 6fe6b3694c4792a8e26755d3b06f0b80
   depends:
@@ -6236,13 +5218,21 @@ packages:
   purls: []
   size: 1328502
   timestamp: 1727295490806
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_he0c23c2_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
+  md5: 706da5e791c569a7b9814877098a6a0a
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  constrains:
+  - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1179072
+  timestamp: 1727295571173
+- conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240722.0-cxx17_he0c23c2_1.conda
   sha256: 52ff148dee1871ef1d5c298bae20309707e866b44714a0a333a5ed2cf9a38832
   md5: 3f59a73b07a05530b252ecb07dd882b9
   depends:
@@ -6257,48 +5247,7 @@ packages:
   purls: []
   size: 1777570
   timestamp: 1727296115119
-- kind: conda
-  name: libabseil
-  version: '20240722.0'
-  build: cxx17_hf9b8971_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
-  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
-  md5: 706da5e791c569a7b9814877098a6a0a
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  constrains:
-  - libabseil-static =20240722.0=cxx17*
-  - abseil-cpp =20240722.0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 1179072
-  timestamp: 1727295571173
-- kind: conda
-  name: libaec
-  version: 1.1.3
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
-  sha256: 9c366233b4f4bf11e64ce886055aaac34445205a178061923300872e0564a4f2
-  md5: e52c4a30901a90354855e40992af907d
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 35339
-  timestamp: 1711021162162
-- kind: conda
-  name: libaec
-  version: 1.1.3
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
   sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
   md5: 5e97e271911b8b2001a8b71860c32faa
   depends:
@@ -6309,12 +5258,28 @@ packages:
   purls: []
   size: 35446
   timestamp: 1711021212685
-- kind: conda
-  name: libaec
-  version: 1.1.3
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
+  sha256: 9c366233b4f4bf11e64ce886055aaac34445205a178061923300872e0564a4f2
+  md5: e52c4a30901a90354855e40992af907d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 35339
+  timestamp: 1711021162162
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
+  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 28451
+  timestamp: 1711021498493
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
   sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
   md5: 8723000f6ffdbdaef16025f0a01b64c5
   depends:
@@ -6326,73 +5291,7 @@ packages:
   purls: []
   size: 32567
   timestamp: 1711021603471
-- kind: conda
-  name: libaec
-  version: 1.1.3
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
-  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
-  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
-  depends:
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 28451
-  timestamp: 1711021498493
-- kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: h5728263_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
-  sha256: 8e41136b7e4ec44c1c0bae0ff51cdb0d04e026d0b44eaaf5a9ff8b4e1b6b019b
-  md5: 9f661052be1d477dcf61ee3cd77ce5ee
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 49776
-  timestamp: 1723629333404
-- kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: h8414b35_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8414b35_3.conda
-  sha256: 819bf95543470658f48db53a267a3fabe1616797c4031cf88e63f451c5029e6f
-  md5: 472b673c083175195965a48f2f4808f8
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 40657
-  timestamp: 1723626937704
-- kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: h87f4aca_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h87f4aca_3.conda
-  sha256: b438814a7190a541950da68d3cde8ecbcc55629ce677eb65afbb01cfa1e4e651
-  md5: 332ce64c2dec75dc0849e7ffcdf7a3a4
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 42627
-  timestamp: 1723626204541
-- kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: he8f35ee_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
   sha256: 2da5c735811cbf38c7f7844ab457ff8b25046bbf5fe5ebd5dc1c2fafdf4fbe1c
   md5: 4fab9799da9571266d05ca5503330655
   depends:
@@ -6403,29 +5302,34 @@ packages:
   purls: []
   size: 42817
   timestamp: 1723626012203
-- kind: conda
-  name: libasprintf-devel
-  version: 0.22.5
-  build: h87f4aca_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h87f4aca_3.conda
-  sha256: c9eda86140a5a023b72a8997f82629f4b071df17d57d00ba75a66b65a0525a5e
-  md5: dbaa9d8c0030bda3e3d22d325ea48191
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h87f4aca_3.conda
+  sha256: b438814a7190a541950da68d3cde8ecbcc55629ce677eb65afbb01cfa1e4e651
+  md5: 332ce64c2dec75dc0849e7ffcdf7a3a4
   depends:
-  - libasprintf 0.22.5 h87f4aca_3
   - libgcc-ng >=12
+  - libstdcxx-ng >=12
   license: LGPL-2.1-or-later
   purls: []
-  size: 34359
-  timestamp: 1723626223953
-- kind: conda
-  name: libasprintf-devel
-  version: 0.22.5
-  build: he8f35ee_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
+  size: 42627
+  timestamp: 1723626204541
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8414b35_3.conda
+  sha256: 819bf95543470658f48db53a267a3fabe1616797c4031cf88e63f451c5029e6f
+  md5: 472b673c083175195965a48f2f4808f8
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 40657
+  timestamp: 1723626937704
+- conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_3.conda
+  sha256: 8e41136b7e4ec44c1c0bae0ff51cdb0d04e026d0b44eaaf5a9ff8b4e1b6b019b
+  md5: 9f661052be1d477dcf61ee3cd77ce5ee
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 49776
+  timestamp: 1723629333404
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
   sha256: ccc7967e298ddf3124c8ad9741c7180dc6f778ae4135ec87978214f7b3c64dc2
   md5: 1091193789bb830127ed067a9e01ac57
   depends:
@@ -6436,12 +5340,17 @@ packages:
   purls: []
   size: 34172
   timestamp: 1723626026096
-- kind: conda
-  name: libass
-  version: 0.17.3
-  build: h1dc1e6a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h87f4aca_3.conda
+  sha256: c9eda86140a5a023b72a8997f82629f4b071df17d57d00ba75a66b65a0525a5e
+  md5: dbaa9d8c0030bda3e3d22d325ea48191
+  depends:
+  - libasprintf 0.22.5 h87f4aca_3
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 34359
+  timestamp: 1723626223953
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.3-h1dc1e6a_0.conda
   sha256: 52afd5e79681185ea33da0e7548aa3721be7e9a153a90f004c5adc33d61f7a14
   md5: 2a66267ba586dadd110cc991063cfff7
   depends:
@@ -6459,12 +5368,7 @@ packages:
   purls: []
   size: 133110
   timestamp: 1719985879751
-- kind: conda
-  name: libass
-  version: 0.17.3
-  build: hcc173ff_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.3-hcc173ff_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.3-hcc173ff_0.conda
   sha256: 93d84d22f9fa360c175ce6b0bdd4ec33c0f6399eb6e6a17fcbf8b34375343528
   md5: 7a3fcba797d23512f55ef23e68ae4ec9
   depends:
@@ -6481,12 +5385,7 @@ packages:
   purls: []
   size: 145939
   timestamp: 1719986023948
-- kind: conda
-  name: libass
-  version: 0.17.3
-  build: hf20b609_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.3-hf20b609_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.3-hf20b609_0.conda
   sha256: 2c03d080b48e65e4c488b4824b817fbdce5b79e18f49fc4e823819268b74bb7d
   md5: 50f6b3ead2c75c7c4009a8ed477d8142
   depends:
@@ -6503,13 +5402,8 @@ packages:
   purls: []
   size: 116755
   timestamp: 1719986027249
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-25_linux64_openblas.conda
   sha256: d6d12dc437d060f838820e9e61bf73baab651f91935ac594cf10beb9ef1b4450
   md5: 8ea26d42ca88ec5258802715fe1ee10b
   depends:
@@ -6525,13 +5419,8 @@ packages:
   purls: []
   size: 15677
   timestamp: 1729642900350
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_linuxaarch64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-25_linuxaarch64_openblas.conda
   build_number: 25
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-25_linuxaarch64_openblas.conda
   sha256: 5c08f78312874bb61307f5ea737377df2d0f6e7f7833ded21ca58d8820c794ca
   md5: f9b8a4a955ed2d0b68b1f453abcc1c9e
   depends:
@@ -6547,13 +5436,8 @@ packages:
   purls: []
   size: 15808
   timestamp: 1729643002627
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_osxarm64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
   build_number: 25
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-25_osxarm64_openblas.conda
   sha256: f1fb9a11af0b2878bd8804b4c77d3733c40076218bcbdb35f575b1c0c9fddf11
   md5: f8cf4d920ff36ce471619010eff59cac
   depends:
@@ -6569,13 +5453,8 @@ packages:
   purls: []
   size: 15913
   timestamp: 1729643265495
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-25_win64_mkl.conda
   sha256: 5468bb91c44b41ce060bbd997c797b2f91e2b7ce91a7cbf4ddf7e7b734a8dc98
   md5: 499208e81242efb6e5abc7366c91c816
   depends:
@@ -6590,60 +5469,7 @@ packages:
   purls: []
   size: 3736641
   timestamp: 1729643534444
-- kind: conda
-  name: libboost
-  version: 1.86.0
-  build: h29978a0_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.86.0-h29978a0_2.conda
-  sha256: d9e080b69dc963cab704d33439a7ed6d76b6c9eb644b63163eda2a32e3a1a799
-  md5: 3f5b15eed5e82e7ea8358a161e974ced
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - icu >=75.1,<76.0a0
-  - libcxx >=17
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - boost-cpp <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 2004506
-  timestamp: 1725334277168
-- kind: conda
-  name: libboost
-  version: 1.86.0
-  build: h444863b_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-1.86.0-h444863b_2.conda
-  sha256: a444cc7877f061b7f7c6195c806db183806f1f3a3b6ae26b1c9a89c89a049632
-  md5: 3208cfab6cdb23e6b49805a3771361f2
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - boost-cpp <0.0a0
-  license: BSL-1.0
-  purls: []
-  size: 2384613
-  timestamp: 1725335041520
-- kind: conda
-  name: libboost
-  version: 1.86.0
-  build: hb8260a3_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hb8260a3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hb8260a3_2.conda
   sha256: d2b5959c9d73486fba422b1f4f844447df110924860df5583847b7ca62e98a6e
   md5: 5e0ef327c03bb0092046cc9e964b3ceb
   depends:
@@ -6661,13 +5487,7 @@ packages:
   purls: []
   size: 3075722
   timestamp: 1725333797199
-- kind: conda
-  name: libboost
-  version: 1.86.0
-  build: hcc9b45e_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.86.0-hcc9b45e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libboost-1.86.0-hcc9b45e_2.conda
   sha256: 4b8fc3d46b64ba4e690a3d6eb9a1a7c38ac2e6c20f54c2621d796f1749c7015b
   md5: 9098a06de7a66110540ca2974f69a6b4
   depends:
@@ -6684,12 +5504,42 @@ packages:
   purls: []
   size: 3105189
   timestamp: 1725333795866
-- kind: conda
-  name: libcap
-  version: '2.69'
-  build: h0f662aa_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.86.0-h29978a0_2.conda
+  sha256: d9e080b69dc963cab704d33439a7ed6d76b6c9eb644b63163eda2a32e3a1a799
+  md5: 3f5b15eed5e82e7ea8358a161e974ced
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=17
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  purls: []
+  size: 2004506
+  timestamp: 1725334277168
+- conda: https://conda.anaconda.org/conda-forge/win-64/libboost-1.86.0-h444863b_2.conda
+  sha256: a444cc7877f061b7f7c6195c806db183806f1f3a3b6ae26b1c9a89c89a049632
+  md5: 3208cfab6cdb23e6b49805a3771361f2
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  purls: []
+  size: 2384613
+  timestamp: 1725335041520
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
   sha256: 942f9564b4228609f017b6617425d29a74c43b8a030e12239fa4458e5cb6323c
   md5: 25cb5999faa414e5ccb2c1388f62d3d5
   depends:
@@ -6700,12 +5550,7 @@ packages:
   purls: []
   size: 100582
   timestamp: 1684162447012
-- kind: conda
-  name: libcap
-  version: '2.69'
-  build: h883460d_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.69-h883460d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.69-h883460d_0.conda
   sha256: c0944a372d2d2d961cb86726fad17950219f10837bed281ac22127cb3889b06d
   md5: fd395b538afc08d28c0db275a42c8078
   depends:
@@ -6716,13 +5561,8 @@ packages:
   purls: []
   size: 103105
   timestamp: 1684162437148
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-25_linux64_openblas.conda
   sha256: ab87b0477078837c91d9cda62a9faca18fba7c57cc77aa779ae24b3ac783b5dd
   md5: 5dbd1b0fc0d01ec5e0e1fbe667281a11
   depends:
@@ -6736,13 +5576,8 @@ packages:
   purls: []
   size: 15613
   timestamp: 1729642905619
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_linuxaarch64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-25_linuxaarch64_openblas.conda
   build_number: 25
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-25_linuxaarch64_openblas.conda
   sha256: fde797e5528040fed0e9228dd75331be0cf5cbb0bc63641f53c3cca9eb86ec16
   md5: db6af51123c67814572a8c25542cb368
   depends:
@@ -6756,13 +5591,8 @@ packages:
   purls: []
   size: 15700
   timestamp: 1729643006729
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_osxarm64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
   build_number: 25
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-25_osxarm64_openblas.conda
   sha256: d9fa5b6b11252132a3383bbf87bd2f1b9d6248bef1b7e113c2a8ae41b0376218
   md5: 4df0fae81f0b5bf47d48c882b086da11
   depends:
@@ -6776,13 +5606,8 @@ packages:
   purls: []
   size: 15837
   timestamp: 1729643270793
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-25_win64_mkl.conda
   sha256: 21528cdfe67dafdb2d21925515a167f13963e002c2b6d06d68984767f731850c
   md5: 3ed189ba03a9888a8013aaee0d67c49d
   depends:
@@ -6796,32 +5621,7 @@ packages:
   purls: []
   size: 3732258
   timestamp: 1729643561581
-- kind: conda
-  name: libccd-double
-  version: '2.1'
-  build: h2f0025b_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libccd-double-2.1-h2f0025b_3.conda
-  sha256: 98abf6dd8f17fe1fabc2828d934f8c96ea21b4e27cff6c7c12bd2a31827ea669
-  md5: 3898f9a528720cc10e8c62e08e1a11ea
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  constrains:
-  - libccd <1
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 34226
-  timestamp: 1687341851768
-- kind: conda
-  name: libccd-double
-  version: '2.1'
-  build: h59595ed_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libccd-double-2.1-h59595ed_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libccd-double-2.1-h59595ed_3.conda
   sha256: 4695ce68eda595b4f53146bea1096a9f2e0d33290618ba83a246b5ed8871ebc9
   md5: 6a3d962d34385e0a511b859d679f6ea2
   depends:
@@ -6834,13 +5634,32 @@ packages:
   purls: []
   size: 36171
   timestamp: 1687341825064
-- kind: conda
-  name: libccd-double
-  version: '2.1'
-  build: h63175ca_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libccd-double-2.1-h63175ca_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libccd-double-2.1-h2f0025b_3.conda
+  sha256: 98abf6dd8f17fe1fabc2828d934f8c96ea21b4e27cff6c7c12bd2a31827ea669
+  md5: 3898f9a528720cc10e8c62e08e1a11ea
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - libccd <1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 34226
+  timestamp: 1687341851768
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libccd-double-2.1-h9a09cb3_2.tar.bz2
+  sha256: eaba0b8153f4346229a0c52916a13fbedd689a3d3b31f4196bac65ece9050b8e
+  md5: 4d27a7d50c8d4bcafe33c9215e66251c
+  depends:
+  - libcxx >=13.0.1
+  constrains:
+  - libccd <1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 29852
+  timestamp: 1654586481871
+- conda: https://conda.anaconda.org/conda-forge/win-64/libccd-double-2.1-h63175ca_3.conda
   sha256: 0e967ccf9d0de3778bf08a5905a082f5aa036afa85954441bf935f65df0e2fca
   md5: a5e539b436324684efb811b0d3e66aff
   depends:
@@ -6854,31 +5673,7 @@ packages:
   purls: []
   size: 36657
   timestamp: 1687342325491
-- kind: conda
-  name: libccd-double
-  version: '2.1'
-  build: h9a09cb3_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libccd-double-2.1-h9a09cb3_2.tar.bz2
-  sha256: eaba0b8153f4346229a0c52916a13fbedd689a3d3b31f4196bac65ece9050b8e
-  md5: 4d27a7d50c8d4bcafe33c9215e66251c
-  depends:
-  - libcxx >=13.0.1
-  constrains:
-  - libccd <1
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 29852
-  timestamp: 1654586481871
-- kind: conda
-  name: libclang-cpp17
-  version: 17.0.6
-  build: default_h146c034_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_h146c034_7.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_h146c034_7.conda
   sha256: 2e338629ae19faae0d1a85543b8c84441ead61957cf69a65c0031d5b18ebac08
   md5: bc6797a6a66ec6f919cc8d4d9285b11c
   depends:
@@ -6890,12 +5685,7 @@ packages:
   purls: []
   size: 12408943
   timestamp: 1725505311206
-- kind: conda
-  name: libclang-cpp19.1
-  version: 19.1.3
-  build: default_hb5137d0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.3-default_hb5137d0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.3-default_hb5137d0_0.conda
   sha256: 576c1826a91f93ef7c433fc6481334d21177996bd72ff6901f58fae8f6a765db
   md5: 311e6a1d041db3d6a8a8437750d4234f
   depends:
@@ -6908,12 +5698,7 @@ packages:
   purls: []
   size: 20548148
   timestamp: 1730335997703
-- kind: conda
-  name: libclang-cpp19.1
-  version: 19.1.3
-  build: default_he324ac1_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.3-default_he324ac1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.3-default_he324ac1_0.conda
   sha256: fe708e1e180f77e414cc83e78b3171fbb4bd453a64a74a022918ddaeed654ef0
   md5: 9ac4956d6676bdb251279d8c27406954
   depends:
@@ -6925,46 +5710,7 @@ packages:
   purls: []
   size: 20104055
   timestamp: 1730333285641
-- kind: conda
-  name: libclang13
-  version: 19.1.3
-  build: default_h4390ef5_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.3-default_h4390ef5_0.conda
-  sha256: 95ca8571d07fd61851e04786d1c6d9830427c72a03873fb7c8b6b4114e548bb8
-  md5: d23cae404c2763d07fee33a9299f2d63
-  depends:
-  - libgcc >=13
-  - libllvm19 >=19.1.3,<19.2.0a0
-  - libstdcxx >=13
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  purls: []
-  size: 11612409
-  timestamp: 1730333501142
-- kind: conda
-  name: libclang13
-  version: 19.1.3
-  build: default_h5f28f6d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-19.1.3-default_h5f28f6d_0.conda
-  sha256: 88867feff3fa105505da9e74c334ba994ca9328c6deec640001d43e9d0c93f82
-  md5: 883e1a71b3c28fee013bae5459ed394c
-  depends:
-  - __osx >=11.0
-  - libcxx >=19.1.3
-  - libllvm19 >=19.1.3,<19.2.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  purls: []
-  size: 8060128
-  timestamp: 1730332344891
-- kind: conda
-  name: libclang13
-  version: 19.1.3
-  build: default_h9c6a7e4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.3-default_h9c6a7e4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.3-default_h9c6a7e4_0.conda
   sha256: 7537cfefd76ffb0208484a2dc7d35d3752c6c42c80edabbc5f0dcae354d4b41e
   md5: b8a8cd77810b20754f358f2327812552
   depends:
@@ -6977,12 +5723,31 @@ packages:
   purls: []
   size: 11827604
   timestamp: 1730336232401
-- kind: conda
-  name: libclang13
-  version: 19.1.3
-  build: default_ha5278ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-19.1.3-default_ha5278ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.3-default_h4390ef5_0.conda
+  sha256: 95ca8571d07fd61851e04786d1c6d9830427c72a03873fb7c8b6b4114e548bb8
+  md5: d23cae404c2763d07fee33a9299f2d63
+  depends:
+  - libgcc >=13
+  - libllvm19 >=19.1.3,<19.2.0a0
+  - libstdcxx >=13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 11612409
+  timestamp: 1730333501142
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-19.1.3-default_h5f28f6d_0.conda
+  sha256: 88867feff3fa105505da9e74c334ba994ca9328c6deec640001d43e9d0c93f82
+  md5: 883e1a71b3c28fee013bae5459ed394c
+  depends:
+  - __osx >=11.0
+  - libcxx >=19.1.3
+  - libllvm19 >=19.1.3,<19.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 8060128
+  timestamp: 1730332344891
+- conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-19.1.3-default_ha5278ca_0.conda
   sha256: 02e9e0ee3f9a7b375d1a268f90f1f2ffe31bccacb904b9f36270255e9a02df6e
   md5: fe6aa50eeb307558f8974f115305388f
   depends:
@@ -6996,32 +5761,7 @@ packages:
   purls: []
   size: 26749218
   timestamp: 1730355727736
-- kind: conda
-  name: libcups
-  version: 2.3.3
-  build: h405e4a8_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
-  sha256: f9007d5ca44741de72f9d7be03e74c911b61af062ed7a3761594675f30f5890c
-  md5: d42c670b0c96c1795fd859d5e0275a55
-  depends:
-  - krb5 >=1.21.1,<1.22.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 4551247
-  timestamp: 1689195336749
-- kind: conda
-  name: libcups
-  version: 2.3.3
-  build: h4637d8d_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
   sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
   md5: d4529f4dff3057982a7617c7ac58fde3
   depends:
@@ -7034,74 +5774,20 @@ packages:
   purls: []
   size: 4519402
   timestamp: 1689195353551
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: h13a7ad3_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
-  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
-  md5: d84030d0863ffe7dea00b9a807fee961
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
+  sha256: f9007d5ca44741de72f9d7be03e74c911b61af062ed7a3761594675f30f5890c
+  md5: d42c670b0c96c1795fd859d5e0275a55
   depends:
-  - __osx >=11.0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: curl
-  license_family: MIT
+  - krb5 >=1.21.1,<1.22.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: Apache-2.0
+  license_family: Apache
   purls: []
-  size: 379948
-  timestamp: 1726660033582
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: h1ee3ff0_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
-  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
-  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
-  depends:
-  - krb5 >=1.21.3,<1.22.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: curl
-  license_family: MIT
-  purls: []
-  size: 342388
-  timestamp: 1726660508261
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: h3ec0cbf_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.10.1-h3ec0cbf_0.conda
-  sha256: 7c4983001c727f713b4448280ed4803d301087c184cd2819ba0b788ca62b73d1
-  md5: f43539295c4e0cd15202d41bc72b8a26
-  depends:
-  - krb5 >=1.21.3,<1.22.0a0
-  - libgcc >=13
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: curl
-  license_family: MIT
-  purls: []
-  size: 439171
-  timestamp: 1726659843118
-- kind: conda
-  name: libcurl
-  version: 8.10.1
-  build: hbbe4b11_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
+  size: 4551247
+  timestamp: 1689195336749
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
   sha256: 54e6114dfce566c3a22ad3b7b309657e3600cdb668398e95f1301360d5d52c99
   md5: 6e801c50a40301f6978c53976917b277
   depends:
@@ -7118,12 +5804,54 @@ packages:
   purls: []
   size: 424900
   timestamp: 1726659794676
-- kind: conda
-  name: libcxx
-  version: 19.1.3
-  build: ha82da77_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.3-ha82da77_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.10.1-h3ec0cbf_0.conda
+  sha256: 7c4983001c727f713b4448280ed4803d301087c184cd2819ba0b788ca62b73d1
+  md5: f43539295c4e0cd15202d41bc72b8a26
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  size: 439171
+  timestamp: 1726659843118
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
+  sha256: 983a977c5627f975a930542c8aabb46089ec6ea72f28d9c4d3ee8eafaf2fc25a
+  md5: d84030d0863ffe7dea00b9a807fee961
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  size: 379948
+  timestamp: 1726660033582
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  purls: []
+  size: 342388
+  timestamp: 1726660508261
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.3-ha82da77_0.conda
   sha256: 6d062760c6439e75b9a44d800d89aff60fe3441998d87506c62dc94c50412ef4
   md5: bf691071fba4734984231617783225bc
   depends:
@@ -7133,12 +5861,38 @@ packages:
   purls: []
   size: 520771
   timestamp: 1730314603920
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
+  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
+  md5: b422943d5d772b7cc858b36ad2a92db5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 72242
+  timestamp: 1728177071251
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.22-h86ecc28_0.conda
+  sha256: 986207f130703897300ddc3637c52e86a5b21c735fe384bf48554d9a6d91c56d
+  md5: ff6a44e8b1707d02be2fe9a36ea88d4a
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 69601
+  timestamp: 1728177137503
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
+  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
+  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 54089
+  timestamp: 1728177149927
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.22-h2466b09_0.conda
   sha256: 579c634b7de8869cb1d76eccd4c032dc275d5a017212128502ea4dc828a5b361
   md5: a3439ce12d4e3cd887270d9436f9a4c8
   depends:
@@ -7150,74 +5904,7 @@ packages:
   purls: []
   size: 155506
   timestamp: 1728177485361
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.22-h86ecc28_0.conda
-  sha256: 986207f130703897300ddc3637c52e86a5b21c735fe384bf48554d9a6d91c56d
-  md5: ff6a44e8b1707d02be2fe9a36ea88d4a
-  depends:
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 69601
-  timestamp: 1728177137503
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
-  sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
-  md5: b422943d5d772b7cc858b36ad2a92db5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 72242
-  timestamp: 1728177071251
-- kind: conda
-  name: libdeflate
-  version: '1.22'
-  build: hd74edd7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.22-hd74edd7_0.conda
-  sha256: 3552894ca62bebc33d05982937cda25a4fa19e56a82af2ff20944ff4c2532fda
-  md5: 2d3e3f3d8ab315748420ef58d5a3ae0f
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 54089
-  timestamp: 1728177149927
-- kind: conda
-  name: libdrm
-  version: 2.4.123
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.123-h86ecc28_0.conda
-  sha256: 9a5dc3585a6468b266fc80e21fd2b6f3d8236818ee3fa853b6972ab0a44d7804
-  md5: 4e3c67f6999ea7ccac41611f930d19d4
-  depends:
-  - libgcc-ng >=13
-  - libpciaccess >=0.18,<0.19.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 273843
-  timestamp: 1724719291504
-- kind: conda
-  name: libdrm
-  version: 2.4.123
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
   sha256: 5f274243fc7480b721a4ed6623c72d07b86a508a1363a85f0f16451ab655ace8
   md5: ee605e794bdc14e2b7f84c4faa0d8c2c
   depends:
@@ -7229,29 +5916,18 @@ packages:
   purls: []
   size: 303108
   timestamp: 1724719521496
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: hc8eb9b7_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
-  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
-  md5: 30e4362988a2623e9eb34337b83e01f9
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdrm-2.4.123-h86ecc28_0.conda
+  sha256: 9a5dc3585a6468b266fc80e21fd2b6f3d8236818ee3fa853b6972ab0a44d7804
+  md5: 4e3c67f6999ea7ccac41611f930d19d4
   depends:
-  - ncurses >=6.2,<7.0.0a0
-  license: BSD-2-Clause
-  license_family: BSD
+  - libgcc-ng >=13
+  - libpciaccess >=0.18,<0.19.0a0
+  license: MIT
+  license_family: MIT
   purls: []
-  size: 96607
-  timestamp: 1597616630749
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: he28a2e2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  size: 273843
+  timestamp: 1724719291504
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
   md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
   depends:
@@ -7262,13 +5938,7 @@ packages:
   purls: []
   size: 123878
   timestamp: 1597616541093
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: he28a2e2_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   sha256: debc31fb2f07ba2b0363f90e455873670734082822926ba4a9556431ec0bf36d
   md5: 29371161d77933a54fccf1bb66b96529
   depends:
@@ -7279,13 +5949,17 @@ packages:
   purls: []
   size: 134104
   timestamp: 1597617110769
-- kind: conda
-  name: libegl
-  version: 1.7.0
-  build: ha4b6fd6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  md5: 30e4362988a2623e9eb34337b83e01f9
+  depends:
+  - ncurses >=6.2,<7.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 96607
+  timestamp: 1597616630749
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_1.conda
   sha256: e64388e983cf14354b70fe908ca3943f2481ea63df8a4de5e4d418dc2addd38e
   md5: 38a5cd3be5fb620b48069e27285f1a44
   depends:
@@ -7295,13 +5969,7 @@ packages:
   purls: []
   size: 44620
   timestamp: 1727968589748
-- kind: conda
-  name: libegl
-  version: 1.7.0
-  build: hd24410f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libegl-1.7.0-hd24410f_1.conda
   sha256: 52cc18200fefa4a65852421c6fd1ccff57e598d2c331574b9093258a4ee774a2
   md5: f82d2736a04324c05bdce1c39a57fee6
   depends:
@@ -7310,33 +5978,7 @@ packages:
   purls: []
   size: 53358
   timestamp: 1727968557699
-- kind: conda
-  name: libergocub-software
-  version: 0.7.5
-  build: h21e95ee_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libergocub-software-0.7.5-h21e95ee_1.conda
-  sha256: 7eba67d1b601720b11b03523667dd15e3bfb6ea3d8c6d09ae7140640d2f2c77e
-  md5: 6962ccc955676095d2be4636aa219d3c
-  depends:
-  - libopencv >=4.10.0,<4.10.1.0a0
-  - libyarp >=3.9.0,<3.9.1.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 6681269
-  timestamp: 1726698568811
-- kind: conda
-  name: libergocub-software
-  version: 0.7.5
-  build: h30dabe4_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libergocub-software-0.7.5-h30dabe4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libergocub-software-0.7.5-h30dabe4_1.conda
   sha256: 2f2e9e00e6b77e445c7fad24a902d1e8612954d20ae5d56336a42772f1730f0b
   md5: 64558e622297fdf3e9b274b0282c8da6
   depends:
@@ -7350,13 +5992,7 @@ packages:
   purls: []
   size: 6774050
   timestamp: 1726697330835
-- kind: conda
-  name: libergocub-software
-  version: 0.7.5
-  build: h37d1830_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libergocub-software-0.7.5-h37d1830_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libergocub-software-0.7.5-h37d1830_1.conda
   sha256: 20e0ae270666957cf22c9eee4f33d31712fb4e665a31d220a511eafb98dfb1fd
   md5: 60fb3fac467305a06280eea152527d1c
   depends:
@@ -7369,13 +6005,7 @@ packages:
   purls: []
   size: 6807587
   timestamp: 1726697481382
-- kind: conda
-  name: libergocub-software
-  version: 0.7.5
-  build: h91bdf57_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libergocub-software-0.7.5-h91bdf57_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libergocub-software-0.7.5-h91bdf57_1.conda
   sha256: 302c0362943038a6678ed28a4276cf529a3955cf6f512421c36f13c98b434ac6
   md5: 9ff99a5ced64cdb35106ffbf406c8b40
   depends:
@@ -7388,43 +6018,21 @@ packages:
   purls: []
   size: 6774400
   timestamp: 1726697608007
-- kind: conda
-  name: libev
-  version: '4.33'
-  build: h31becfc_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
-  sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
-  md5: a9a13cb143bbaa477b1ebaefbe47a302
+- conda: https://conda.anaconda.org/conda-forge/win-64/libergocub-software-0.7.5-h21e95ee_1.conda
+  sha256: 7eba67d1b601720b11b03523667dd15e3bfb6ea3d8c6d09ae7140640d2f2c77e
+  md5: 6962ccc955676095d2be4636aa219d3c
   depends:
-  - libgcc-ng >=12
-  license: BSD-2-Clause
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libyarp >=3.9.0,<3.9.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 115123
-  timestamp: 1702146237623
-- kind: conda
-  name: libev
-  version: '4.33'
-  build: h93a5062_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
-  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
-  md5: 36d33e440c31857372a72137f78bacf5
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 107458
-  timestamp: 1702146414478
-- kind: conda
-  name: libev
-  version: '4.33'
-  build: hd590300_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  size: 6681269
+  timestamp: 1726698568811
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
   sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
   md5: 172bf1cd1ff8629f2b1179945ed45055
   depends:
@@ -7434,30 +6042,25 @@ packages:
   purls: []
   size: 112766
   timestamp: 1702146165126
-- kind: conda
-  name: libevent
-  version: 2.1.12
-  build: h4ba1bb4_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
-  sha256: 01333cc7d6e6985dd5700b43660d90e9e58049182017fd24862088ecbe1458e4
-  md5: 96ae6083cd1ac9f6bc81631ac835b317
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+  sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
+  md5: a9a13cb143bbaa477b1ebaefbe47a302
   depends:
   - libgcc-ng >=12
-  - openssl >=3.1.1,<4.0a0
-  license: BSD-3-Clause
+  license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 438992
-  timestamp: 1685726046519
-- kind: conda
-  name: libevent
-  version: 2.1.12
-  build: hf998b51_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  size: 115123
+  timestamp: 1702146237623
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+  md5: 36d33e440c31857372a72137f78bacf5
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 107458
+  timestamp: 1702146414478
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
   sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
   md5: a1cfcc585f0c42bf8d5546bb1dfb668d
   depends:
@@ -7468,29 +6071,18 @@ packages:
   purls: []
   size: 427426
   timestamp: 1685725977222
-- kind: conda
-  name: libexpat
-  version: 2.6.4
-  build: h286801f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
-  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
-  md5: 38d2656dd914feb0cab8c629370768bf
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
+  sha256: 01333cc7d6e6985dd5700b43660d90e9e58049182017fd24862088ecbe1458e4
+  md5: 96ae6083cd1ac9f6bc81631ac835b317
   depends:
-  - __osx >=11.0
-  constrains:
-  - expat 2.6.4.*
-  license: MIT
-  license_family: MIT
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
   purls: []
-  size: 64693
-  timestamp: 1730967175868
-- kind: conda
-  name: libexpat
-  version: 2.6.4
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
+  size: 438992
+  timestamp: 1685726046519
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.4-h5888daf_0.conda
   sha256: 56541b98447b58e52d824bd59d6382d609e11de1f8adf20b23143e353d2b8d26
   md5: db833e03127376d461e1e13e76f09b6c
   depends:
@@ -7503,12 +6095,7 @@ packages:
   purls: []
   size: 73304
   timestamp: 1730967041968
-- kind: conda
-  name: libexpat
-  version: 2.6.4
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.4-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.4-h5ad3122_0.conda
   sha256: f42e758009ba9db90d1fe7992bc3e60d0c52f71fb20923375d2c44ae69a5a2b3
   md5: f1b3fab36861b3ce945a13f0dfdfc688
   depends:
@@ -7520,12 +6107,19 @@ packages:
   purls: []
   size: 72345
   timestamp: 1730967203789
-- kind: conda
-  name: libexpat
-  version: 2.6.4
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+  sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+  md5: 38d2656dd914feb0cab8c629370768bf
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 64693
+  timestamp: 1730967175868
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.4-he0c23c2_0.conda
   sha256: 0c0447bf20d1013d5603499de93a16b6faa92d7ead870d96305c0f065b6a5a12
   md5: eb383771c680aa792feb529eaf9df82f
   depends:
@@ -7539,43 +6133,7 @@ packages:
   purls: []
   size: 139068
   timestamp: 1730967442102
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h3422bc3_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
-  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
-  md5: 086914b672be056eb70fd4285b6783b6
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 39020
-  timestamp: 1636488587153
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h3557bc0_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
-  sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
-  md5: dddd85f4d52121fab0a8b099c5e06501
-  depends:
-  - libgcc-ng >=9.4.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 59450
-  timestamp: 1636488255090
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h7f98852_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
   sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
   md5: d645c6d2ac96843a2bfaccd2d62b3ac3
   depends:
@@ -7585,13 +6143,25 @@ packages:
   purls: []
   size: 58292
   timestamp: 1636488182923
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h8ffe710_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
+  sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
+  md5: dddd85f4d52121fab0a8b099c5e06501
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 59450
+  timestamp: 1636488255090
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 39020
+  timestamp: 1636488587153
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
   sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
   md5: 2c96d1b6915b408893f9472569dee135
   depends:
@@ -7602,31 +6172,7 @@ packages:
   purls: []
   size: 42063
   timestamp: 1636489106777
-- kind: conda
-  name: libflac
-  version: 1.4.3
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
-  sha256: b54935360349d3418b0663d787f20b3cba0b7ce3fcdf3ba5e7ef02b884759049
-  md5: 520b12eab32a92e19b1f239ac545ec03
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - libgcc-ng >=12
-  - libogg 1.3.*
-  - libogg >=1.3.4,<1.4.0a0
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 371550
-  timestamp: 1687765491794
-- kind: conda
-  name: libflac
-  version: 1.4.3
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
   sha256: 65908b75fa7003167b8a8f0001e11e58ed5b1ef5e98b96ab2ba66d7c1b822c7d
   md5: ee48bf17cc83a00f59ca1494d5646869
   depends:
@@ -7640,33 +6186,33 @@ packages:
   purls: []
   size: 394383
   timestamp: 1687765514062
-- kind: conda
-  name: libflang
-  version: 5.0.0
-  build: h6538335_20180525
-  build_number: 20180525
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
+  sha256: b54935360349d3418b0663d787f20b3cba0b7ce3fcdf3ba5e7ef02b884759049
+  md5: 520b12eab32a92e19b1f239ac545ec03
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libogg 1.3.*
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 371550
+  timestamp: 1687765491794
+- conda: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
   sha256: 0b893b511190332320f4a3e3d6424fbd350271ffbca34eb25b5cd8bc451f1a05
   md5: 9f473a344e18668e99a93f7e21a54b69
   depends:
   - openmp 5.0.0
   - vc >=14,<15.0a0
-  arch: x86_64
-  platform: win
   track_features:
   - flang
   license: Apache 2.0
   purls: []
   size: 531143
   timestamp: 1527899216421
-- kind: conda
-  name: libgcc
-  version: 14.2.0
-  build: h77fa898_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h77fa898_1.conda
   sha256: 53eb8a79365e58849e7b1a068d31f4f9e718dc938d6f2c03e960345739a03569
   md5: 3cb76c3f10d3bc7f1105b2fc9db984df
   depends:
@@ -7680,13 +6226,7 @@ packages:
   purls: []
   size: 848745
   timestamp: 1729027721139
-- kind: conda
-  name: libgcc
-  version: 14.2.0
-  build: he277a41_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_1.conda
   sha256: 5d56757ccad208c79214395b00d006d8d18929a4ba49c47bd9460789a7620943
   md5: 511b511c5445e324066c3377481bcab8
   depends:
@@ -7699,13 +6239,7 @@ packages:
   purls: []
   size: 535243
   timestamp: 1729089435134
-- kind: conda
-  name: libgcc-ng
-  version: 14.2.0
-  build: h69a702a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_1.conda
   sha256: 3a76969c80e9af8b6e7a55090088bc41da4cffcde9e2c71b17f44d37b7cb87f7
   md5: e39480b9ca41323497b05492a63bc35b
   depends:
@@ -7715,13 +6249,7 @@ packages:
   purls: []
   size: 54142
   timestamp: 1729027726517
-- kind: conda
-  name: libgcc-ng
-  version: 14.2.0
-  build: he9431aa_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_1.conda
   sha256: 9b5cf168a6c7361cae869cb74b716766ee7c6d6b3f6172b32ba9bf91135efdc4
   md5: 0694c249c61469f2c0f7e2990782af21
   depends:
@@ -7731,13 +6259,7 @@ packages:
   purls: []
   size: 54104
   timestamp: 1729089444587
-- kind: conda
-  name: libgcrypt
-  version: 1.11.0
-  build: h4ab18f5_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-h4ab18f5_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-h4ab18f5_1.conda
   sha256: 9e97e4a753d2ee238cfc7375f0882830f0d8c1667431bc9d070a0f6718355570
   md5: 14858a47d4cc995892e79f2b340682d7
   depends:
@@ -7748,13 +6270,7 @@ packages:
   purls: []
   size: 684307
   timestamp: 1721392291497
-- kind: conda
-  name: libgcrypt
-  version: 1.11.0
-  build: h68df207_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.11.0-h68df207_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.11.0-h68df207_1.conda
   sha256: c0b09d4135a3d613c0ca6d52b5efa0c043bc497bcfe1c80d9b8385c40990f298
   md5: 75b5ba9d835a79c15a27cb7af804762f
   depends:
@@ -7765,13 +6281,18 @@ packages:
   purls: []
   size: 736802
   timestamp: 1721392376840
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: h0a1ffab_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h0a1ffab_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
+  sha256: 7f2d1f4d69973e2c3c3d2b6420d5eb989982baba97d63ab2d7a2b25a92d886b4
+  md5: efab66b82ec976930b96d62a976de8e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  purls: []
+  size: 170646
+  timestamp: 1723626019265
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h0a1ffab_3.conda
   sha256: f816747b63432def4bfe2bfa517057149b2b94a48101fe13e7fcc2c223ec2042
   md5: 263a0b8af4b3fcdb35acc4038bb5bff5
   depends:
@@ -7781,30 +6302,7 @@ packages:
   purls: []
   size: 199824
   timestamp: 1723626215655
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: h5728263_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
-  sha256: 6747bd29a0896b21ee1fe07bd212210475655354a3e8033c25b797e054ddd821
-  md5: e46c142e2d2d9ccef31ad3d176b10fab
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_3
-  license: GPL-3.0-or-later
-  license_family: GPL
-  purls: []
-  size: 171120
-  timestamp: 1723629671164
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: h8414b35_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8414b35_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8414b35_3.conda
   sha256: bc446fad58155e96a01b28e99254415c2151bdddf57f9a2c00c44e6f0298bb62
   md5: c8cd7295cfb7bda5cbabea4fef904349
   depends:
@@ -7816,47 +6314,18 @@ packages:
   purls: []
   size: 159800
   timestamp: 1723627007035
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: he02047a_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
-  sha256: 7f2d1f4d69973e2c3c3d2b6420d5eb989982baba97d63ab2d7a2b25a92d886b4
-  md5: efab66b82ec976930b96d62a976de8e7
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_3.conda
+  sha256: 6747bd29a0896b21ee1fe07bd212210475655354a3e8033c25b797e054ddd821
+  md5: e46c142e2d2d9ccef31ad3d176b10fab
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5728263_3
   license: GPL-3.0-or-later
   license_family: GPL
   purls: []
-  size: 170646
-  timestamp: 1723626019265
-- kind: conda
-  name: libgettextpo-devel
-  version: 0.22.5
-  build: h0a1ffab_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h0a1ffab_3.conda
-  sha256: 677df7af241b36c6b06dff52528c2a8e4f42f8cf40d962e693caa707b563c86c
-  md5: 5c1498c4da030824d57072f05220aad8
-  depends:
-  - libgcc-ng >=12
-  - libgettextpo 0.22.5 h0a1ffab_3
-  license: GPL-3.0-or-later
-  license_family: GPL
-  purls: []
-  size: 36989
-  timestamp: 1723626232155
-- kind: conda
-  name: libgettextpo-devel
-  version: 0.22.5
-  build: he02047a_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
+  size: 171120
+  timestamp: 1723629671164
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
   sha256: 0a66cdd46d1cd5201061252535cd91905b3222328a9294c1a5bcd32e85531545
   md5: 9aba7960731e6b4547b3a52f812ed801
   depends:
@@ -7868,29 +6337,18 @@ packages:
   purls: []
   size: 36790
   timestamp: 1723626032786
-- kind: conda
-  name: libgfortran
-  version: 5.0.0
-  build: 13_2_0_hd922786_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
-  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
-  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h0a1ffab_3.conda
+  sha256: 677df7af241b36c6b06dff52528c2a8e4f42f8cf40d962e693caa707b563c86c
+  md5: 5c1498c4da030824d57072f05220aad8
   depends:
-  - libgfortran5 13.2.0 hf226fd6_3
-  license: GPL-3.0-only WITH GCC-exception-3.1
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 h0a1ffab_3
+  license: GPL-3.0-or-later
   license_family: GPL
   purls: []
-  size: 110233
-  timestamp: 1707330749033
-- kind: conda
-  name: libgfortran
-  version: 14.2.0
-  build: h69a702a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
+  size: 36989
+  timestamp: 1723626232155
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_1.conda
   sha256: fc9e7f22a17faf74da904ebfc4d88699013d2992e55505e4aa0eb01770290977
   md5: f1fd30127802683586f768875127a987
   depends:
@@ -7902,13 +6360,7 @@ packages:
   purls: []
   size: 53997
   timestamp: 1729027752995
-- kind: conda
-  name: libgfortran
-  version: 14.2.0
-  build: he9431aa_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_1.conda
   sha256: cb66e411fa32a5c6040f4e5e2a63c00897aae4c3133a9c004c2e929ccf19575b
   md5: 0294b92d2f47a240bebb1e3336b495f1
   depends:
@@ -7920,13 +6372,17 @@ packages:
   purls: []
   size: 54105
   timestamp: 1729089471124
-- kind: conda
-  name: libgfortran-ng
-  version: 14.2.0
-  build: h69a702a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
+  sha256: 44e541b4821c96b28b27fef5630883a60ce4fee91fd9c79f25a199f8f73f337b
+  md5: 4a55d9e169114b2b90d3ec4604cd7bbf
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 110233
+  timestamp: 1707330749033
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
   sha256: 423f1e2403f0c665748e42d335e421e53fd03c08d457cfb6f360d329d9459851
   md5: 0a7f4cd238267c88e5d69f7826a407eb
   depends:
@@ -7936,13 +6392,7 @@ packages:
   purls: []
   size: 54106
   timestamp: 1729027945817
-- kind: conda
-  name: libgfortran-ng
-  version: 14.2.0
-  build: he9431aa_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.2.0-he9431aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.2.0-he9431aa_1.conda
   sha256: cdd5bae1e33d6bdafe837c2e6ea594faf5bb7f880272ac1984468c7967adff41
   md5: 5e90005d310d69708ba0aa7f4fed1de6
   depends:
@@ -7952,49 +6402,7 @@ packages:
   purls: []
   size: 54111
   timestamp: 1729089714658
-- kind: conda
-  name: libgfortran5
-  version: 13.2.0
-  build: hf226fd6_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
-  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
-  md5: 66ac81d54e95c534ae488726c1f698ea
-  depends:
-  - llvm-openmp >=8.0.0
-  constrains:
-  - libgfortran 5.0.0 13_2_0_*_3
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 997381
-  timestamp: 1707330687590
-- kind: conda
-  name: libgfortran5
-  version: 14.2.0
-  build: hb6113d0_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_1.conda
-  sha256: a87ff46d19916403cbf68cf1d785bf56b4d1ab7b2552468d2ea775d70782493f
-  md5: fc068e11b10e18f184e027782baa12b6
-  depends:
-  - libgcc >=14.2.0
-  constrains:
-  - libgfortran 14.2.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 1102158
-  timestamp: 1729089452640
-- kind: conda
-  name: libgfortran5
-  version: 14.2.0
-  build: hd5240d6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
   sha256: d149a37ca73611e425041f33b9d8dbed6e52ec506fe8cc1fc0ee054bddeb6d5d
   md5: 9822b874ea29af082e5d36098d25427d
   depends:
@@ -8006,13 +6414,31 @@ packages:
   purls: []
   size: 1462645
   timestamp: 1729027735353
-- kind: conda
-  name: libgl
-  version: 1.7.0
-  build: ha4b6fd6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_1.conda
+  sha256: a87ff46d19916403cbf68cf1d785bf56b4d1ab7b2552468d2ea775d70782493f
+  md5: fc068e11b10e18f184e027782baa12b6
+  depends:
+  - libgcc >=14.2.0
+  constrains:
+  - libgfortran 14.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 1102158
+  timestamp: 1729089452640
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
+  sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  md5: 66ac81d54e95c534ae488726c1f698ea
+  depends:
+  - llvm-openmp >=8.0.0
+  constrains:
+  - libgfortran 5.0.0 13_2_0_*_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 997381
+  timestamp: 1707330687590
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_1.conda
   sha256: 2de573a2231d0ffa13242e274d33b7bae88fb0a178392fd4a03cf803a47e4051
   md5: 204892bce2e44252b5cf272712f10bdd
   depends:
@@ -8023,13 +6449,7 @@ packages:
   purls: []
   size: 134476
   timestamp: 1727968620103
-- kind: conda
-  name: libgl
-  version: 1.7.0
-  build: hd24410f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_1.conda
   sha256: 26e3570dcd72d95c4c5d007776fd0169028575140adef029a5b23729c4f164d6
   md5: 06cf88e73c69957c56318c6a1ccc5306
   depends:
@@ -8039,33 +6459,7 @@ packages:
   purls: []
   size: 146874
   timestamp: 1727968574647
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: h07bd6cf_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-h07bd6cf_0.conda
-  sha256: 101fb31c509d6a69ac5d612b51d4088ddbc675fca18cf0c3589cfee26cd01ca0
-  md5: 890783f64502fa6bfcdc723cfbf581b4
-  depends:
-  - __osx >=11.0
-  - libffi >=3.4,<4.0a0
-  - libiconv >=1.17,<2.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  constrains:
-  - glib 2.82.2 *_0
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 3635416
-  timestamp: 1729191799117
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: h2ff4ddf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
   sha256: 49ee9401d483a76423461c50dcd37f91d070efaec7e4dc2828d8cdd2ce694231
   md5: 13e8e54035ddd2b91875ba399f0f7c04
   depends:
@@ -8081,12 +6475,38 @@ packages:
   purls: []
   size: 3931898
   timestamp: 1729191404130
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: h7025463_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.2-hc486b8e_0.conda
+  sha256: 6797d24de7acd298f81a86078c64e4f3fea6d551a3e8892205c9e72a37a7cc3c
+  md5: 47f6d85fe47b865e56c539f2ba5f4dad
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 4020802
+  timestamp: 1729191545578
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.82.2-h07bd6cf_0.conda
+  sha256: 101fb31c509d6a69ac5d612b51d4088ddbc675fca18cf0c3589cfee26cd01ca0
+  md5: 890783f64502fa6bfcdc723cfbf581b4
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 3635416
+  timestamp: 1729191799117
+- conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.82.2-h7025463_0.conda
   sha256: 7dfbf492b736f8d379f8c3b32a823f0bf2167ff69963e4c940339b146a04c54a
   md5: 3e379c1b908a7101ecbc503def24613f
   depends:
@@ -8104,33 +6524,21 @@ packages:
   purls: []
   size: 3810166
   timestamp: 1729192227078
-- kind: conda
-  name: libglib
-  version: 2.82.2
-  build: hc486b8e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.2-hc486b8e_0.conda
-  sha256: 6797d24de7acd298f81a86078c64e4f3fea6d551a3e8892205c9e72a37a7cc3c
-  md5: 47f6d85fe47b865e56c539f2ba5f4dad
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
+  sha256: c4a14878c2be8c18b7e89a19917f0f6c964dd962c91a079fe5e0c6e8b8b1bbd4
+  md5: df069bea331c8486ac21814969301c1f
   depends:
-  - libffi >=3.4,<4.0a0
-  - libgcc >=13
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.44,<10.45.0a0
-  constrains:
-  - glib 2.82.2 *_0
-  license: LGPL-2.1-or-later
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xextproto >=7.3.0,<8.0a0
+  license: SGI-2
   purls: []
-  size: 4020802
-  timestamp: 1729191545578
-- kind: conda
-  name: libglu
-  version: 9.0.0
-  build: h5eeb66e_1004
-  build_number: 1004
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-h5eeb66e_1004.conda
+  size: 325824
+  timestamp: 1718880563533
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-h5eeb66e_1004.conda
   sha256: d4b60ab4337f7513c2c40419b04f3f8d71dc12bdf7e5baf0517d936296f11d78
   md5: 0554e8a9ccab69bc8033d0bebed1b933
   depends:
@@ -8145,33 +6553,7 @@ packages:
   purls: []
   size: 317747
   timestamp: 1718880641384
-- kind: conda
-  name: libglu
-  version: 9.0.0
-  build: ha6d2627_1004
-  build_number: 1004
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-ha6d2627_1004.conda
-  sha256: c4a14878c2be8c18b7e89a19917f0f6c964dd962c91a079fe5e0c6e8b8b1bbd4
-  md5: df069bea331c8486ac21814969301c1f
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-xextproto >=7.3.0,<8.0a0
-  license: SGI-2
-  purls: []
-  size: 325824
-  timestamp: 1718880563533
-- kind: conda
-  name: libglvnd
-  version: 1.7.0
-  build: ha4b6fd6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_1.conda
   sha256: 67942c2b6e4ddb705640b5db962e678f17d8305df5c1633e939cef1158a95058
   md5: 1ece2ccb1dc8c68639712b05e0fae070
   depends:
@@ -8180,26 +6562,14 @@ packages:
   purls: []
   size: 132216
   timestamp: 1727968577428
-- kind: conda
-  name: libglvnd
-  version: 1.7.0
-  build: hd24410f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_1.conda
   sha256: 281d2be6dbad9a7267ef2581bbaefb95f26be8d62c119e1a4efbc3c405d381b7
   md5: 32763e24bc6e5ed4de4a4a1598448d5b
   license: LicenseRef-libglvnd
   purls: []
   size: 142605
   timestamp: 1727968549960
-- kind: conda
-  name: libglx
-  version: 1.7.0
-  build: ha4b6fd6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_1.conda
   sha256: facc239145719034f7b8815d9630032e701d26534dae28303cdbae8b19590a82
   md5: 80a57756c545ad11f9847835aa21e6b2
   depends:
@@ -8210,13 +6580,7 @@ packages:
   purls: []
   size: 77902
   timestamp: 1727968607539
-- kind: conda
-  name: libglx
-  version: 1.7.0
-  build: hd24410f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_1.conda
   sha256: 822e2178395d18dc71d25dee255852b9eac0f6943bafa5be44cc2a12cf00e7e5
   md5: b4e4c7703e944564b512dabbcc1130d0
   depends:
@@ -8226,12 +6590,7 @@ packages:
   purls: []
   size: 77728
   timestamp: 1727968567627
-- kind: conda
-  name: libgpg-error
-  version: '1.50'
-  build: h4f305b6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.50-h4f305b6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.50-h4f305b6_0.conda
   sha256: c60969d5c315f33fee90a1f2dd5d169e2834ace5a55f5a6f822aa7485a3a84cc
   md5: 0d7ff1a8e69565ca3add6925e18e708f
   depends:
@@ -8245,12 +6604,7 @@ packages:
   purls: []
   size: 273774
   timestamp: 1719390736440
-- kind: conda
-  name: libgpg-error
-  version: '1.50'
-  build: hb13efb6_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.50-hb13efb6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.50-hb13efb6_0.conda
   sha256: 03742eddce9f264edfcf6a02a3c7bfef2b1d27e7d0c32b1598ebbcadab84cc65
   md5: 7c2cdd2e6915976622cfc519b76a3d56
   depends:
@@ -8264,13 +6618,44 @@ packages:
   purls: []
   size: 283819
   timestamp: 1719390791757
-- kind: conda
-  name: libhwloc
-  version: 2.11.1
-  build: default_h8125262_1000
-  build_number: 1000
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_he43201b_1000.conda
+  sha256: 75be8732e6f94ff2faa129f44ec4970275e1d977559b0c2fb75b7baa5347e16b
+  md5: 36247217c4e1018085bd9db41eb3526a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2425405
+  timestamp: 1727379398547
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.11.2-default_hab9fc21_1000.conda
+  sha256: f43a0bbf5029bc97da07773a482c8204518b2e7711053d21e4747994e5bc4a71
+  md5: 9ec708cad5b5750fda19595684446fe4
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.12.7,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2437317
+  timestamp: 1727379267622
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.11.2-default_h3f80f97_1000.conda
+  sha256: 24b5aa4cf1df330f07492e9d27e5ec77b92fbe86ff689ef411ffd660eb837a7f
+  md5: 642da422d3cea85e76caad1e6333d56b
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libxml2 >=2.12.7,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2334888
+  timestamp: 1727379312877
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
   sha256: 92728e292640186759d6dddae3334a1bc0b139740b736ffaeccb825fb8c07a2e
   md5: 933bad6e4658157f1aec9b171374fde2
   depends:
@@ -8284,67 +6669,7 @@ packages:
   purls: []
   size: 2379689
   timestamp: 1720461835526
-- kind: conda
-  name: libhwloc
-  version: 2.11.2
-  build: default_h3f80f97_1000
-  build_number: 1000
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.11.2-default_h3f80f97_1000.conda
-  sha256: 24b5aa4cf1df330f07492e9d27e5ec77b92fbe86ff689ef411ffd660eb837a7f
-  md5: 642da422d3cea85e76caad1e6333d56b
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libxml2 >=2.12.7,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 2334888
-  timestamp: 1727379312877
-- kind: conda
-  name: libhwloc
-  version: 2.11.2
-  build: default_hab9fc21_1000
-  build_number: 1000
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.11.2-default_hab9fc21_1000.conda
-  sha256: f43a0bbf5029bc97da07773a482c8204518b2e7711053d21e4747994e5bc4a71
-  md5: 9ec708cad5b5750fda19595684446fe4
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - libxml2 >=2.12.7,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 2437317
-  timestamp: 1727379267622
-- kind: conda
-  name: libhwloc
-  version: 2.11.2
-  build: default_he43201b_1000
-  build_number: 1000
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_he43201b_1000.conda
-  sha256: 75be8732e6f94ff2faa129f44ec4970275e1d977559b0c2fb75b7baa5347e16b
-  md5: 36247217c4e1018085bd9db41eb3526a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libxml2 >=2.12.7,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 2425405
-  timestamp: 1727379398547
-- kind: conda
-  name: libi2c
-  version: '4.4'
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.4-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libi2c-4.4-h5888daf_0.conda
   sha256: c6edef9b97719961a68aa631e4b0ed4dcd34254646e10b37555562c119ddefc5
   md5: 36c48b1a98b62f477ddb1185eecddbc5
   depends:
@@ -8355,12 +6680,7 @@ packages:
   purls: []
   size: 18846
   timestamp: 1728589119656
-- kind: conda
-  name: libi2c
-  version: '4.4'
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.4-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libi2c-4.4-h5ad3122_0.conda
   sha256: 859343e7bfaf073235742905b529bc08fb2c1d47989117dc2cad208e747ba38e
   md5: a2cc659fbbcf1d4ca9aa6ae3d0d6651b
   depends:
@@ -8370,26 +6690,16 @@ packages:
   purls: []
   size: 19131
   timestamp: 1728589137907
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: h0d3ecfb_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
-  sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
-  md5: 69bda57310071cf6d2b86caf11573d2d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
+  - libgcc-ng >=12
   license: LGPL-2.1-only
   purls: []
-  size: 676469
-  timestamp: 1702682458114
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: h31becfc_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
+  size: 705775
+  timestamp: 1702682170569
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
   sha256: a30e09d089cb75a0d5b8e5c354694c1317da98261185ed65aa3793e741060614
   md5: 9a8eb13f14de7d761555a98712e6df65
   depends:
@@ -8398,13 +6708,14 @@ packages:
   purls: []
   size: 705787
   timestamp: 1702684557134
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: hcfcfb64_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+  sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
+  md5: 69bda57310071cf6d2b86caf11573d2d
+  license: LGPL-2.1-only
+  purls: []
+  size: 676469
+  timestamp: 1702682458114
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
   sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
   md5: e1eb10b1cca179f2baa3601e4efc8712
   depends:
@@ -8415,43 +6726,7 @@ packages:
   purls: []
   size: 636146
   timestamp: 1702682547199
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: hd590300_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
-  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
-  md5: d66573916ffcf376178462f1b61c941e
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-only
-  purls: []
-  size: 705775
-  timestamp: 1702682170569
-- kind: conda
-  name: libintl
-  version: 0.22.5
-  build: h5728263_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
-  sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
-  md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
-  depends:
-  - libiconv >=1.17,<2.0a0
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 95568
-  timestamp: 1723629479451
-- kind: conda
-  name: libintl
-  version: 0.22.5
-  build: h8414b35_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8414b35_3.conda
   sha256: 7c1d238d4333af385e594c89ebcb520caad7ed83a735c901099ec0970a87a891
   md5: 3b98ec32e91b3b59ad53dbb9c96dd334
   depends:
@@ -8461,29 +6736,16 @@ packages:
   purls: []
   size: 81171
   timestamp: 1723626968270
-- kind: conda
-  name: libintl-devel
-  version: 0.22.5
-  build: h5728263_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
-  sha256: be1f3c48bc750bca7e68955d57180dfd826d6f9fa7eb32994f6cb61b813f9a6a
-  md5: 7537784e9e35399234d4007f45cdb744
+- conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+  sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
+  md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
   depends:
   - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_3
   license: LGPL-2.1-or-later
   purls: []
-  size: 40746
-  timestamp: 1723629745649
-- kind: conda
-  name: libintl-devel
-  version: 0.22.5
-  build: h8414b35_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8414b35_3.conda
+  size: 95568
+  timestamp: 1723629479451
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8414b35_3.conda
   sha256: c9d1d4fdfb5775828e54bc9fb443b1a6de9319a04b81d1bac52c26114a763154
   md5: 271646de11b018c66e81eb4c4717b291
   depends:
@@ -8494,13 +6756,28 @@ packages:
   purls: []
   size: 38584
   timestamp: 1723627022409
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
+  sha256: be1f3c48bc750bca7e68955d57180dfd826d6f9fa7eb32994f6cb61b813f9a6a
+  md5: 7537784e9e35399234d4007f45cdb744
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5728263_3
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 40746
+  timestamp: 1723629745649
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
+  md5: ea25936bb4080d843790b586850f82b8
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
+  size: 618575
+  timestamp: 1694474974816
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
   sha256: 675bc1f2a8581cd34a86c412663ec29c5f90c1d9f8d11866aa1ade5cdbdf8429
   md5: ed24e702928be089d9ba3f05618515c6
   depends:
@@ -8511,13 +6788,7 @@ packages:
   purls: []
   size: 647126
   timestamp: 1694475003570
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: hb547adb_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
   sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
   md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
   constrains:
@@ -8526,13 +6797,7 @@ packages:
   purls: []
   size: 547541
   timestamp: 1694475104253
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: hcfcfb64_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
   sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
   md5: 3f1b948619c45b1ca714d60c7389092c
   depends:
@@ -8545,30 +6810,8 @@ packages:
   purls: []
   size: 822966
   timestamp: 1694475223854
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
-  sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
-  md5: ea25936bb4080d843790b586850f82b8
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - jpeg <0.0.0a
-  license: IJG AND BSD-3-Clause AND Zlib
-  purls: []
-  size: 618575
-  timestamp: 1694474974816
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
   sha256: 9d1ff017714edb2d84868f0f931a4a0e7c289a971062b2ac66cfc8145df7e20e
   md5: 4dc03a53fc69371a6158d0ed37214cd3
   depends:
@@ -8582,13 +6825,8 @@ packages:
   purls: []
   size: 15608
   timestamp: 1729642910812
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_linuxaarch64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-25_linuxaarch64_openblas.conda
   build_number: 25
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-25_linuxaarch64_openblas.conda
   sha256: 2b399e65e0338bf249657b98333e910cd7086ea1332d4d6f303735883ca49318
   md5: 0eb74e81de46454960bde9e44e7ee378
   depends:
@@ -8602,13 +6840,8 @@ packages:
   purls: []
   size: 15711
   timestamp: 1729643010817
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_osxarm64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
   build_number: 25
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
   sha256: fdd742407672a9af20e70764550cf18b3ab67f12e48bf04163b90492fbc401e7
   md5: 19bbddfec972d401838330453186108d
   depends:
@@ -8622,13 +6855,8 @@ packages:
   purls: []
   size: 15823
   timestamp: 1729643275943
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
   sha256: 98c13a28596389539abe3f608c6fbd2826df47671f77c58a331df878c6140c53
   md5: f716ef84564c574e8e74ae725f5d5f93
   depends:
@@ -8642,13 +6870,8 @@ packages:
   purls: []
   size: 3736560
   timestamp: 1729643588182
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 25_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-25_linux64_openblas.conda
   build_number: 25
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-25_linux64_openblas.conda
   sha256: f8bc6fe22126ca0bf204c27f829d1e0006069cc98776a33122bf8d0548940b3c
   md5: 8f5ead31b3a168aedd488b8a87736c41
   depends:
@@ -8662,13 +6885,8 @@ packages:
   purls: []
   size: 15609
   timestamp: 1729642916038
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 25_linuxaarch64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-25_linuxaarch64_openblas.conda
   build_number: 25
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-25_linuxaarch64_openblas.conda
   sha256: f0a591a2ac7e1259971124ddd466ce39da646699decda1a8ab45a2fabd257665
   md5: 1e68063075954830f707b41dab6c7fd8
   depends:
@@ -8682,13 +6900,8 @@ packages:
   purls: []
   size: 15712
   timestamp: 1729643014949
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 25_osxarm64_openblas
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-25_osxarm64_openblas.conda
   build_number: 25
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-25_osxarm64_openblas.conda
   sha256: 3db3a803a9295784c1fae97c1397b44f5c1c58472b7b06834d8387ed986778f9
   md5: fe649c1f453f9952a9048b80dc25f92f
   depends:
@@ -8702,13 +6915,8 @@ packages:
   purls: []
   size: 15836
   timestamp: 1729643281243
-- kind: conda
-  name: liblapacke
-  version: 3.9.0
-  build: 25_win64_mkl
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-25_win64_mkl.conda
   build_number: 25
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-25_win64_mkl.conda
   sha256: a7a6d417bf963659bdfa6ef6f5604696fb0717f7bed7f594ceb1ceedf7d93d16
   md5: d59fc46f1e1c2f3cf38a08a0a76ffee5
   depends:
@@ -8722,13 +6930,7 @@ packages:
   purls: []
   size: 3736581
   timestamp: 1729643615092
-- kind: conda
-  name: libllvm17
-  version: 17.0.6
-  build: h5090b49_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-h5090b49_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-h5090b49_2.conda
   sha256: 5829e490e395d85442fb6c7edb0ec18d1a5bb1bc529919a89337d34235205064
   md5: 443b26505722696a9535732bc2a07576
   depends:
@@ -8742,31 +6944,7 @@ packages:
   purls: []
   size: 24612870
   timestamp: 1718320971519
-- kind: conda
-  name: libllvm19
-  version: 19.1.3
-  build: h2edbd07_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.3-h2edbd07_0.conda
-  sha256: b61b78b600ee09006512973b4f79b3efda5013bfcb3ed2563ec7c0d9bbdf44c3
-  md5: 4f335bb2183b2a9a062518cbc079dc8b
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - libxml2 >=2.13.4,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  purls: []
-  size: 39439341
-  timestamp: 1730296177275
-- kind: conda
-  name: libllvm19
-  version: 19.1.3
-  build: ha7bfdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.3-ha7bfdaf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.3-ha7bfdaf_0.conda
   sha256: 44502d37011472549367110a58ea78ff6c627f9436d1e4ebb5b34f80763dbf2a
   md5: 8bd654307c455162668cd66e36494000
   depends:
@@ -8781,12 +6959,21 @@ packages:
   purls: []
   size: 40124530
   timestamp: 1730301303455
-- kind: conda
-  name: libllvm19
-  version: 19.1.3
-  build: haf57ff0_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.3-haf57ff0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm19-19.1.3-h2edbd07_0.conda
+  sha256: b61b78b600ee09006512973b4f79b3efda5013bfcb3ed2563ec7c0d9bbdf44c3
+  md5: 4f335bb2183b2a9a062518cbc079dc8b
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libxml2 >=2.13.4,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 39439341
+  timestamp: 1730296177275
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm19-19.1.3-haf57ff0_0.conda
   sha256: 174e24adb8bf5e55c6871057c6ac6aace11a043afd0528a7314c4f641c176444
   md5: 25dd0e37da590d639d35e1b6a66a4a96
   depends:
@@ -8800,12 +6987,7 @@ packages:
   purls: []
   size: 26881534
   timestamp: 1730291029268
-- kind: conda
-  name: libmpdec
-  version: 4.0.0
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
   sha256: fc529fc82c7caf51202cc5cec5bb1c2e8d90edbac6d0a4602c966366efe3c7bf
   md5: 74860100b2029e2523cf480804c76b9b
   depends:
@@ -8817,35 +6999,7 @@ packages:
   purls: []
   size: 88657
   timestamp: 1723861474602
-- kind: conda
-  name: libmujoco
-  version: 3.2.5
-  build: h04ce485_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libmujoco-3.2.5-h04ce485_0.conda
-  sha256: 69d51292c29a918a8b8b702b4203449feb90f9f4ecc31b93e86f3980f88d8a1f
-  md5: 7a8ca03376b4e0ac3d2b9fbb6766b512
-  depends:
-  - libccd-double >=2.1,<2.2.0a0
-  - lodepng >=20220109,<20220110.0a0
-  - qhull >=2020.2,<2020.3.0a0
-  - tinyxml2 >=10.0.0,<11.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - mujoco-cxx <0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 11541321
-  timestamp: 1730840906318
-- kind: conda
-  name: libmujoco
-  version: 3.2.5
-  build: h1419bf0_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmujoco-3.2.5-h1419bf0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmujoco-3.2.5-h1419bf0_0.conda
   sha256: fa01b58bc66b4abdb31d1161496cd632a6dfc7d3261fb6a86f9394fe228e075a
   md5: 8d2f37ab80c42c88734d2206507003af
   depends:
@@ -8863,34 +7017,7 @@ packages:
   purls: []
   size: 11664242
   timestamp: 1730840583962
-- kind: conda
-  name: libmujoco
-  version: 3.2.5
-  build: h20f2781_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmujoco-3.2.5-h20f2781_0.conda
-  sha256: 6a78b84c0840dcd0133f0b575e21b7fe7bdb20603683274609c59c9e6f25f659
-  md5: 75326ef0f1a74a6daa94fb7efc230263
-  depends:
-  - __osx >=11.0
-  - libccd-double >=2.1,<2.2.0a0
-  - libcxx >=18
-  - lodepng >=20220109,<20220110.0a0
-  - qhull >=2020.2,<2020.3.0a0
-  - tinyxml2 >=10.0.0,<11.0a0
-  constrains:
-  - mujoco-cxx <0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 11528710
-  timestamp: 1730840657500
-- kind: conda
-  name: libmujoco
-  version: 3.2.5
-  build: h8a3ac16_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libmujoco-3.2.5-h8a3ac16_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmujoco-3.2.5-h8a3ac16_0.conda
   sha256: f9580be519dab1eea4f23096ea54245ff3e25fef4cc7f7d2282d6af6e9de45f8
   md5: 15c6f778a0630c15d87da58712d4f263
   depends:
@@ -8907,12 +7034,42 @@ packages:
   purls: []
   size: 11563776
   timestamp: 1730840532889
-- kind: conda
-  name: libnghttp2
-  version: 1.64.0
-  build: h161d5f1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmujoco-3.2.5-h20f2781_0.conda
+  sha256: 6a78b84c0840dcd0133f0b575e21b7fe7bdb20603683274609c59c9e6f25f659
+  md5: 75326ef0f1a74a6daa94fb7efc230263
+  depends:
+  - __osx >=11.0
+  - libccd-double >=2.1,<2.2.0a0
+  - libcxx >=18
+  - lodepng >=20220109,<20220110.0a0
+  - qhull >=2020.2,<2020.3.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  constrains:
+  - mujoco-cxx <0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 11528710
+  timestamp: 1730840657500
+- conda: https://conda.anaconda.org/conda-forge/win-64/libmujoco-3.2.5-h04ce485_0.conda
+  sha256: 69d51292c29a918a8b8b702b4203449feb90f9f4ecc31b93e86f3980f88d8a1f
+  md5: 7a8ca03376b4e0ac3d2b9fbb6766b512
+  depends:
+  - libccd-double >=2.1,<2.2.0a0
+  - lodepng >=20220109,<20220110.0a0
+  - qhull >=2020.2,<2020.3.0a0
+  - tinyxml2 >=10.0.0,<11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - mujoco-cxx <0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 11541321
+  timestamp: 1730840906318
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
   sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
   md5: 19e57602824042dfd0446292ef90488b
   depends:
@@ -8929,33 +7086,7 @@ packages:
   purls: []
   size: 647599
   timestamp: 1729571887612
-- kind: conda
-  name: libnghttp2
-  version: 1.64.0
-  build: h6d7220d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
-  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
-  md5: 3408c02539cee5f1141f9f11450b6a51
-  depends:
-  - __osx >=11.0
-  - c-ares >=1.34.2,<2.0a0
-  - libcxx >=17
-  - libev >=4.33,<4.34.0a0
-  - libev >=4.33,<5.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 566719
-  timestamp: 1729572385640
-- kind: conda
-  name: libnghttp2
-  version: 1.64.0
-  build: hc8609a4_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.64.0-hc8609a4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.64.0-hc8609a4_0.conda
   sha256: c093c6d370aadbf0409c20b6c54c488ee2f6fea976181919fcc63e87ee232673
   md5: f52c614fa214a8bedece9421c771670d
   depends:
@@ -8971,27 +7102,23 @@ packages:
   purls: []
   size: 714610
   timestamp: 1729571912479
-- kind: conda
-  name: libnsl
-  version: 2.0.1
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
-  sha256: fd18c2b75d7411096428d36a70b36b1a17e31f7b8956b6905d145792d49e97f8
-  md5: c14f32510f694e3185704d89967ec422
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
+  sha256: 00cc685824f39f51be5233b54e19f45abd60de5d8847f1a56906f8936648b72f
+  md5: 3408c02539cee5f1141f9f11450b6a51
   depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-only
-  license_family: GPL
+  - __osx >=11.0
+  - c-ares >=1.34.2,<2.0a0
+  - libcxx >=17
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  license: MIT
+  license_family: MIT
   purls: []
-  size: 34501
-  timestamp: 1697358973269
-- kind: conda
-  name: libnsl
-  version: 2.0.1
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  size: 566719
+  timestamp: 1729572385640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
   sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
   depends:
@@ -9001,12 +7128,27 @@ packages:
   purls: []
   size: 33408
   timestamp: 1697359010159
-- kind: conda
-  name: libogg
-  version: 1.3.5
-  build: h0b9eccb_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h0b9eccb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
+  sha256: fd18c2b75d7411096428d36a70b36b1a17e31f7b8956b6905d145792d49e97f8
+  md5: c14f32510f694e3185704d89967ec422
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  purls: []
+  size: 34501
+  timestamp: 1697358973269
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
+  sha256: 5eda3fe92b99b25dd4737226a9485078ab405672d9f621be75edcb68f1e9026d
+  md5: 601bfb4b3c6f0b844443bb81a56651e0
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 205914
+  timestamp: 1719301575771
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h0b9eccb_0.conda
   sha256: e65acc318b7535fb8f2b5e994fe6eac3ae0be3bdb2acbe6037841d033c51f290
   md5: 15cb67b1b9dd0d4b37c81daba785e6ad
   depends:
@@ -9016,12 +7158,17 @@ packages:
   purls: []
   size: 208233
   timestamp: 1719301637185
-- kind: conda
-  name: libogg
-  version: 1.3.5
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h99b78c6_0.conda
+  sha256: 685f73b7241978007dfe0cecb9cae46c6a26d87d192b6f85a09eb65023c0b99e
+  md5: 57b668b9b78dea2c08e44bb2385d57c0
+  depends:
+  - __osx >=11.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 205451
+  timestamp: 1719301708541
+- conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
   sha256: fcffdf32c620569738b85c98ddd25e1c84c8add80cd732743d90d469b7b532bb
   md5: 44a4d173e62c5ed6d715f18ae7c46b7a
   depends:
@@ -9033,68 +7180,7 @@ packages:
   purls: []
   size: 35459
   timestamp: 1719302192495
-- kind: conda
-  name: libogg
-  version: 1.3.5
-  build: h4ab18f5_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
-  sha256: 5eda3fe92b99b25dd4737226a9485078ab405672d9f621be75edcb68f1e9026d
-  md5: 601bfb4b3c6f0b844443bb81a56651e0
-  depends:
-  - libgcc-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 205914
-  timestamp: 1719301575771
-- kind: conda
-  name: libogg
-  version: 1.3.5
-  build: h99b78c6_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h99b78c6_0.conda
-  sha256: 685f73b7241978007dfe0cecb9cae46c6a26d87d192b6f85a09eb65023c0b99e
-  md5: 57b668b9b78dea2c08e44bb2385d57c0
-  depends:
-  - __osx >=11.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 205451
-  timestamp: 1719301708541
-- kind: conda
-  name: libopenblas
-  version: 0.3.28
-  build: openmp_h1a8b088_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.28-openmp_h1a8b088_1.conda
-  sha256: 8f182263b877c540863d9751f2f3152a9ebe5b5602714ce0b59cb368dd041535
-  md5: a1ad061431840807d3749ced3a969e0a
-  depends:
-  - _openmp_mutex * *_llvm
-  - _openmp_mutex >=4.5
-  - libgcc >=14
-  - libgfortran
-  - libgfortran5 >=14.2.0
-  - llvm-openmp >=19.1.3
-  constrains:
-  - openblas >=0.3.28,<0.3.29.0a0
-  track_features:
-  - openblas_threading_openmp
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 4800170
-  timestamp: 1730773060430
-- kind: conda
-  name: libopenblas
-  version: 0.3.28
-  build: openmp_hd680484_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-openmp_hd680484_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-openmp_hd680484_1.conda
   sha256: a3250af599973f2f0c3d3424d398256b9a60ce033db2c66eaa34a90e1989941f
   md5: 5b291c189ab95420d4f59a44c44ad3d9
   depends:
@@ -9114,13 +7200,26 @@ packages:
   purls: []
   size: 5590762
   timestamp: 1730772709864
-- kind: conda
-  name: libopenblas
-  version: 0.3.28
-  build: openmp_hf332438_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.28-openmp_h1a8b088_1.conda
+  sha256: 8f182263b877c540863d9751f2f3152a9ebe5b5602714ce0b59cb368dd041535
+  md5: a1ad061431840807d3749ced3a969e0a
+  depends:
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.2.0
+  - llvm-openmp >=19.1.3
+  constrains:
+  - openblas >=0.3.28,<0.3.29.0a0
+  track_features:
+  - openblas_threading_openmp
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 4800170
+  timestamp: 1730773060430
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
   sha256: 62bb669c37a845129096f73d446cdb6bb170e4927f2fea2b661329680dbbc373
   md5: 40803a48d947c8639da6704e9a44d3ce
   depends:
@@ -9135,170 +7234,7 @@ packages:
   purls: []
   size: 4165774
   timestamp: 1730772154295
-- kind: conda
-  name: libopencv
-  version: 4.10.0
-  build: headless_py312h346ddc4_10
-  build_number: 10
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.10.0-headless_py312h346ddc4_10.conda
-  sha256: 75090ad08d12b9215c2e2cb4c268a5b33886f9c708224943be5f86bd197ba682
-  md5: 7f05c9f6a9571a340dffa638d620c65c
-  depends:
-  - _openmp_mutex >=4.5
-  - ffmpeg >=7.1.0,<8.0a0
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - hdf5 >=1.14.4,<1.14.5.0a0
-  - jasper >=4.2.4,<5.0a0
-  - libasprintf >=0.22.5,<1.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc >=13
-  - libgettextpo >=0.22.5,<1.0a0
-  - libglib >=2.82.2,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libstdcxx >=13
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.19,<3
-  - openexr >=3.3.1,<3.4.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/opencv-python?source=hash-mapping
-  - pkg:pypi/opencv-python-headless?source=hash-mapping
-  size: 20092901
-  timestamp: 1729610773773
-- kind: conda
-  name: libopencv
-  version: 4.10.0
-  build: headless_py312hd376c54_10
-  build_number: 10
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.10.0-headless_py312hd376c54_10.conda
-  sha256: 41d6a787a644a1c32f501264a4bb5d0ccf90d613685259fbe685969f1f725603
-  md5: ba971a881620b895a2a0519fdd6e268d
-  depends:
-  - __osx >=11.0
-  - ffmpeg >=7.1.0,<8.0a0
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - hdf5 >=1.14.4,<1.14.5.0a0
-  - jasper >=4.2.4,<5.0a0
-  - libasprintf >=0.22.5,<1.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=17
-  - libgettextpo >=0.22.5,<1.0a0
-  - libglib >=2.82.2,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.19,<3
-  - openexr >=3.3.1,<3.4.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/opencv-python?source=hash-mapping
-  - pkg:pypi/opencv-python-headless?source=hash-mapping
-  size: 21932354
-  timestamp: 1729610239055
-- kind: conda
-  name: libopencv
-  version: 4.10.0
-  build: qt6_py312hff6938d_610
-  build_number: 610
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py312hff6938d_610.conda
-  sha256: 6e6755cc455fd2226e092ba1fa9e66e7c7e78d1d65067b7c7427d53ea2d7c7e7
-  md5: b17595e74f1cdbf38d3eef405bbc5b6b
-  depends:
-  - ffmpeg >=7.1.0,<8.0a0
-  - freetype >=2.12.1,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - hdf5 >=1.14.4,<1.14.5.0a0
-  - jasper >=4.2.4,<5.0a0
-  - libasprintf >=0.22.5,<1.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgettextpo >=0.22.5,<1.0a0
-  - libglib >=2.82.2,<3.0a0
-  - libintl >=0.22.5,<1.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - liblapacke >=3.9.0,<4.0a0
-  - libopenvino >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-intel-gpu-plugin >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libtiff >=4.7.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - numpy >=1.19,<3
-  - openexr >=3.3.1,<3.4.0a0
-  - qt6-main >=6.7.3,<6.8.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/opencv-python?source=hash-mapping
-  - pkg:pypi/opencv-python-headless?source=hash-mapping
-  size: 33151323
-  timestamp: 1729612364411
-- kind: conda
-  name: libopencv
-  version: 4.10.0
-  build: qt6_py39h5cac152_610
-  build_number: 610
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.10.0-qt6_py39h5cac152_610.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.10.0-qt6_py39h5cac152_610.conda
   sha256: 966c9c441f8a0005ebbe26d66cefccd08556faf4eaf6df2ee308c08ef0f50d91
   md5: 45d7118cbbbb6f4733a9b23d91989a3d
   depends:
@@ -9349,13 +7285,146 @@ packages:
   - pkg:pypi/opencv-python-headless?source=hash-mapping
   size: 30891589
   timestamp: 1729610949785
-- kind: conda
-  name: libopenvino
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.4.0-hac27bb2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.10.0-headless_py312h346ddc4_10.conda
+  sha256: 75090ad08d12b9215c2e2cb4c268a5b33886f9c708224943be5f86bd197ba682
+  md5: 7f05c9f6a9571a340dffa638d620c65c
+  depends:
+  - _openmp_mutex >=4.5
+  - ffmpeg >=7.1.0,<8.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.3.1,<3.4.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/opencv-python?source=hash-mapping
+  - pkg:pypi/opencv-python-headless?source=hash-mapping
+  size: 20092901
+  timestamp: 1729610773773
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.10.0-headless_py312hd376c54_10.conda
+  sha256: 41d6a787a644a1c32f501264a4bb5d0ccf90d613685259fbe685969f1f725603
+  md5: ba971a881620b895a2a0519fdd6e268d
+  depends:
+  - __osx >=11.0
+  - ffmpeg >=7.1.0,<8.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=17
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-arm-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.3.1,<3.4.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/opencv-python?source=hash-mapping
+  - pkg:pypi/opencv-python-headless?source=hash-mapping
+  size: 21932354
+  timestamp: 1729610239055
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.10.0-qt6_py312hff6938d_610.conda
+  sha256: 6e6755cc455fd2226e092ba1fa9e66e7c7e78d1d65067b7c7427d53ea2d7c7e7
+  md5: b17595e74f1cdbf38d3eef405bbc5b6b
+  depends:
+  - ffmpeg >=7.1.0,<8.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - hdf5 >=1.14.4,<1.14.5.0a0
+  - jasper >=4.2.4,<5.0a0
+  - libasprintf >=0.22.5,<1.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgettextpo >=0.22.5,<1.0a0
+  - libglib >=2.82.2,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-batch-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-auto-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-hetero-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-cpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-intel-gpu-plugin >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-ir-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-onnx-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-paddle-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-pytorch-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-frontend >=2024.4.0,<2024.4.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2024.4.0,<2024.4.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - openexr >=3.3.1,<3.4.0a0
+  - qt6-main >=6.7.3,<6.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/opencv-python?source=hash-mapping
+  - pkg:pypi/opencv-python-headless?source=hash-mapping
+  size: 33151323
+  timestamp: 1729612364411
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2024.4.0-hac27bb2_2.conda
   sha256: 1f804b6238951d59b3a431c2e01bd831d44e015ea6835809775bb60b6978e3b3
   md5: ba5ac0bb9ec5aec38dec37c230b12d64
   depends:
@@ -9367,30 +7436,7 @@ packages:
   purls: []
   size: 5362131
   timestamp: 1729594675874
-- kind: conda
-  name: libopenvino
-  version: 2024.4.0
-  build: hbfeda7a_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2024.4.0-hbfeda7a_2.conda
-  sha256: 372064e0ae774b50ce66522699648b3115837afad6261d7a6dec447b701611d2
-  md5: bfb018530a5e9beacd8ef7d01ce01708
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  purls: []
-  size: 3947154
-  timestamp: 1729589796148
-- kind: conda
-  name: libopenvino
-  version: 2024.4.0
-  build: hd7d4d4f_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.4.0-hd7d4d4f_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2024.4.0-hd7d4d4f_2.conda
   sha256: fa92fa4e9da3cb1a6ac37004c0f63922e62d3b2fe631385c923436a51d76005e
   md5: 842ca0bee620b70ce30d397d7eb47d26
   depends:
@@ -9401,13 +7447,18 @@ packages:
   purls: []
   size: 4902384
   timestamp: 1729590142049
-- kind: conda
-  name: libopenvino
-  version: 2024.4.0
-  build: hfe1841e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.4.0-hfe1841e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2024.4.0-hbfeda7a_2.conda
+  sha256: 372064e0ae774b50ce66522699648b3115837afad6261d7a6dec447b701611d2
+  md5: bfb018530a5e9beacd8ef7d01ce01708
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
+  purls: []
+  size: 3947154
+  timestamp: 1729589796148
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2024.4.0-hfe1841e_2.conda
   sha256: eb24dc441b6234a7f2259b0f34484cc4ab7b2c0ef37e6a78467772c826b3234d
   md5: ca1f434dc9b599772c9a9ba0e10c34e7
   depends:
@@ -9419,31 +7470,7 @@ packages:
   purls: []
   size: 3315154
   timestamp: 1729596416745
-- kind: conda
-  name: libopenvino-arm-cpu-plugin
-  version: 2024.4.0
-  build: hbfeda7a_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2024.4.0-hbfeda7a_2.conda
-  sha256: 1d6119f9012bdf4d5c044bd23ae7bea05fab435e216b9861521b2d241ba186c2
-  md5: 76383ff76071f723294edff67968ed18
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libopenvino 2024.4.0 hbfeda7a_2
-  - pugixml >=1.14,<1.15.0a0
-  - tbb >=2021.13.0
-  purls: []
-  size: 7430916
-  timestamp: 1729589826098
-- kind: conda
-  name: libopenvino-arm-cpu-plugin
-  version: 2024.4.0
-  build: hd7d4d4f_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.4.0-hd7d4d4f_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2024.4.0-hd7d4d4f_2.conda
   sha256: f8c598062b07f7c7047c1a3fe5479aad30884cf02bbb49842e9fdcd1ed1468fb
   md5: e5817f6e796293f49bd94c9ce47b2d69
   depends:
@@ -9455,31 +7482,19 @@ packages:
   purls: []
   size: 8377593
   timestamp: 1729590158748
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
-  build: h04f32e0_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.4.0-h04f32e0_2.conda
-  sha256: df72f57fd09be5ec3045ada38c52d96cb5fb3dd5c0b63cf7863da2e7a0f171d1
-  md5: 9da7c58a1a74f939ce35072939f6190a
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2024.4.0-hbfeda7a_2.conda
+  sha256: 1d6119f9012bdf4d5c044bd23ae7bea05fab435e216b9861521b2d241ba186c2
+  md5: 76383ff76071f723294edff67968ed18
   depends:
-  - libopenvino 2024.4.0 hfe1841e_2
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 hbfeda7a_2
+  - pugixml >=1.14,<1.15.0a0
   - tbb >=2021.13.0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
   purls: []
-  size: 99458
-  timestamp: 1729596450079
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
-  build: h4d9b6c2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.4.0-h4d9b6c2_2.conda
+  size: 7430916
+  timestamp: 1729589826098
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2024.4.0-h4d9b6c2_2.conda
   sha256: dc596ff555b7ae19a7cd62af8965445575e1441dd486b8aec6a647f9ecbada3a
   md5: 1d05a25da36ba5f98291d7237fc6b8ce
   depends:
@@ -9491,13 +7506,7 @@ packages:
   purls: []
   size: 111701
   timestamp: 1729594696807
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
-  build: hf15766e_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.4.0-hf15766e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2024.4.0-hf15766e_2.conda
   sha256: f0c1a7e5a5654328c88814590ed53aa98ac6d079d336c3335d9f0ba00d70ffc0
   md5: 1f737fa48eadcbadc5e35cd86c1b0036
   depends:
@@ -9508,13 +7517,7 @@ packages:
   purls: []
   size: 108042
   timestamp: 1729590183012
-- kind: conda
-  name: libopenvino-auto-batch-plugin
-  version: 2024.4.0
-  build: hf276634_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2024.4.0-hf276634_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2024.4.0-hf276634_2.conda
   sha256: 1d182574a0987728971e9d119b11bb4cfadf71fde28f0e357e11c7af2b7a82b9
   md5: a8669452d6178b41f9bc9ead21f9b7d3
   depends:
@@ -9525,15 +7528,9 @@ packages:
   purls: []
   size: 104374
   timestamp: 1729589873528
-- kind: conda
-  name: libopenvino-auto-plugin
-  version: 2024.4.0
-  build: h04f32e0_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.4.0-h04f32e0_2.conda
-  sha256: 916fad203b281d35cf82264273d4c6a0fe6c86155151ee385a8aeffdc1c8f28f
-  md5: 6b231f5d7b287a3225ee0fc0e9905e60
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2024.4.0-h04f32e0_2.conda
+  sha256: df72f57fd09be5ec3045ada38c52d96cb5fb3dd5c0b63cf7863da2e7a0f171d1
+  md5: 9da7c58a1a74f939ce35072939f6190a
   depends:
   - libopenvino 2024.4.0 hfe1841e_2
   - tbb >=2021.13.0
@@ -9541,15 +7538,9 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   purls: []
-  size: 193740
-  timestamp: 1729596483320
-- kind: conda
-  name: libopenvino-auto-plugin
-  version: 2024.4.0
-  build: h4d9b6c2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.4.0-h4d9b6c2_2.conda
+  size: 99458
+  timestamp: 1729596450079
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2024.4.0-h4d9b6c2_2.conda
   sha256: 27b732f1ba3ae7dc8263f59e69447eebabcc76de86e2ec4c9722842a1d2f4aa8
   md5: 838b2db868f9ab69a7bad9c065a3362d
   depends:
@@ -9561,13 +7552,7 @@ packages:
   purls: []
   size: 237694
   timestamp: 1729594707449
-- kind: conda
-  name: libopenvino-auto-plugin
-  version: 2024.4.0
-  build: hf15766e_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.4.0-hf15766e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2024.4.0-hf15766e_2.conda
   sha256: 2de62ad880f30283778fa9c148b6e9095a206f0a1f0fb6b6d5f7bcaf9572d184
   md5: 040cfcec2cccffd2599ba746d8dac9a6
   depends:
@@ -9578,13 +7563,7 @@ packages:
   purls: []
   size: 224080
   timestamp: 1729590192079
-- kind: conda
-  name: libopenvino-auto-plugin
-  version: 2024.4.0
-  build: hf276634_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2024.4.0-hf276634_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2024.4.0-hf276634_2.conda
   sha256: 52c22114bd16956d5a810c9dc9a624a53446578a872a2cdb4188333256b04dac
   md5: 0a6f2709c335049b804d7ce23c1dc46f
   depends:
@@ -9595,48 +7574,19 @@ packages:
   purls: []
   size: 211623
   timestamp: 1729589895613
-- kind: conda
-  name: libopenvino-hetero-plugin
-  version: 2024.4.0
-  build: h03892cd_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2024.4.0-h03892cd_2.conda
-  sha256: 5ec87af2db01843ed4ecef25485e772b75e77d1b484b459a9ce56c28442b4e56
-  md5: cfd28b170b1a6e097a014c4e1f514bdc
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libopenvino 2024.4.0 hbfeda7a_2
-  - pugixml >=1.14,<1.15.0a0
-  purls: []
-  size: 174162
-  timestamp: 1729589920318
-- kind: conda
-  name: libopenvino-hetero-plugin
-  version: 2024.4.0
-  build: h372dad0_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.4.0-h372dad0_2.conda
-  sha256: 9e042cb9565bd4df991d2e1d6e04a77afa7a141754d51d634a950abe69a28e7c
-  md5: 15388e73cd24ba415b36c3b43c849639
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2024.4.0-h04f32e0_2.conda
+  sha256: 916fad203b281d35cf82264273d4c6a0fe6c86155151ee385a8aeffdc1c8f28f
+  md5: 6b231f5d7b287a3225ee0fc0e9905e60
   depends:
   - libopenvino 2024.4.0 hfe1841e_2
-  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.13.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   purls: []
-  size: 160127
-  timestamp: 1729596509788
-- kind: conda
-  name: libopenvino-hetero-plugin
-  version: 2024.4.0
-  build: h3f63f65_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.4.0-h3f63f65_2.conda
+  size: 193740
+  timestamp: 1729596483320
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2024.4.0-h3f63f65_2.conda
   sha256: 0c7cd10c9e3d99d6f23e4d7b48cd8e72aeb4a1c7acb801b6ca9add0f87f238d3
   md5: 00a6127960a3f41d4bfcabd35d5fbeec
   depends:
@@ -9648,13 +7598,7 @@ packages:
   purls: []
   size: 197567
   timestamp: 1729594718187
-- kind: conda
-  name: libopenvino-hetero-plugin
-  version: 2024.4.0
-  build: h6ef32b0_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.4.0-h6ef32b0_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2024.4.0-h6ef32b0_2.conda
   sha256: 215665ba9169a61f30d96c197bf799b85223963af483fdd137f508e7865fa057
   md5: b106de2dc7ebc8cb930061cffbd117e0
   depends:
@@ -9665,13 +7609,30 @@ packages:
   purls: []
   size: 184694
   timestamp: 1729590203040
-- kind: conda
-  name: libopenvino-intel-cpu-plugin
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.4.0-hac27bb2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2024.4.0-h03892cd_2.conda
+  sha256: 5ec87af2db01843ed4ecef25485e772b75e77d1b484b459a9ce56c28442b4e56
+  md5: cfd28b170b1a6e097a014c4e1f514bdc
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 hbfeda7a_2
+  - pugixml >=1.14,<1.15.0a0
+  purls: []
+  size: 174162
+  timestamp: 1729589920318
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2024.4.0-h372dad0_2.conda
+  sha256: 9e042cb9565bd4df991d2e1d6e04a77afa7a141754d51d634a950abe69a28e7c
+  md5: 15388e73cd24ba415b36c3b43c849639
+  depends:
+  - libopenvino 2024.4.0 hfe1841e_2
+  - pugixml >=1.14,<1.15.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  purls: []
+  size: 160127
+  timestamp: 1729596509788
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2024.4.0-hac27bb2_2.conda
   sha256: 5642443645408f030e9dfbe20dbe2c2ab6d852daf02c9a36eac123b44bf2980f
   md5: 6cfc840bc39c17d92fb25e5a35789e5b
   depends:
@@ -9684,13 +7645,7 @@ packages:
   purls: []
   size: 12101994
   timestamp: 1729594729554
-- kind: conda
-  name: libopenvino-intel-cpu-plugin
-  version: 2024.4.0
-  build: hfe1841e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.4.0-hfe1841e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2024.4.0-hfe1841e_2.conda
   sha256: 4049a7613da003e2f220d976549e4110f501d2feba7f0778483a5504856eec07
   md5: fbacb501be2a46be7dcf20cd299ac53c
   depends:
@@ -9703,13 +7658,7 @@ packages:
   purls: []
   size: 8031319
   timestamp: 1729596537775
-- kind: conda
-  name: libopenvino-intel-gpu-plugin
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.4.0-hac27bb2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2024.4.0-hac27bb2_2.conda
   sha256: 508d0e36febebfb66628d8cb0312b4133c212eac1e8d891fc8977e0d85b23741
   md5: 9e9814b40d8fdfd8485451e3fa2f1719
   depends:
@@ -9723,13 +7672,7 @@ packages:
   purls: []
   size: 8885078
   timestamp: 1729594772427
-- kind: conda
-  name: libopenvino-intel-gpu-plugin
-  version: 2024.4.0
-  build: hfe1841e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.4.0-hfe1841e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2024.4.0-hfe1841e_2.conda
   sha256: 5e971f5db8eadc20420a7b9f4d9044d38b7daab3d6179ce9d36b2d1f45e43016
   md5: 6d7f9d318217a23933801669f61b5be2
   depends:
@@ -9743,13 +7686,7 @@ packages:
   purls: []
   size: 7173636
   timestamp: 1729596587870
-- kind: conda
-  name: libopenvino-intel-npu-plugin
-  version: 2024.4.0
-  build: hac27bb2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.4.0-hac27bb2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2024.4.0-hac27bb2_2.conda
   sha256: a07bdb55c3214cd5b27736ee6d06abe55782ddf1cfaeb9fffee96179bf12390b
   md5: 724719ce97feb6f310f88ae8dbb40afd
   depends:
@@ -9762,48 +7699,7 @@ packages:
   purls: []
   size: 799335
   timestamp: 1729594804720
-- kind: conda
-  name: libopenvino-ir-frontend
-  version: 2024.4.0
-  build: h03892cd_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2024.4.0-h03892cd_2.conda
-  sha256: 60026c3fe4655c210bde3c447ab84c8f23c9794657f4ea758f27427983056b90
-  md5: 928ecc20581599707acda5c5434bf98d
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libopenvino 2024.4.0 hbfeda7a_2
-  - pugixml >=1.14,<1.15.0a0
-  purls: []
-  size: 173928
-  timestamp: 1729589940535
-- kind: conda
-  name: libopenvino-ir-frontend
-  version: 2024.4.0
-  build: h372dad0_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.4.0-h372dad0_2.conda
-  sha256: d6d7f9d2fcbdffc39a2256c838c3b26a0826330576b844e48f5f050551887032
-  md5: 63b4d6cbf08c634fe74b428811204368
-  depends:
-  - libopenvino 2024.4.0 hfe1841e_2
-  - pugixml >=1.14,<1.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  purls: []
-  size: 157792
-  timestamp: 1729596630667
-- kind: conda
-  name: libopenvino-ir-frontend
-  version: 2024.4.0
-  build: h3f63f65_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.4.0-h3f63f65_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2024.4.0-h3f63f65_2.conda
   sha256: 6038aefea84aeb9534aaf6963d2b266eb757fa36c1a7a9f5e29d6d813bd85a2c
   md5: 8908f31eab30f65636eb61ab9cb1f3ad
   depends:
@@ -9815,13 +7711,7 @@ packages:
   purls: []
   size: 204163
   timestamp: 1729594816408
-- kind: conda
-  name: libopenvino-ir-frontend
-  version: 2024.4.0
-  build: h6ef32b0_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.4.0-h6ef32b0_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2024.4.0-h6ef32b0_2.conda
   sha256: 846de69b4e387684857d824974e07a42213781d6519ab59a7bca768d94c49736
   md5: 60f6f88fa0b0cda9c635963aef4013d7
   depends:
@@ -9832,13 +7722,30 @@ packages:
   purls: []
   size: 192130
   timestamp: 1729590212150
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2024.4.0
-  build: h5c8f2c3_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.4.0-h5c8f2c3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2024.4.0-h03892cd_2.conda
+  sha256: 60026c3fe4655c210bde3c447ab84c8f23c9794657f4ea758f27427983056b90
+  md5: 928ecc20581599707acda5c5434bf98d
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 hbfeda7a_2
+  - pugixml >=1.14,<1.15.0a0
+  purls: []
+  size: 173928
+  timestamp: 1729589940535
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2024.4.0-h372dad0_2.conda
+  sha256: d6d7f9d2fcbdffc39a2256c838c3b26a0826330576b844e48f5f050551887032
+  md5: 63b4d6cbf08c634fe74b428811204368
+  depends:
+  - libopenvino 2024.4.0 hfe1841e_2
+  - pugixml >=1.14,<1.15.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  purls: []
+  size: 157792
+  timestamp: 1729596630667
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2024.4.0-h5c8f2c3_2.conda
   sha256: b68c2ee5fd08c0974ad9395ea0de809b306c261485114cbcbbc0f55c1e0285b3
   md5: e098caa87868e8dcc7ed5d011981207d
   depends:
@@ -9852,13 +7759,33 @@ packages:
   purls: []
   size: 1559399
   timestamp: 1729594827815
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2024.4.0
-  build: h7d5e7ba_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.4.0-h7d5e7ba_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.4.0-haa99d6a_2.conda
+  sha256: e33692a3da876040d877c207290e7df5bef56639466769cb7fdec935754e699d
+  md5: a626d0a2138aea9e65f978e936069fe5
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_2
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  purls: []
+  size: 1404356
+  timestamp: 1729590221767
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2024.4.0-h7f5a098_2.conda
+  sha256: 6f7e9871a71e06e8dae9f2cd43db209fdbe4f957ac778cc7f0f0bed556e04f26
+  md5: 26dcc0a3c16a97c717f88981472db4aa
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 hbfeda7a_2
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  purls: []
+  size: 1227299
+  timestamp: 1729589977734
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2024.4.0-h7d5e7ba_2.conda
   sha256: 4565e94965d036c9964dd1368a1150c872c1f13e57c08b7e7d683a9b0fafc62c
   md5: 6ac156a9f05804265b464eec179e75a7
   depends:
@@ -9872,51 +7799,7 @@ packages:
   purls: []
   size: 991143
   timestamp: 1729596659689
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2024.4.0
-  build: h7f5a098_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2024.4.0-h7f5a098_2.conda
-  sha256: 6f7e9871a71e06e8dae9f2cd43db209fdbe4f957ac778cc7f0f0bed556e04f26
-  md5: 26dcc0a3c16a97c717f88981472db4aa
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcxx >=17
-  - libopenvino 2024.4.0 hbfeda7a_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  purls: []
-  size: 1227299
-  timestamp: 1729589977734
-- kind: conda
-  name: libopenvino-onnx-frontend
-  version: 2024.4.0
-  build: haa99d6a_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2024.4.0-haa99d6a_2.conda
-  sha256: e33692a3da876040d877c207290e7df5bef56639466769cb7fdec935754e699d
-  md5: a626d0a2138aea9e65f978e936069fe5
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libstdcxx >=13
-  purls: []
-  size: 1404356
-  timestamp: 1729590221767
-- kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2024.4.0
-  build: h5c8f2c3_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.4.0-h5c8f2c3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2024.4.0-h5c8f2c3_2.conda
   sha256: fa57b201fb92af0adc2118de8e92648959b98c0dc1a60b278ba2b79c5601eea6
   md5: 59bb8c3502cb9d35f1fb26691730288c
   depends:
@@ -9930,13 +7813,33 @@ packages:
   purls: []
   size: 653105
   timestamp: 1729594841297
-- kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2024.4.0
-  build: h7d5e7ba_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.4.0-h7d5e7ba_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.4.0-haa99d6a_2.conda
+  sha256: 43c3ef7aeb90bcafe93e3946c063d72dc82933818eff7f9eb7a5b51bad430703
+  md5: 75480960fe1dfcfc5f8eeea26e56b4be
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_2
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  purls: []
+  size: 605764
+  timestamp: 1729590232511
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2024.4.0-h7f5a098_2.conda
+  sha256: 4bc7994673c5b7bfe700ca6297f563d7f535403ba28178e6b7f4d54959534aa2
+  md5: c109c0314b83a852d7c85a91b98b277f
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 hbfeda7a_2
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  purls: []
+  size: 418862
+  timestamp: 1729590007426
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2024.4.0-h7d5e7ba_2.conda
   sha256: 49700da26843986434f340b44407eb742f3128cc73392d1f3b050bca3321b1a8
   md5: 2601cb643104e143a84eedde3b9d4689
   depends:
@@ -9950,67 +7853,7 @@ packages:
   purls: []
   size: 419425
   timestamp: 1729596690710
-- kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2024.4.0
-  build: h7f5a098_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2024.4.0-h7f5a098_2.conda
-  sha256: 4bc7994673c5b7bfe700ca6297f563d7f535403ba28178e6b7f4d54959534aa2
-  md5: c109c0314b83a852d7c85a91b98b277f
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcxx >=17
-  - libopenvino 2024.4.0 hbfeda7a_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  purls: []
-  size: 418862
-  timestamp: 1729590007426
-- kind: conda
-  name: libopenvino-paddle-frontend
-  version: 2024.4.0
-  build: haa99d6a_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2024.4.0-haa99d6a_2.conda
-  sha256: 43c3ef7aeb90bcafe93e3946c063d72dc82933818eff7f9eb7a5b51bad430703
-  md5: 75480960fe1dfcfc5f8eeea26e56b4be
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libstdcxx >=13
-  purls: []
-  size: 605764
-  timestamp: 1729590232511
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2024.4.0
-  build: h5833ebf_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2024.4.0-h5833ebf_2.conda
-  sha256: 2b6ee15f5b2f44331c5e161cff01c15b2b109582131f73c6557666748633faac
-  md5: 31f2b940f1c0a5390353b10b72449832
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libopenvino 2024.4.0 hbfeda7a_2
-  purls: []
-  size: 766073
-  timestamp: 1729590028174
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2024.4.0
-  build: h5888daf_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.4.0-h5888daf_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2024.4.0-h5888daf_2.conda
   sha256: a029b3ebff1e8d1d2736a548a616c20066ed6508f238782afbf3a77a4f57c6cd
   md5: e0b88fd64dc95f715ef52e607a9af89b
   depends:
@@ -10021,13 +7864,7 @@ packages:
   purls: []
   size: 1075090
   timestamp: 1729594854413
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2024.4.0
-  build: h5ad3122_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.4.0-h5ad3122_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2024.4.0-h5ad3122_2.conda
   sha256: e86b89a8d7fda8d1015abc1918a23785310348f64b73012e1ea87a639e27a14a
   md5: fbeb65db200c04bac9e95ad05b859161
   depends:
@@ -10037,13 +7874,17 @@ packages:
   purls: []
   size: 996903
   timestamp: 1729590242095
-- kind: conda
-  name: libopenvino-pytorch-frontend
-  version: 2024.4.0
-  build: he0c23c2_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.4.0-he0c23c2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2024.4.0-h5833ebf_2.conda
+  sha256: 2b6ee15f5b2f44331c5e161cff01c15b2b109582131f73c6557666748633faac
+  md5: 31f2b940f1c0a5390353b10b72449832
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 hbfeda7a_2
+  purls: []
+  size: 766073
+  timestamp: 1729590028174
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2024.4.0-he0c23c2_2.conda
   sha256: 2ed421b6874a1cc924d4a304161a38e5228588822f7833bcedcfdf188bab4e7e
   md5: 61bc081531072227ff4ef79110578933
   depends:
@@ -10054,13 +7895,7 @@ packages:
   purls: []
   size: 677080
   timestamp: 1729596717862
-- kind: conda
-  name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
-  build: h6481b9d_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.4.0-h6481b9d_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2024.4.0-h6481b9d_2.conda
   sha256: fdc4871a05bbb61cfe6db1e60018d74cbd6d65d82f03b9be515c3ad41bb7ca04
   md5: 12bf831b85f17368bc71a26ac93a8493
   depends:
@@ -10075,13 +7910,35 @@ packages:
   purls: []
   size: 1282840
   timestamp: 1729594867098
-- kind: conda
-  name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
-  build: h7d689a8_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.4.0-h7d689a8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.4.0-he24a241_2.conda
+  sha256: d7f2247da62e2605f768694144100637afff046989aa6b5d4aff8bc74cdeffbc
+  md5: 91a86ff710cd96f4241ef18aa594a764
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libopenvino 2024.4.0 hd7d4d4f_2
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - libstdcxx >=13
+  - snappy >=1.2.1,<1.3.0a0
+  purls: []
+  size: 1192974
+  timestamp: 1729590252604
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2024.4.0-h9d544f2_2.conda
+  sha256: 577dff3fa81c389878312200a649b4360f44430c4aaf06c93c8f827256b5c6ac
+  md5: 9acac136a616aa3f36fd317eb9ff821a
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=17
+  - libopenvino 2024.4.0 hbfeda7a_2
+  - libprotobuf >=5.28.2,<5.28.3.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  purls: []
+  size: 932555
+  timestamp: 1729590076653
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2024.4.0-h7d689a8_2.conda
   sha256: 4a8e8b7f55a8cb7867a7fad550feeac0e48b51428b5aa6aef65bdcb5ee9fe5b9
   md5: 311bf783bf1677e63d8fbd10545856da
   depends:
@@ -10096,69 +7953,7 @@ packages:
   purls: []
   size: 877353
   timestamp: 1729596749023
-- kind: conda
-  name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
-  build: h9d544f2_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2024.4.0-h9d544f2_2.conda
-  sha256: 577dff3fa81c389878312200a649b4360f44430c4aaf06c93c8f827256b5c6ac
-  md5: 9acac136a616aa3f36fd317eb9ff821a
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcxx >=17
-  - libopenvino 2024.4.0 hbfeda7a_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - snappy >=1.2.1,<1.3.0a0
-  purls: []
-  size: 932555
-  timestamp: 1729590076653
-- kind: conda
-  name: libopenvino-tensorflow-frontend
-  version: 2024.4.0
-  build: he24a241_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2024.4.0-he24a241_2.conda
-  sha256: d7f2247da62e2605f768694144100637afff046989aa6b5d4aff8bc74cdeffbc
-  md5: 91a86ff710cd96f4241ef18aa594a764
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libopenvino 2024.4.0 hd7d4d4f_2
-  - libprotobuf >=5.28.2,<5.28.3.0a0
-  - libstdcxx >=13
-  - snappy >=1.2.1,<1.3.0a0
-  purls: []
-  size: 1192974
-  timestamp: 1729590252604
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
-  build: h5833ebf_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5833ebf_2.conda
-  sha256: 0583c58e6c6796f7c756a10937fa6c7a1c52b1afc1f75451c4690a38ec57f7fd
-  md5: e6b793ea4b5dc41ea6ae1dfc65becabc
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libopenvino 2024.4.0 hbfeda7a_2
-  purls: []
-  size: 369779
-  timestamp: 1729590097301
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
-  build: h5888daf_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5888daf_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5888daf_2.conda
   sha256: a8f26058cf57159492c63fb0622ea2858763ea22338c507ff40a6e9bb792295e
   md5: d48c774c40ea2047adbff043e9076e7a
   depends:
@@ -10169,13 +7964,7 @@ packages:
   purls: []
   size: 466563
   timestamp: 1729594879557
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
-  build: h5ad3122_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5ad3122_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5ad3122_2.conda
   sha256: b67b4c74e97a810a902e4aa81a173db9281955270dae2890afc29320df7659ae
   md5: a3f82dbd3189dffd49ed67216f21e35a
   depends:
@@ -10185,13 +7974,17 @@ packages:
   purls: []
   size: 430404
   timestamp: 1729590264452
-- kind: conda
-  name: libopenvino-tensorflow-lite-frontend
-  version: 2024.4.0
-  build: he0c23c2_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.4.0-he0c23c2_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2024.4.0-h5833ebf_2.conda
+  sha256: 0583c58e6c6796f7c756a10937fa6c7a1c52b1afc1f75451c4690a38ec57f7fd
+  md5: e6b793ea4b5dc41ea6ae1dfc65becabc
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libopenvino 2024.4.0 hbfeda7a_2
+  purls: []
+  size: 369779
+  timestamp: 1729590097301
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2024.4.0-he0c23c2_2.conda
   sha256: e2f6c8c63b3c4a3800a0f8bab558cf7075822a3aa105399cf0c26c1137b02b5a
   md5: 06f6a53a17c793422a1f3c6ca2bd7a74
   depends:
@@ -10202,27 +7995,7 @@ packages:
   purls: []
   size: 324037
   timestamp: 1729596776958
-- kind: conda
-  name: libopus
-  version: 1.3.1
-  build: h27ca646_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
-  sha256: e9912101a58cbc609a1917c5289f3bd1f600c82ed3a1c90a6dd4ca02df77958a
-  md5: 3d0dbee0ccd2f6d6781d270313627b62
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 252854
-  timestamp: 1606823635137
-- kind: conda
-  name: libopus
-  version: 1.3.1
-  build: h7f98852_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
   sha256: 0e1c2740ebd1c93226dc5387461bbcf8142c518f2092f3ea7551f77755decc8f
   md5: 15345e56d527b330e1cacbdf58676e8f
   depends:
@@ -10232,13 +8005,25 @@ packages:
   purls: []
   size: 260658
   timestamp: 1606823578035
-- kind: conda
-  name: libopus
-  version: 1.3.1
-  build: h8ffe710_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
+  sha256: 92a87ade11af2cff41c35cf941f1a79390fde1f113f8e51e1cce30d31b7c8305
+  md5: ac7534c50934ed25e4749d74b04c667a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 328825
+  timestamp: 1606823775764
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
+  sha256: e9912101a58cbc609a1917c5289f3bd1f600c82ed3a1c90a6dd4ca02df77958a
+  md5: 3d0dbee0ccd2f6d6781d270313627b62
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 252854
+  timestamp: 1606823635137
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
   sha256: b2e5ec193762a5b4f905f8100437370e164df3db0ea5c18b4ce09390f5d3d525
   md5: e35a6bcfeb20ea83aab21dfc50ae62a4
   depends:
@@ -10249,47 +8034,7 @@ packages:
   purls: []
   size: 260615
   timestamp: 1606824019288
-- kind: conda
-  name: libopus
-  version: 1.3.1
-  build: hf897c2e_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
-  sha256: 92a87ade11af2cff41c35cf941f1a79390fde1f113f8e51e1cce30d31b7c8305
-  md5: ac7534c50934ed25e4749d74b04c667a
-  depends:
-  - libgcc-ng >=9.3.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 328825
-  timestamp: 1606823775764
-- kind: conda
-  name: libosqp
-  version: 0.6.3
-  build: h5833ebf_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-0.6.3-h5833ebf_1.conda
-  sha256: 05740cc58df7a9c966a277331dea1987db485508c0a35d2ac9ef562f8061df06
-  md5: 7b4c6d7f35e9fe945e810e213d21b942
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libqdldl >=0.1.7,<0.1.8.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 360361
-  timestamp: 1729342406705
-- kind: conda
-  name: libosqp
-  version: 0.6.3
-  build: h5888daf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libosqp-0.6.3-h5888daf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libosqp-0.6.3-h5888daf_1.conda
   sha256: 7c083bdff58df5cc3aed647020fef2a708d2fb57c8a504866db6a1e5e2f12b94
   md5: 2a6b1aade375d6d404a0838c95793f6a
   depends:
@@ -10302,13 +8047,7 @@ packages:
   purls: []
   size: 432789
   timestamp: 1729342281763
-- kind: conda
-  name: libosqp
-  version: 0.6.3
-  build: h5ad3122_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-0.6.3-h5ad3122_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libosqp-0.6.3-h5ad3122_1.conda
   sha256: 005a3ff75e883f480f5b25644addcef31d8213106229b6d42b665f7fbdff0a2f
   md5: 2620cfedf3f3d4722f4508cca423ecac
   depends:
@@ -10320,13 +8059,19 @@ packages:
   purls: []
   size: 414572
   timestamp: 1729342273243
-- kind: conda
-  name: libosqp
-  version: 0.6.3
-  build: he0c23c2_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libosqp-0.6.3-he0c23c2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libosqp-0.6.3-h5833ebf_1.conda
+  sha256: 05740cc58df7a9c966a277331dea1987db485508c0a35d2ac9ef562f8061df06
+  md5: 7b4c6d7f35e9fe945e810e213d21b942
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libqdldl >=0.1.7,<0.1.8.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 360361
+  timestamp: 1729342406705
+- conda: https://conda.anaconda.org/conda-forge/win-64/libosqp-0.6.3-he0c23c2_1.conda
   sha256: 4960d81fe9251fa0dd11b171716a1e5b76ea10f583c82766b27b219f739b97ec
   md5: 3cb8c763b4cc0d0d99931fe296cb9df2
   depends:
@@ -10339,27 +8084,7 @@ packages:
   purls: []
   size: 268107
   timestamp: 1729342615595
-- kind: conda
-  name: libpciaccess
-  version: '0.18'
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h31becfc_0.conda
-  sha256: 0c6806dcd53da457c472cf22ad7793aef074cb198a10677a91b02c7dceeee770
-  md5: 6d48179630f00e8c9ad9e30879ce1e54
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 29211
-  timestamp: 1707101477910
-- kind: conda
-  name: libpciaccess
-  version: '0.18'
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
   sha256: c0a30ac74eba66ea76a4f0a39acc7833f5ed783a632ca3bb6665b2d81aabd2fb
   md5: 48f4330bfcd959c3cfb704d424903c82
   depends:
@@ -10369,12 +8094,48 @@ packages:
   purls: []
   size: 28361
   timestamp: 1707101388552
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: h3ca93ac_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h31becfc_0.conda
+  sha256: 0c6806dcd53da457c472cf22ad7793aef074cb198a10677a91b02c7dceeee770
+  md5: 6d48179630f00e8c9ad9e30879ce1e54
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 29211
+  timestamp: 1707101477910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  purls: []
+  size: 290661
+  timestamp: 1726234747153
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.44-hc4a20ef_0.conda
+  sha256: 23b5ce15cf9c6017641a8396bab00ae807dd9f662718cfa7f61de114d0c97647
+  md5: 5d25802b25fcc7419fa13e21affaeb3a
+  depends:
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  purls: []
+  size: 294907
+  timestamp: 1726236639270
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
+  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
+  md5: fb36e93f0ea6a6f5d2b99984f34b049e
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  purls: []
+  size: 263385
+  timestamp: 1726234714421
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
   sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
   md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
   depends:
@@ -10386,59 +8147,7 @@ packages:
   purls: []
   size: 348933
   timestamp: 1726235196095
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: hadc24fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
-  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
-  md5: f4cc49d7aa68316213e4b12be35308d1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: zlib-acknowledgement
-  purls: []
-  size: 290661
-  timestamp: 1726234747153
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: hc14010f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
-  sha256: 38f8759a3eb8060deabd4db41f0f023514d853e46ddcbd0ba21768fc4e563bb1
-  md5: fb36e93f0ea6a6f5d2b99984f34b049e
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: zlib-acknowledgement
-  purls: []
-  size: 263385
-  timestamp: 1726234714421
-- kind: conda
-  name: libpng
-  version: 1.6.44
-  build: hc4a20ef_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.44-hc4a20ef_0.conda
-  sha256: 23b5ce15cf9c6017641a8396bab00ae807dd9f662718cfa7f61de114d0c97647
-  md5: 5d25802b25fcc7419fa13e21affaeb3a
-  depends:
-  - libgcc >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: zlib-acknowledgement
-  purls: []
-  size: 294907
-  timestamp: 1726236639270
-- kind: conda
-  name: libpq
-  version: '16.4'
-  build: h2d7952a_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.4-h2d7952a_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.4-h2d7952a_3.conda
   sha256: 51dddb6e5879960a1b9b3c5de0eb970373903977c0fa68a42f86bb7197c695cf
   md5: 50e2dddb3417a419cbc2388d0b1c06f7
   depends:
@@ -10450,13 +8159,7 @@ packages:
   purls: []
   size: 2530022
   timestamp: 1729085009049
-- kind: conda
-  name: libpq
-  version: '16.4'
-  build: hb7c570e_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.4-hb7c570e_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.4-hb7c570e_3.conda
   sha256: cd17b7b1fa11907c28319a80c18cd025ec8344be630a2b3f7dfe97b3ef682000
   md5: 49e510416b386a1ea805edf38ce09956
   depends:
@@ -10467,13 +8170,7 @@ packages:
   purls: []
   size: 2661524
   timestamp: 1729085053843
-- kind: conda
-  name: libpq
-  version: '16.4'
-  build: hfb0b52a_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.4-hfb0b52a_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.4-hfb0b52a_3.conda
   sha256: 7c9766926fa1bfad284d27dc252eeddb189126ea5694da8f8045f1fb55c8f8d3
   md5: ce76e2611f75bfe95efb239bd69be770
   depends:
@@ -10484,31 +8181,7 @@ packages:
   purls: []
   size: 2411968
   timestamp: 1729085615848
-- kind: conda
-  name: libprotobuf
-  version: 5.28.2
-  build: h029595c_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.28.2-h029595c_0.conda
-  sha256: d8c7b6f851bfc53494d9b8e54d473c4f11ab26483a6e64df6f7967563df166b1
-  md5: 538dbe0ad9f248e2e109abb9b6809ea5
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 2802876
-  timestamp: 1728564881988
-- kind: conda
-  name: libprotobuf
-  version: 5.28.2
-  build: h5b01275_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.28.2-h5b01275_0.conda
   sha256: 5e8fd4aa00193c85602ce6101dd28fe31306dff85c9725048f6dc828dfa7c421
   md5: ab0bff36363bec94720275a681af8b83
   depends:
@@ -10523,12 +8196,21 @@ packages:
   purls: []
   size: 2945348
   timestamp: 1728565355702
-- kind: conda
-  name: libprotobuf
-  version: 5.28.2
-  build: h8f0b736_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.28.2-h029595c_0.conda
+  sha256: d8c7b6f851bfc53494d9b8e54d473c4f11ab26483a6e64df6f7967563df166b1
+  md5: 538dbe0ad9f248e2e109abb9b6809ea5
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2802876
+  timestamp: 1728564881988
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.2-h8f0b736_0.conda
   sha256: f732a6fa918428e2d5ba61e78fe11bb44a002cc8f6bb74c94ee5b1297fefcfd8
   md5: d2cb5991f2fb8eb079c80084435e9ce6
   depends:
@@ -10542,12 +8224,7 @@ packages:
   purls: []
   size: 2374965
   timestamp: 1728565334796
-- kind: conda
-  name: libprotobuf
-  version: 5.28.2
-  build: hcaed137_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.28.2-hcaed137_0.conda
   sha256: 798c6675fb709ceaa6a9bd83e9cffe06bc98e83f519c7d7d881243d2e6d0c34d
   md5: 97c6d2f83edd7b400a22660e2a4d1488
   depends:
@@ -10562,12 +8239,39 @@ packages:
   purls: []
   size: 6033581
   timestamp: 1728565880841
-- kind: conda
-  name: libqdldl
-  version: 0.1.7
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libqdldl-0.1.7-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.7-hcb278e6_0.conda
+  sha256: 62230c93e8f7508a97e5b3a439b2b981eda9aa192cbc08497cbcca220ebf3acc
+  md5: 9221c4cca4d44cf4103fbdd47595e3dd
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 18277
+  timestamp: 1680741612751
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.7-hd600fc2_0.conda
+  sha256: 231a460dd87408d1d07150ffd53c29a8d8aaa494f111c83a369d85b53bf4015d
+  md5: 07140396b010c957bf75471ea7fcb858
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 18380
+  timestamp: 1680741551284
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.7-hb7217d7_0.conda
+  sha256: 39bb718bca8ce87afdc592d857944ba39bfac54c31a1de4d669597b52bc668ea
+  md5: b4df6812b4ab33c1a520287f46d91220
+  depends:
+  - libcxx >=14.0.6
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 17189
+  timestamp: 1680741853527
+- conda: https://conda.anaconda.org/conda-forge/win-64/libqdldl-0.1.7-h63175ca_0.conda
   sha256: 706c0405c5d01e58d08dfc26a9b49b7121e25f4913f594692f05afe45dacca6f
   md5: 0f2bbabcd06bfd6015a783a788f88b0f
   depends:
@@ -10579,125 +8283,7 @@ packages:
   purls: []
   size: 21662
   timestamp: 1680741889208
-- kind: conda
-  name: libqdldl
-  version: 0.1.7
-  build: hb7217d7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libqdldl-0.1.7-hb7217d7_0.conda
-  sha256: 39bb718bca8ce87afdc592d857944ba39bfac54c31a1de4d669597b52bc668ea
-  md5: b4df6812b4ab33c1a520287f46d91220
-  depends:
-  - libcxx >=14.0.6
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 17189
-  timestamp: 1680741853527
-- kind: conda
-  name: libqdldl
-  version: 0.1.7
-  build: hcb278e6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libqdldl-0.1.7-hcb278e6_0.conda
-  sha256: 62230c93e8f7508a97e5b3a439b2b981eda9aa192cbc08497cbcca220ebf3acc
-  md5: 9221c4cca4d44cf4103fbdd47595e3dd
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 18277
-  timestamp: 1680741612751
-- kind: conda
-  name: libqdldl
-  version: 0.1.7
-  build: hd600fc2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libqdldl-0.1.7-hd600fc2_0.conda
-  sha256: 231a460dd87408d1d07150ffd53c29a8d8aaa494f111c83a369d85b53bf4015d
-  md5: 07140396b010c957bf75471ea7fcb858
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 18380
-  timestamp: 1680741551284
-- kind: conda
-  name: librsvg
-  version: 2.58.4
-  build: h00090f3_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.58.4-h00090f3_0.conda
-  sha256: f27d29bec094cd4a9190409a0e881a8eac2affdf2bda850d9f2a580b3280ab96
-  md5: e217f742afbec9f3632e73602dadb810
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - gdk-pixbuf >=2.42.12,<3.0a0
-  - harfbuzz >=9.0.0,<10.0a0
-  - libgcc >=13
-  - libglib >=2.80.3,<3.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - pango >=1.54.0,<2.0a0
-  constrains:
-  - __glibc >=2.17
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 6366018
-  timestamp: 1726236562130
-- kind: conda
-  name: librsvg
-  version: 2.58.4
-  build: h33bc1f6_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/librsvg-2.58.4-h33bc1f6_0.conda
-  sha256: 21d3c867a7cfa28ed7e77840c0275ac4ae8a3eb4d17455b920cb0c24051d84f1
-  md5: 40b2421b8358e85cde3f153022b6f364
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - gdk-pixbuf >=2.42.12,<3.0a0
-  - libglib >=2.80.3,<3.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - pango >=1.54.0,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.40.33810
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 3871820
-  timestamp: 1726228304069
-- kind: conda
-  name: librsvg
-  version: 2.58.4
-  build: h40956f1_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.4-h40956f1_0.conda
-  sha256: 88cd8603a6fe6c3299e9cd0a81f5e38cf431d20b7d3e2e6642c8a41113ede6db
-  md5: 27c333944e11caae7bc3a35178d32ac5
-  depends:
-  - __osx >=11.0
-  - cairo >=1.18.0,<2.0a0
-  - gdk-pixbuf >=2.42.12,<3.0a0
-  - libglib >=2.80.3,<3.0a0
-  - libxml2 >=2.12.7,<3.0a0
-  - pango >=1.54.0,<2.0a0
-  constrains:
-  - __osx >=11.0
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 4688893
-  timestamp: 1726228099207
-- kind: conda
-  name: librsvg
-  version: 2.58.4
-  build: hc0ffecb_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-hc0ffecb_0.conda
   sha256: fda3197ffb24512e719d55defa02f9f70286038e56cad8c1d580ed6460f417fa
   md5: 83f045969988f5c7a65f3950b95a8b35
   depends:
@@ -10717,13 +8303,58 @@ packages:
   purls: []
   size: 6390511
   timestamp: 1726227212382
-- kind: conda
-  name: libscotch
-  version: 7.0.5
-  build: h3428b0d_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.5-h3428b0d_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librsvg-2.58.4-h00090f3_0.conda
+  sha256: f27d29bec094cd4a9190409a0e881a8eac2affdf2bda850d9f2a580b3280ab96
+  md5: e217f742afbec9f3632e73602dadb810
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - harfbuzz >=9.0.0,<10.0a0
+  - libgcc >=13
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - pango >=1.54.0,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 6366018
+  timestamp: 1726236562130
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.4-h40956f1_0.conda
+  sha256: 88cd8603a6fe6c3299e9cd0a81f5e38cf431d20b7d3e2e6642c8a41113ede6db
+  md5: 27c333944e11caae7bc3a35178d32ac5
+  depends:
+  - __osx >=11.0
+  - cairo >=1.18.0,<2.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - pango >=1.54.0,<2.0a0
+  constrains:
+  - __osx >=11.0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 4688893
+  timestamp: 1726228099207
+- conda: https://conda.anaconda.org/conda-forge/win-64/librsvg-2.58.4-h33bc1f6_0.conda
+  sha256: 21d3c867a7cfa28ed7e77840c0275ac4ae8a3eb4d17455b920cb0c24051d84f1
+  md5: 40b2421b8358e85cde3f153022b6f364
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - libglib >=2.80.3,<3.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - pango >=1.54.0,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.40.33810
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 3871820
+  timestamp: 1726228304069
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libscotch-7.0.5-h3428b0d_2.conda
   sha256: 18d517b71e832698477ce58be8a77dd83326c1b82745e61dc6be25c68f319cbd
   md5: f32423a30fe0f5634ce1a16916d3bc76
   depends:
@@ -10739,13 +8370,7 @@ packages:
   purls: []
   size: 343836
   timestamp: 1728823102739
-- kind: conda
-  name: libscotch
-  version: 7.0.5
-  build: h57f7dbb_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.5-h57f7dbb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libscotch-7.0.5-h57f7dbb_2.conda
   sha256: f7981a98752f5115049c41922bff8f84b4beae663bb5e036c395f96b01b11d00
   md5: 537c6cc6087ef85bc75e323508bb43c6
   depends:
@@ -10760,13 +8385,7 @@ packages:
   purls: []
   size: 358635
   timestamp: 1728825149231
-- kind: conda
-  name: libscotch
-  version: 7.0.5
-  build: h9f781f6_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.5-h9f781f6_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.5-h9f781f6_2.conda
   sha256: 589231872f000f96c4f27ee8fadd388631a7edd2c68b06c4987d77981681bb95
   md5: 588d606a602d0058bd6c63a81fc4cfc8
   depends:
@@ -10781,36 +8400,7 @@ packages:
   purls: []
   size: 270272
   timestamp: 1728823368136
-- kind: conda
-  name: libsndfile
-  version: 1.2.2
-  build: h79657aa_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
-  sha256: 8fcd5e45d6fb071e8baf492ebb8710203fd5eedf0cb791e007265db373c89942
-  md5: ad8e62c0faec46b1442f960489c80b49
-  depends:
-  - lame >=3.100,<3.101.0a0
-  - libflac >=1.4.3,<1.5.0a0
-  - libgcc-ng >=12
-  - libogg >=1.3.4,<1.4.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libstdcxx-ng >=12
-  - libvorbis >=1.3.7,<1.4.0a0
-  - mpg123 >=1.32.1,<1.33.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  purls: []
-  size: 396501
-  timestamp: 1695747749825
-- kind: conda
-  name: libsndfile
-  version: 1.2.2
-  build: hc60ed4a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
   sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
   md5: ef1910918dd895516a769ed36b5b3a4e
   depends:
@@ -10827,13 +8417,24 @@ packages:
   purls: []
   size: 354372
   timestamp: 1695747735668
-- kind: conda
-  name: libspral
-  version: 2024.05.08
-  build: h2b245be_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libspral-2024.05.08-h2b245be_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
+  sha256: 8fcd5e45d6fb071e8baf492ebb8710203fd5eedf0cb791e007265db373c89942
+  md5: ad8e62c0faec46b1442f960489c80b49
+  depends:
+  - lame >=3.100,<3.101.0a0
+  - libflac >=1.4.3,<1.5.0a0
+  - libgcc-ng >=12
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libvorbis >=1.3.7,<1.4.0a0
+  - mpg123 >=1.32.1,<1.33.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 396501
+  timestamp: 1695747749825
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libspral-2024.05.08-h2b245be_4.conda
   sha256: 79ebc8f15625aede815019bd58c32ee8327c68e93a52adbdace68fbf7d64a288
   md5: 5e90da1c9b6f156657eaabcbd254e799
   depends:
@@ -10854,13 +8455,7 @@ packages:
   purls: []
   size: 354213
   timestamp: 1730491842874
-- kind: conda
-  name: libspral
-  version: 2024.05.08
-  build: hc4cad06_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2024.05.08-hc4cad06_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspral-2024.05.08-hc4cad06_4.conda
   sha256: 3af438647c97608687237ca89b4fd5caf75b63e194ab5f2b910e3a38347c52f6
   md5: eb90416dfecf86193acce7d71c83a800
   depends:
@@ -10880,30 +8475,7 @@ packages:
   purls: []
   size: 343091
   timestamp: 1730496384733
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: h2466b09_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
-  sha256: 3342d6fe787f5830f7e8466d9c65c914bfd8d67220fb5673041b338cbba47afe
-  md5: 5b1f36012cc3d09c4eb9f24ad0e2c379
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Unlicense
-  purls: []
-  size: 892175
-  timestamp: 1730208431651
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: hadc24fc_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.47.0-hadc24fc_1.conda
   sha256: 8a9aadf996a2399f65b679c6e7f29139d5059f699c63e6d7b50e20db10c00508
   md5: b6f02b52a174e612e89548f4663ce56a
   depends:
@@ -10914,29 +8486,7 @@ packages:
   purls: []
   size: 875349
   timestamp: 1730208050020
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: hbaaea75_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
-  sha256: 5a96caa566c11e5a5ebdcdb86a0759a7fb27d3c5f42e6a0fd0d6023c1e935d9e
-  md5: 07a14fbe439eef078cc479deca321161
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: Unlicense
-  purls: []
-  size: 837683
-  timestamp: 1730208293578
-- kind: conda
-  name: libsqlite
-  version: 3.47.0
-  build: hc4a20ef_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.47.0-hc4a20ef_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.47.0-hc4a20ef_1.conda
   sha256: 73e143fdb966b61cd25ab804d416d87dfce43ac684e0fac3ad8b1450796331ab
   md5: a6b185aac10d08028340858f77231b23
   depends:
@@ -10946,12 +8496,28 @@ packages:
   purls: []
   size: 1041855
   timestamp: 1730208187962
-- kind: conda
-  name: libssh2
-  version: 1.11.0
-  build: h0841786_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.47.0-hbaaea75_1.conda
+  sha256: 5a96caa566c11e5a5ebdcdb86a0759a7fb27d3c5f42e6a0fd0d6023c1e935d9e
+  md5: 07a14fbe439eef078cc479deca321161
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  purls: []
+  size: 837683
+  timestamp: 1730208293578
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
+  sha256: 3342d6fe787f5830f7e8466d9c65c914bfd8d67220fb5673041b338cbba47afe
+  md5: 5b1f36012cc3d09c4eb9f24ad0e2c379
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  purls: []
+  size: 892175
+  timestamp: 1730208431651
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
   sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
   md5: 1f5a58e686b13bcfde88b93f547d23fe
   depends:
@@ -10963,12 +8529,7 @@ packages:
   purls: []
   size: 271133
   timestamp: 1685837707056
-- kind: conda
-  name: libssh2
-  version: 1.11.0
-  build: h492db2e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
   sha256: 409163dd4a888b9266369f1bce57b5ca56c216e34249637c3e10eb404e356171
   md5: 45532845e121677ad328c9af9953f161
   depends:
@@ -10980,12 +8541,7 @@ packages:
   purls: []
   size: 284335
   timestamp: 1685837600415
-- kind: conda
-  name: libssh2
-  version: 1.11.0
-  build: h7a5bd25_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
   sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
   md5: 029f7dc931a3b626b94823bc77830b01
   depends:
@@ -10996,12 +8552,7 @@ packages:
   purls: []
   size: 255610
   timestamp: 1685837894256
-- kind: conda
-  name: libssh2
-  version: 1.11.0
-  build: h7dfc565_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
   sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
   md5: dc262d03aae04fe26825062879141a41
   depends:
@@ -11015,29 +8566,7 @@ packages:
   purls: []
   size: 266806
   timestamp: 1685838242099
-- kind: conda
-  name: libstdcxx
-  version: 14.2.0
-  build: h3f4de04_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_1.conda
-  sha256: 519556d2c93f1b487091ce046d62e762286177f4a670ec10e16005177d0bcab3
-  md5: 37f489acd39e22b623d2d1e5ac6d195c
-  depends:
-  - libgcc 14.2.0 he277a41_1
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 3816794
-  timestamp: 1729089463404
-- kind: conda
-  name: libstdcxx
-  version: 14.2.0
-  build: hc0a3c3a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
   sha256: 4661af0eb9bdcbb5fb33e5d0023b001ad4be828fccdcc56500059d56f9869462
   md5: 234a5554c53625688d51062645337328
   depends:
@@ -11047,13 +8576,17 @@ packages:
   purls: []
   size: 3893695
   timestamp: 1729027746910
-- kind: conda
-  name: libstdcxx-ng
-  version: 14.2.0
-  build: h4852527_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_1.conda
+  sha256: 519556d2c93f1b487091ce046d62e762286177f4a670ec10e16005177d0bcab3
+  md5: 37f489acd39e22b623d2d1e5ac6d195c
+  depends:
+  - libgcc 14.2.0 he277a41_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 3816794
+  timestamp: 1729089463404
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
   sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
   md5: 8371ac6457591af2cf6159439c1fd051
   depends:
@@ -11063,13 +8596,7 @@ packages:
   purls: []
   size: 54105
   timestamp: 1729027780628
-- kind: conda
-  name: libstdcxx-ng
-  version: 14.2.0
-  build: hf1166c9_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_1.conda
   sha256: 9f97461bd55a2745a7a0941f3502a047f15bfe7bb2952dc7fb204b3202f866fd
   md5: 0e75771b8a03afae5a2c6ce71bc733f5
   depends:
@@ -11079,13 +8606,7 @@ packages:
   purls: []
   size: 54133
   timestamp: 1729089498541
-- kind: conda
-  name: libsystemd0
-  version: '256.7'
-  build: h2774228_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-256.7-h2774228_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-256.7-h2774228_1.conda
   sha256: fa9cfbacaa2f14072b07ff9c832a8750627755346a1472f116a94aecea28f08e
   md5: ad328c530a12a8798776e5f03942090f
   depends:
@@ -11100,13 +8621,7 @@ packages:
   purls: []
   size: 411535
   timestamp: 1729786797378
-- kind: conda
-  name: libsystemd0
-  version: '256.7'
-  build: hd54d049_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-256.7-hd54d049_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-256.7-hd54d049_1.conda
   sha256: 6deceabf4a4109293aacba77a61a83d5bdef028b879b29d3b819937c80de8909
   md5: c44e82f6be3d65cf0589f1182e162ce8
   depends:
@@ -11120,13 +8635,7 @@ packages:
   purls: []
   size: 430774
   timestamp: 1729786916983
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: he137b08_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-he137b08_1.conda
   sha256: 9890121db85f6ef463fe12eb04ef1471176e3ef3b5e2d62e8d6dac713df00df4
   md5: 63872517c98aa305da58a757c443698e
   depends:
@@ -11144,13 +8653,7 @@ packages:
   purls: []
   size: 428156
   timestamp: 1728232228989
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: hec21d91_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-hec21d91_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-hec21d91_1.conda
   sha256: 14ecb9e129b1b5ffd6d4bee48de95cd2cd0973c712e1b965d3ef977cca23936d
   md5: 1f80061f5ba6956fcdc381f34618cd8d
   depends:
@@ -11167,36 +8670,7 @@ packages:
   purls: []
   size: 464938
   timestamp: 1728232266969
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: hfc51747_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
-  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
-  md5: eac317ed1cc6b9c0af0c27297e364665
-  depends:
-  - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: HPND
-  purls: []
-  size: 978865
-  timestamp: 1728232594877
-- kind: conda
-  name: libtiff
-  version: 4.7.0
-  build: hfce79cd_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.0-hfce79cd_1.conda
   sha256: 97ba24c74750b6e731b3fe0d2a751cda6148b4937d2cc3f72d43bf7b3885c39d
   md5: b9abf45f7c64caf3303725f1aa0e9a4d
   depends:
@@ -11213,12 +8687,24 @@ packages:
   purls: []
   size: 366323
   timestamp: 1728232400072
-- kind: conda
-  name: libuuid
-  version: 2.38.1
-  build: h0b41bf4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.0-hfc51747_1.conda
+  sha256: 902cb9f7f54d17dcfd54ce050b1ce2bc944b9bbd1748913342c2ea1e1140f8bb
+  md5: eac317ed1cc6b9c0af0c27297e364665
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: HPND
+  purls: []
+  size: 978865
+  timestamp: 1728232594877
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
   sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
@@ -11228,12 +8714,7 @@ packages:
   purls: []
   size: 33601
   timestamp: 1680112270483
-- kind: conda
-  name: libuuid
-  version: 2.38.1
-  build: hb4cce97_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
   sha256: 616277b0c5f7616c2cdf36f6c316ea3f9aa5bb35f2d4476a349ab58b9b91675f
   md5: 000e30b09db0b7c775b21695dff30969
   depends:
@@ -11243,13 +8724,7 @@ packages:
   purls: []
   size: 35720
   timestamp: 1680113474501
-- kind: conda
-  name: libva
-  version: 2.22.0
-  build: h8a09558_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h8a09558_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.22.0-h8a09558_1.conda
   sha256: 0bd81019e02cce8d9d4077c96b82ca03c9b0ece67831c7437f977ca1f5a924a3
   md5: 139262125a3eac8ff6eef898598745a3
   depends:
@@ -11270,46 +8745,7 @@ packages:
   purls: []
   size: 217708
   timestamp: 1726828458441
-- kind: conda
-  name: libvorbis
-  version: 1.3.7
-  build: h01db608_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
-  sha256: 1ade4727be5c52b287001b8094d02af66342dfe0ba13ef69222aaaf2e9be4342
-  md5: c2863ff72c6d8a59054f8b9102c206e9
-  depends:
-  - libgcc-ng >=9.3.0
-  - libogg >=1.3.4,<1.4.0a0
-  - libstdcxx-ng >=9.3.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 292082
-  timestamp: 1610616294416
-- kind: conda
-  name: libvorbis
-  version: 1.3.7
-  build: h0e60522_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
-  sha256: 6cdc018a024908270205d8512d92f92cf0adaaa5401c2b403757189b138bf56a
-  md5: e1a22282de0169c93e4ffe6ce6acc212
-  depends:
-  - libogg >=1.3.4,<1.4.0a0
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 273721
-  timestamp: 1610610022421
-- kind: conda
-  name: libvorbis
-  version: 1.3.7
-  build: h9c3ff4c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
   sha256: 53080d72388a57b3c31ad5805c93a7328e46ff22fab7c44ad2a86d712740af33
   md5: 309dec04b70a3cc0f1e84a4013683bc0
   depends:
@@ -11321,12 +8757,19 @@ packages:
   purls: []
   size: 286280
   timestamp: 1610609811627
-- kind: conda
-  name: libvorbis
-  version: 1.3.7
-  build: h9f76cd9_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h9f76cd9_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
+  sha256: 1ade4727be5c52b287001b8094d02af66342dfe0ba13ef69222aaaf2e9be4342
+  md5: c2863ff72c6d8a59054f8b9102c206e9
+  depends:
+  - libgcc-ng >=9.3.0
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 292082
+  timestamp: 1610616294416
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h9f76cd9_0.tar.bz2
   sha256: 60457217e20d8b24a8390c81338a8fa69c8656b440c067cd82f802a09da93cb9
   md5: 92a1a88d1a1d468c19d9e1659ac8d3df
   depends:
@@ -11337,44 +8780,19 @@ packages:
   purls: []
   size: 254839
   timestamp: 1610609991029
-- kind: conda
-  name: libvpx
-  version: 1.14.1
-  build: h0a1ffab_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
-  sha256: 918493354f78cb3bb2c3d91264afbcb312b2afe287237e7d1c85ee7e96d15b47
-  md5: 3cb63f822a49e4c406639ebf8b5d87d7
+- conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
+  sha256: 6cdc018a024908270205d8512d92f92cf0adaaa5401c2b403757189b138bf56a
+  md5: e1a22282de0169c93e4ffe6ce6acc212
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - libogg >=1.3.4,<1.4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 1211700
-  timestamp: 1717859955539
-- kind: conda
-  name: libvpx
-  version: 1.14.1
-  build: h7bae524_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.14.1-h7bae524_0.conda
-  sha256: 5d6458b5395cba0804846f156574aa8a34eef6d5f05d39e9932ddbb4215f8bd0
-  md5: 95bee48afff34f203e4828444c2b2ae9
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 1178981
-  timestamp: 1717860096742
-- kind: conda
-  name: libvpx
-  version: 1.14.1
-  build: hac33072_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
+  size: 273721
+  timestamp: 1610610022421
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.14.1-hac33072_0.conda
   sha256: e7d2daf409c807be48310fcc8924e481b62988143f582eb3a58c5523a6763b13
   md5: cde393f461e0c169d9ffb2fc70f81c33
   depends:
@@ -11385,12 +8803,41 @@ packages:
   purls: []
   size: 1022466
   timestamp: 1717859935011
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.14.1-h0a1ffab_0.conda
+  sha256: 918493354f78cb3bb2c3d91264afbcb312b2afe287237e7d1c85ee7e96d15b47
+  md5: 3cb63f822a49e4c406639ebf8b5d87d7
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1211700
+  timestamp: 1717859955539
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.14.1-h7bae524_0.conda
+  sha256: 5d6458b5395cba0804846f156574aa8a34eef6d5f05d39e9932ddbb4215f8bd0
+  md5: 95bee48afff34f203e4828444c2b2ae9
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1178981
+  timestamp: 1717860096742
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 438953
+  timestamp: 1713199854503
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
   sha256: 10dded60f274e29c573cfacf6e96f5d0fc374ee431250374a44cbd773916ab9d
   md5: 5fd7ab3e5f382c70607fbac6335e6e19
   depends:
@@ -11402,12 +8849,7 @@ packages:
   purls: []
   size: 363577
   timestamp: 1713201785160
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: h93a5062_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
   sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
   md5: c0af0edfebe780b19940e94871f1a765
   constrains:
@@ -11417,12 +8859,7 @@ packages:
   purls: []
   size: 287750
   timestamp: 1713200194013
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
   sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
   md5: abd61d0ab127ec5cd68f62c2969e6f34
   depends:
@@ -11436,47 +8873,7 @@ packages:
   purls: []
   size: 274359
   timestamp: 1713200524021
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
-  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
-  md5: b26e8aa824079e1be0294e7152ca4559
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - libwebp 1.4.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 438953
-  timestamp: 1713199854503
-- kind: conda
-  name: libxcb
-  version: 1.17.0
-  build: h262b8f6_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
-  sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
-  md5: cd14ee5cca2464a425b1dbfc24d90db2
-  depends:
-  - libgcc >=13
-  - pthread-stubs
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxdmcp
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 397493
-  timestamp: 1727280745441
-- kind: conda
-  name: libxcb
-  version: 1.17.0
-  build: h8a09558_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
   sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
   md5: 92ed62436b625154323d40d5f2f11dd7
   depends:
@@ -11490,12 +8887,20 @@ packages:
   purls: []
   size: 395888
   timestamp: 1727278577118
-- kind: conda
-  name: libxcb
-  version: 1.17.0
-  build: hdb1d25a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+  sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
+  md5: cd14ee5cca2464a425b1dbfc24d90db2
+  depends:
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 397493
+  timestamp: 1727280745441
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
   sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
   md5: af523aae2eca6dfa1c8eec693f5b9a79
   depends:
@@ -11508,28 +8913,7 @@ packages:
   purls: []
   size: 323658
   timestamp: 1727278733917
-- kind: conda
-  name: libxcrypt
-  version: 4.4.36
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
-  sha256: 6b46c397644091b8a26a3048636d10b989b1bf266d4be5e9474bf763f828f41f
-  md5: b4df5d7d4b63579d081fd3a4cf99740e
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 114269
-  timestamp: 1702724369203
-- kind: conda
-  name: libxcrypt
-  version: 4.4.36
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
@@ -11538,13 +8922,16 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
-- kind: conda
-  name: libxkbcommon
-  version: 1.7.0
-  build: h2c5496b_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
+  sha256: 6b46c397644091b8a26a3048636d10b989b1bf266d4be5e9474bf763f828f41f
+  md5: b4df5d7d4b63579d081fd3a4cf99740e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 114269
+  timestamp: 1702724369203
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
   sha256: 6804c2a7062d10de6f159f7106dc45ebccc8d42bfb925f7919e26e567fa6da6b
   md5: e2eaefa4de2b7237af7c907b8bbc760a
   depends:
@@ -11559,13 +8946,7 @@ packages:
   purls: []
   size: 593336
   timestamp: 1718819935698
-- kind: conda
-  name: libxkbcommon
-  version: 1.7.0
-  build: h46f2afe_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h46f2afe_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h46f2afe_1.conda
   sha256: 8ed470f72c733aea32bb5d272bf458041add7923d7716d5046bd40edf7ddd67c
   md5: 78a24e611ab9c09c518f519be49c2e46
   depends:
@@ -11580,53 +8961,7 @@ packages:
   purls: []
   size: 596053
   timestamp: 1718819931537
-- kind: conda
-  name: libxml2
-  version: 2.13.4
-  build: h442d1da_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.4-h442d1da_2.conda
-  sha256: 352eb281dcac491b7ed9e01082947d734a2610f3700f1ab18524590a2862f069
-  md5: 46c233e5c137a2de2d1d95ca35ad8d6a
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 1518137
-  timestamp: 1730355951612
-- kind: conda
-  name: libxml2
-  version: 2.13.4
-  build: h8424949_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.4-h8424949_2.conda
-  sha256: 51048cd9d4d7ab3ab440bac01d1db8193ae1bd3e9502cdf6792a69c792fec2e5
-  md5: 3f0764c38bc02720231d49d6035531f2
-  depends:
-  - __osx >=11.0
-  - icu >=75.1,<76.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - xz >=5.2.6,<6.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 572400
-  timestamp: 1730356085177
-- kind: conda
-  name: libxml2
-  version: 2.13.4
-  build: hb346dea_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.4-hb346dea_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.4-hb346dea_2.conda
   sha256: a111cb7f2deb6e20ebb475e8426ce5291451476f55f0dec6c220aa51e5a5784f
   md5: 69b90b70c434b916abf5a1d5ee5d55fb
   depends:
@@ -11641,13 +8976,7 @@ packages:
   purls: []
   size: 690019
   timestamp: 1730355770718
-- kind: conda
-  name: libxml2
-  version: 2.13.4
-  build: hf4efe5d_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.13.4-hf4efe5d_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.13.4-hf4efe5d_2.conda
   sha256: 69d6197742a7cca2c9a030bf5c6f61d943d45deeaeb3b2df92ebdfd933524ae0
   md5: 0e28ab30d29c5a566d05bf73dfc5c184
   depends:
@@ -11661,45 +8990,35 @@ packages:
   purls: []
   size: 733127
   timestamp: 1730356005200
-- kind: conda
-  name: libyarp
-  version: 3.9.0
-  build: h01dc7ee_6
-  build_number: 6
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-h01dc7ee_6.conda
-  sha256: 79d4076016bad050b50746d83254758585088b22633b9952b1179a46d29fcf28
-  md5: d1e2b8bcf69afd42216ea25dcd204fed
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.4-h8424949_2.conda
+  sha256: 51048cd9d4d7ab3ab440bac01d1db8193ae1bd3e9502cdf6792a69c792fec2e5
+  md5: 3f0764c38bc02720231d49d6035531f2
   depends:
   - __osx >=11.0
-  - ace >=8.0.1,<8.0.2.0a0
-  - eigen
-  - ffmpeg >=7.1.0,<8.0a0
-  - libcxx >=17
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libopencv >=4.10.0,<4.10.1.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libsqlite >=3.46.1,<4.0a0
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - portaudio >=19.6.0,<19.7.0a0
-  - qt-main >=5.15.8,<5.16.0a0
-  - robot-testing-framework >=2.0.1,<2.0.2.0a0
-  - sdl >=1.2.68,<1.3.0a0
-  - soxr >=0.1.3,<0.1.4.0a0
-  - tinyxml
-  - ycm-cmake-modules
-  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
   purls: []
-  size: 7289673
-  timestamp: 1727889364422
-- kind: conda
-  name: libyarp
-  version: 3.9.0
-  build: h564f6a6_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-h564f6a6_6.conda
+  size: 572400
+  timestamp: 1730356085177
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.4-h442d1da_2.conda
+  sha256: 352eb281dcac491b7ed9e01082947d734a2610f3700f1ab18524590a2862f069
+  md5: 46c233e5c137a2de2d1d95ca35ad8d6a
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1518137
+  timestamp: 1730355951612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libyarp-3.9.0-h564f6a6_6.conda
   sha256: c169f24238eeb50bb5aa3eb58c8afb3f11ebe8cddc7098a113e56e601cf25c89
   md5: 0e085c829f738f08547fe5e8958e6649
   depends:
@@ -11728,13 +9047,7 @@ packages:
   purls: []
   size: 10594881
   timestamp: 1727889822933
-- kind: conda
-  name: libyarp
-  version: 3.9.0
-  build: h6720d46_6
-  build_number: 6
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h6720d46_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libyarp-3.9.0-h6720d46_6.conda
   sha256: 3d3698805fb66a98220b7e8771a5b8968d8a2a3782bfd0dae77a4565c56775a0
   md5: 7f254455a53ed8da8aa9a095cb0fcd52
   depends:
@@ -11763,13 +9076,33 @@ packages:
   purls: []
   size: 10791231
   timestamp: 1727889628016
-- kind: conda
-  name: libyarp
-  version: 3.9.0
-  build: he1ac810_6
-  build_number: 6
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-he1ac810_6.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libyarp-3.9.0-h01dc7ee_6.conda
+  sha256: 79d4076016bad050b50746d83254758585088b22633b9952b1179a46d29fcf28
+  md5: d1e2b8bcf69afd42216ea25dcd204fed
+  depends:
+  - __osx >=11.0
+  - ace >=8.0.1,<8.0.2.0a0
+  - eigen
+  - ffmpeg >=7.1.0,<8.0a0
+  - libcxx >=17
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libopencv >=4.10.0,<4.10.1.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - portaudio >=19.6.0,<19.7.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - robot-testing-framework >=2.0.1,<2.0.2.0a0
+  - sdl >=1.2.68,<1.3.0a0
+  - soxr >=0.1.3,<0.1.4.0a0
+  - tinyxml
+  - ycm-cmake-modules
+  license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+  purls: []
+  size: 7289673
+  timestamp: 1727889364422
+- conda: https://conda.anaconda.org/conda-forge/win-64/libyarp-3.9.0-he1ac810_6.conda
   sha256: 852f6b08d30cf6fd7be4ed38ccf532b9e44cd267445284228d0ae96630182f42
   md5: 329e9d4a6a3a9c73e72ac8e46407b70b
   depends:
@@ -11795,13 +9128,44 @@ packages:
   purls: []
   size: 9378718
   timestamp: 1727890468148
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
+  sha256: 5a2c1eeef69342e88a98d1d95bff1603727ab1ff4ee0e421522acd8813439b84
+  md5: 08aad7cbe9f5a6b460d0976076b6ae64
+  depends:
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 66657
+  timestamp: 1727963199518
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
   sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
   md5: 41fbfac52c601159df6c01f875de31b9
   depends:
@@ -11815,95 +9179,14 @@ packages:
   purls: []
   size: 55476
   timestamp: 1727963768015
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h8359307_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
-  md5: 369964e85dc26bfe78f41399b366c435
-  depends:
-  - __osx >=11.0
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 46438
-  timestamp: 1727963202283
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h86ecc28_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h86ecc28_2.conda
-  sha256: 5a2c1eeef69342e88a98d1d95bff1603727ab1ff4ee0e421522acd8813439b84
-  md5: 08aad7cbe9f5a6b460d0976076b6ae64
-  depends:
-  - libgcc >=13
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 66657
-  timestamp: 1727963199518
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
-  md5: edb0dca6bc32e4f4789199455a1dbeb8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 60963
-  timestamp: 1727963148474
-- kind: conda
-  name: llvm-meta
-  version: 5.0.0
-  build: '0'
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
   sha256: 090bbeacc3297ff579b53f55ad184f05c30e316fe9d5d7df63df1d2ad4578b79
   md5: 213b5b5ad34008147a824460e50a691c
   license: BSD-3-Clause
   license_family: BSD
   purls: []
   size: 2667
-- kind: conda
-  name: llvm-openmp
-  version: 19.1.3
-  build: h013ceaa_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-openmp-19.1.3-h013ceaa_0.conda
-  sha256: e4effe49346f846782d8a54068aed66a98e7ffcb520b5ee2e18c5bcec013ca9c
-  md5: 41689b81ad3f991ac539fd00b37af432
-  constrains:
-  - openmp 19.1.3|19.1.3.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: APACHE
-  purls: []
-  size: 3101202
-  timestamp: 1730363974065
-- kind: conda
-  name: llvm-openmp
-  version: 19.1.3
-  build: h024ca30_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-19.1.3-h024ca30_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-19.1.3-h024ca30_0.conda
   sha256: aede34c8e218c539ccd4593e4a60b55293b9c3e8870df42f2e2d6ab9e7550927
   md5: d36687dc90337917a84a96a45111ad59
   depends:
@@ -11915,12 +9198,17 @@ packages:
   purls: []
   size: 3192137
   timestamp: 1730363910114
-- kind: conda
-  name: llvm-openmp
-  version: 19.1.3
-  build: hb52a8e5_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.3-hb52a8e5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-openmp-19.1.3-h013ceaa_0.conda
+  sha256: e4effe49346f846782d8a54068aed66a98e7ffcb520b5ee2e18c5bcec013ca9c
+  md5: 41689b81ad3f991ac539fd00b37af432
+  constrains:
+  - openmp 19.1.3|19.1.3.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  size: 3101202
+  timestamp: 1730363974065
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.3-hb52a8e5_0.conda
   sha256: 49a8940e727aa82ee034fa9a60b3fcababec41b3192d955772aab635a5374b82
   md5: dd695d23e78d1ca4fecce969b1e1db61
   depends:
@@ -11932,27 +9220,7 @@ packages:
   purls: []
   size: 280488
   timestamp: 1730364082380
-- kind: conda
-  name: lodepng
-  version: '20220109'
-  build: h2d74725_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/lodepng-20220109-h2d74725_0.tar.bz2
-  sha256: 21fb85cdc43fd2fb059c3482e471041b5e5b0e89a0f39cd89b179a579ec7ba6a
-  md5: 97bb5427961880e83474c0f0b2c14eca
-  depends:
-  - vc >=14.1,<15
-  - vs2015_runtime >=14.16.27033
-  license: Zlib
-  purls: []
-  size: 96344
-  timestamp: 1654539068393
-- kind: conda
-  name: lodepng
-  version: '20220109'
-  build: h924138e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lodepng-20220109-h924138e_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lodepng-20220109-h924138e_0.tar.bz2
   sha256: 31f9bf8dfa2a6f1eb1c47e48e57b7a2b0ef25d0df18741cc3e4abd0fe076bb1d
   md5: 6d6c59898d7a764ff90bb1147e234056
   depends:
@@ -11962,12 +9230,7 @@ packages:
   purls: []
   size: 102103
   timestamp: 1654538581172
-- kind: conda
-  name: lodepng
-  version: '20220109'
-  build: hdd96247_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lodepng-20220109-hdd96247_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lodepng-20220109-hdd96247_0.tar.bz2
   sha256: af98d46a313c5af26cb88923bf44bdd3b25eb24ae93f125633e6cffcc7f4a03b
   md5: 71a86b259b778dbad7f32c1b0edc3e67
   depends:
@@ -11977,12 +9240,7 @@ packages:
   purls: []
   size: 104299
   timestamp: 1655914369153
-- kind: conda
-  name: lodepng
-  version: '20220109'
-  build: hf86a087_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lodepng-20220109-hf86a087_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lodepng-20220109-hf86a087_0.tar.bz2
   sha256: b911e285cf2e4bfc7ac5a3eb222ae7f70766af1ab8518d16af79c2723d2ac487
   md5: bba20599e9b8bc090ce1963609321042
   depends:
@@ -11991,12 +9249,17 @@ packages:
   purls: []
   size: 96247
   timestamp: 1655900547881
-- kind: conda
-  name: lz4-c
-  version: 1.9.4
-  build: hcb278e6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/lodepng-20220109-h2d74725_0.tar.bz2
+  sha256: 21fb85cdc43fd2fb059c3482e471041b5e5b0e89a0f39cd89b179a579ec7ba6a
+  md5: 97bb5427961880e83474c0f0b2c14eca
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: Zlib
+  purls: []
+  size: 96344
+  timestamp: 1654539068393
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
   sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
   md5: 318b08df404f9c9be5712aaa5a6f0bb0
   depends:
@@ -12007,12 +9270,7 @@ packages:
   purls: []
   size: 143402
   timestamp: 1674727076728
-- kind: conda
-  name: lz4-c
-  version: 1.9.4
-  build: hd600fc2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
   sha256: 076870eb72411f41c46598c7582a2f3f42ba94c526a2d60a0c8f70a0a7a64429
   md5: 500145a83ed07ce79c8cef24252f366b
   depends:
@@ -12023,46 +9281,7 @@ packages:
   purls: []
   size: 163770
   timestamp: 1674727020254
-- kind: conda
-  name: metis
-  version: 5.1.0
-  build: h15f6cfe_1007
-  build_number: 1007
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h15f6cfe_1007.conda
-  sha256: f54ad3e5d47a0235ba2830848fee590faad550639336fe1e2413ab16fee7ac39
-  md5: 7687ec5796288536947bf616179726d8
-  depends:
-  - __osx >=11.0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 3898314
-  timestamp: 1728064659078
-- kind: conda
-  name: metis
-  version: 5.1.0
-  build: h670dfbf_1007
-  build_number: 1007
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/metis-5.1.0-h670dfbf_1007.conda
-  sha256: 453f4733b1803452b8169c31749d92d46bf6fe7e467897d89535d3fcb6f16b6f
-  md5: e6672417b63f335358d90f5ba939c4ab
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 3844618
-  timestamp: 1728064627281
-- kind: conda
-  name: metis
-  version: 5.1.0
-  build: hd0bcaf9_1007
-  build_number: 1007
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-hd0bcaf9_1007.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/metis-5.1.0-hd0bcaf9_1007.conda
   sha256: e8a00971e6d00bd49f375c5d8d005b37a9abba0b1768533aed0f90a422bf5cc7
   md5: 28eb714416de4eb83e2cbc47e99a1b45
   depends:
@@ -12074,13 +9293,28 @@ packages:
   purls: []
   size: 3923560
   timestamp: 1728064567817
-- kind: conda
-  name: mkl
-  version: 2024.2.2
-  build: h66d3029_14
-  build_number: 14
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/metis-5.1.0-h670dfbf_1007.conda
+  sha256: 453f4733b1803452b8169c31749d92d46bf6fe7e467897d89535d3fcb6f16b6f
+  md5: e6672417b63f335358d90f5ba939c4ab
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 3844618
+  timestamp: 1728064627281
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/metis-5.1.0-h15f6cfe_1007.conda
+  sha256: f54ad3e5d47a0235ba2830848fee590faad550639336fe1e2413ab16fee7ac39
+  md5: 7687ec5796288536947bf616179726d8
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 3898314
+  timestamp: 1728064659078
+- conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.2.2-h66d3029_14.conda
   sha256: 098ba4a3cb82f627bc79dc0ab1111b44859c9ef4aaa8d75ce043bce107770cb3
   md5: f011e7cc21918dc9d1efe0209e27fa16
   depends:
@@ -12091,28 +9325,7 @@ packages:
   purls: []
   size: 103019089
   timestamp: 1727378392081
-- kind: conda
-  name: mpg123
-  version: 1.32.9
-  build: h65af167_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.9-h65af167_0.conda
-  sha256: d65d5a00278544639ba4f99887154be00a1f57afb0b34d80b08e5cba40a17072
-  md5: cdf140c7690ab0132106d3bc48bce47d
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  license: LGPL-2.1-only
-  license_family: LGPL
-  purls: []
-  size: 558708
-  timestamp: 1730581372400
-- kind: conda
-  name: mpg123
-  version: 1.32.9
-  build: hc50e24c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
   sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
   md5: c7f302fd11eeb0987a6a5e1f3aed6a21
   depends:
@@ -12124,47 +9337,18 @@ packages:
   purls: []
   size: 491140
   timestamp: 1730581373280
-- kind: conda
-  name: mujoco-python
-  version: 3.2.5
-  build: py312h11540bb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mujoco-python-3.2.5-py312h11540bb_0.conda
-  sha256: 43b47b9d624f7e11acb79f7195a81be9b7c3e57015a2cf4f444c4ba239349270
-  md5: e21fca3d1602f937dfc40a7b3a1d732a
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.9-h65af167_0.conda
+  sha256: d65d5a00278544639ba4f99887154be00a1f57afb0b34d80b08e5cba40a17072
+  md5: cdf140c7690ab0132106d3bc48bce47d
   depends:
-  - __osx >=11.0
-  - absl-py
-  - etils
-  - fsspec
-  - glfw >=3.4,<4.0a0
-  - importlib_resources
-  - libabseil * cxx17*
-  - libabseil >=20240722.0,<20240723.0a0
-  - libcxx >=18
-  - libmujoco 3.2.5 h20f2781_0
-  - lodepng >=20220109,<20220110.0a0
-  - numpy >=1.19,<3
-  - pybind11-abi 4
-  - pyglfw
-  - pyopengl
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - typing_extensions
-  - zipp
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/mujoco?source=hash-mapping
-  size: 1935442
-  timestamp: 1730840942827
-- kind: conda
-  name: mujoco-python
-  version: 3.2.5
-  build: py312h5a0582c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mujoco-python-3.2.5-py312h5a0582c_0.conda
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-only
+  license_family: LGPL
+  purls: []
+  size: 558708
+  timestamp: 1730581372400
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mujoco-python-3.2.5-py312h5a0582c_0.conda
   sha256: 7690294c5d1bc67f2521d6734cfde26e2d2ccc6140e9a13b47a1f417b2e9aad8
   md5: 33a951f26dbf2385efffa028b90358ea
   depends:
@@ -12195,12 +9379,7 @@ packages:
   - pkg:pypi/mujoco?source=hash-mapping
   size: 2023520
   timestamp: 1730840743409
-- kind: conda
-  name: mujoco-python
-  version: 3.2.5
-  build: py312hbae3adf_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mujoco-python-3.2.5-py312hbae3adf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mujoco-python-3.2.5-py312hbae3adf_0.conda
   sha256: 140f580347537a9275386ffd05ca9b53e88aa13d21a2b1ab5abdb9356ff73993
   md5: 89d3c32e382192ffafaf43d887389ae2
   depends:
@@ -12231,12 +9410,37 @@ packages:
   - pkg:pypi/mujoco?source=hash-mapping
   size: 1674605
   timestamp: 1730840934269
-- kind: conda
-  name: mujoco-python
-  version: 3.2.5
-  build: py313h43b31af_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mujoco-python-3.2.5-py313h43b31af_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mujoco-python-3.2.5-py312h11540bb_0.conda
+  sha256: 43b47b9d624f7e11acb79f7195a81be9b7c3e57015a2cf4f444c4ba239349270
+  md5: e21fca3d1602f937dfc40a7b3a1d732a
+  depends:
+  - __osx >=11.0
+  - absl-py
+  - etils
+  - fsspec
+  - glfw >=3.4,<4.0a0
+  - importlib_resources
+  - libabseil * cxx17*
+  - libabseil >=20240722.0,<20240723.0a0
+  - libcxx >=18
+  - libmujoco 3.2.5 h20f2781_0
+  - lodepng >=20220109,<20220110.0a0
+  - numpy >=1.19,<3
+  - pybind11-abi 4
+  - pyglfw
+  - pyopengl
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - typing_extensions
+  - zipp
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/mujoco?source=hash-mapping
+  size: 1935442
+  timestamp: 1730840942827
+- conda: https://conda.anaconda.org/conda-forge/win-64/mujoco-python-3.2.5-py313h43b31af_0.conda
   sha256: 9894c3573bd3348f9e6f30d746b4dda2961f68778ad3cba2f3fa124a41380917
   md5: 497efa2ccb1dc8e3e933d17b4f07d557
   depends:
@@ -12266,116 +9470,45 @@ packages:
   - pkg:pypi/mujoco?source=hash-mapping
   size: 1698023
   timestamp: 1730841694252
-- kind: pypi
+- pypi: ./
   name: mujoco-urdf-loader
-  version: 0.1.dev36+dirty
-  path: .
-  sha256: d6e9875212f8400f8c8325aa5c83fcfb6c19ee7051c08f150de9cb4f2a03e780
+  version: 0.1.dev46+dirty
+  sha256: 63cdf8149f6d5f37790442cff276104b0b0834152218bc295681745b950b1372
   requires_dist:
   - mujoco
   - resolve-robotics-uri-py
   - idyntree
-  - mujoco-urdf-loader[development,testing] ; extra == 'all'
+  - numpy
+  - scipy
   - black ; extra == 'development'
   - isort ; extra == 'development'
   - pre-commit ; extra == 'development'
   - pytest>=6.0 ; extra == 'testing'
   - robot-descriptions ; extra == 'testing'
+  - mujoco-urdf-loader[development,testing] ; extra == 'all'
   requires_python: '>=3.10'
-  editable: true
-- kind: conda
-  name: mumps-include
-  version: 5.7.3
-  build: h8af1aa0_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.7.3-h8af1aa0_5.conda
-  sha256: 29a9527b286203881328f5057b4e75953884ae1a75d01a5119bf10776a150c61
-  md5: 2b8630bd5e0b25e53ee5fbe4844c3b4c
-  license: CECILL-C
-  purls: []
-  size: 23025
-  timestamp: 1727303578959
-- kind: conda
-  name: mumps-include
-  version: 5.7.3
-  build: ha770c72_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.7.3-ha770c72_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-include-5.7.3-ha770c72_5.conda
   sha256: 23749d8c3695d95255c21fa4ebf73c70a07b098262c052a854d1504416e69478
   md5: 1f49bbeab690751b93f54cb61b0722aa
   license: CECILL-C
   purls: []
   size: 22999
   timestamp: 1727303528508
-- kind: conda
-  name: mumps-include
-  version: 5.7.3
-  build: hce30654_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-include-5.7.3-hce30654_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-include-5.7.3-h8af1aa0_5.conda
+  sha256: 29a9527b286203881328f5057b4e75953884ae1a75d01a5119bf10776a150c61
+  md5: 2b8630bd5e0b25e53ee5fbe4844c3b4c
+  license: CECILL-C
+  purls: []
+  size: 23025
+  timestamp: 1727303578959
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-include-5.7.3-hce30654_5.conda
   sha256: 957568ea03765a383d1f2413f701bb4179705f879f4028dfa2653c723f8ec038
   md5: 1a1380f7da054ed3327d40b3abe732f3
   license: CECILL-C
   purls: []
   size: 23186
   timestamp: 1727303612860
-- kind: conda
-  name: mumps-seq
-  version: 5.7.3
-  build: h505cb68_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.7.3-h505cb68_5.conda
-  sha256: 27d4b8d78cb662e0406e42f34474f18565b3c46e893f9e938edf1dbafab30547
-  md5: 2ac9aea3b26d7de591223671b3fe0de2
-  depends:
-  - _openmp_mutex >=4.5
-  - libblas >=3.9.0,<4.0a0
-  - libgcc >=13
-  - libgfortran
-  - libgfortran5 >=13.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - libscotch >=7.0.5,<7.0.6.0a0
-  - metis >=5.1.0,<5.1.1.0a0
-  - mumps-include 5.7.3 h8af1aa0_5
-  constrains:
-  - libopenblas * *openmp*
-  license: CECILL-C
-  purls: []
-  size: 2363904
-  timestamp: 1727303927035
-- kind: conda
-  name: mumps-seq
-  version: 5.7.3
-  build: h7c2359a_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.7.3-h7c2359a_5.conda
-  sha256: 00e65d0dff5d773612c742d2ad48e041fbeb0bd779cf7a3fa85ed91b479254e4
-  md5: 943cbd250d41f9c1f3ac2004deea7a31
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libflang >=5.0.0,<6.0.0.a0
-  - liblapack >=3.9.0,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - libopenblas * *openmp*
-  license: CECILL-C
-  purls: []
-  size: 3074465
-  timestamp: 1727304479582
-- kind: conda
-  name: mumps-seq
-  version: 5.7.3
-  build: hcd84eb1_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.7.3-hcd84eb1_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mumps-seq-5.7.3-hcd84eb1_5.conda
   sha256: 94da4438e92a53bb8670971cb1247787e8f4d91ce06f28e9d31fdb3f6afa33e2
   md5: 46d52291d856e44ff8b81bc3b480b228
   depends:
@@ -12395,13 +9528,26 @@ packages:
   purls: []
   size: 2440160
   timestamp: 1727303788976
-- kind: conda
-  name: mumps-seq
-  version: 5.7.3
-  build: he17653c_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.7.3-he17653c_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mumps-seq-5.7.3-h505cb68_5.conda
+  sha256: 27d4b8d78cb662e0406e42f34474f18565b3c46e893f9e938edf1dbafab30547
+  md5: 2ac9aea3b26d7de591223671b3fe0de2
+  depends:
+  - _openmp_mutex >=4.5
+  - libblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libscotch >=7.0.5,<7.0.6.0a0
+  - metis >=5.1.0,<5.1.1.0a0
+  - mumps-include 5.7.3 h8af1aa0_5
+  constrains:
+  - libopenblas * *openmp*
+  license: CECILL-C
+  purls: []
+  size: 2363904
+  timestamp: 1727303927035
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mumps-seq-5.7.3-he17653c_5.conda
   sha256: fa605c3028d958cbe670620ee583ef8f0551d79fdc0d41a61e43478c9c42b3ee
   md5: 364d512567d810c33ed77207f898129e
   depends:
@@ -12421,13 +9567,23 @@ packages:
   purls: []
   size: 2178444
   timestamp: 1727304238416
-- kind: conda
-  name: mypy_extensions
-  version: 1.0.0
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.7.3-h7c2359a_5.conda
+  sha256: 00e65d0dff5d773612c742d2ad48e041fbeb0bd779cf7a3fa85ed91b479254e4
+  md5: 943cbd250d41f9c1f3ac2004deea7a31
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libflang >=5.0.0,<6.0.0.a0
+  - liblapack >=3.9.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libopenblas * *openmp*
+  license: CECILL-C
+  purls: []
+  size: 3074465
+  timestamp: 1727304479582
+- conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
   sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
   md5: 4eccaeba205f0aed9ac3a9ea58568ca3
   depends:
@@ -12438,31 +9594,7 @@ packages:
   - pkg:pypi/mypy-extensions?source=hash-mapping
   size: 10492
   timestamp: 1675543414256
-- kind: conda
-  name: mysql-common
-  version: 9.0.1
-  build: h0887d5e_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-9.0.1-h0887d5e_2.conda
-  sha256: 7769d67c3b9463e45ec8e57ea3e0adfdd2f17c0c2b32226e1e88ed669baf14fe
-  md5: 7643ebb29dae0a548c356c5c4d44b79e
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - openssl >=3.3.2,<4.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 630582
-  timestamp: 1729802112289
-- kind: conda
-  name: mysql-common
-  version: 9.0.1
-  build: h266115a_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-9.0.1-h266115a_2.conda
   sha256: bf0c230c35ca70e2c98530eb064a99f0c4d4596793a0be3ca8a3cbd92094ef82
   md5: 85c0dc0bcd110c998b01856975486ee7
   depends:
@@ -12475,13 +9607,7 @@ packages:
   purls: []
   size: 649443
   timestamp: 1729804130603
-- kind: conda
-  name: mysql-common
-  version: 9.0.1
-  build: h3f5c77f_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-9.0.1-h3f5c77f_2.conda
   sha256: 27cb52f00b2fedb89ed4e7ed2527caf7c5b245dac76a809d0aed58514e08d325
   md5: cc7bc11893dd1aee492dae85f317769e
   depends:
@@ -12493,34 +9619,19 @@ packages:
   purls: []
   size: 636837
   timestamp: 1729806881403
-- kind: conda
-  name: mysql-libs
-  version: 9.0.1
-  build: h11569fd_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-9.0.1-h11569fd_2.conda
-  sha256: 0c014ecbb449cd10bab96bf036cae646068ce42827f582244117adc805850d04
-  md5: 94c70f21e0a1f8558941d901027215a4
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-9.0.1-h0887d5e_2.conda
+  sha256: 7769d67c3b9463e45ec8e57ea3e0adfdd2f17c0c2b32226e1e88ed669baf14fe
+  md5: 7643ebb29dae0a548c356c5c4d44b79e
   depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - mysql-common 9.0.1 h3f5c77f_2
+  - __osx >=11.0
+  - libcxx >=17
   - openssl >=3.3.2,<4.0a0
-  - zstd >=1.5.6,<1.6.0a0
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 1408789
-  timestamp: 1729806960210
-- kind: conda
-  name: mysql-libs
-  version: 9.0.1
-  build: he0572af_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_2.conda
+  size: 630582
+  timestamp: 1729802112289
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-9.0.1-he0572af_2.conda
   sha256: e376189cd11304f4089971b372dac8a1cbbab6eacda8ca978ead2c220d16b8a4
   md5: 57a9e7ee3c0840d3c8c9012473978629
   depends:
@@ -12536,13 +9647,22 @@ packages:
   purls: []
   size: 1372671
   timestamp: 1729804203990
-- kind: conda
-  name: mysql-libs
-  version: 9.0.1
-  build: he9bc4e1_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-9.0.1-he9bc4e1_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-9.0.1-h11569fd_2.conda
+  sha256: 0c014ecbb449cd10bab96bf036cae646068ce42827f582244117adc805850d04
+  md5: 94c70f21e0a1f8558941d901027215a4
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-common 9.0.1 h3f5c77f_2
+  - openssl >=3.3.2,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 1408789
+  timestamp: 1729806960210
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-9.0.1-he9bc4e1_2.conda
   sha256: ca89f4accacfc2297b5036aa847c2387c53aa937c8f9050ceec275c1be32eec1
   md5: f36d1cf1ffeb604bac5870c04cb4ee8f
   depends:
@@ -12557,43 +9677,7 @@ packages:
   purls: []
   size: 1346928
   timestamp: 1729802330351
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: h7bae524_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
-  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
-  md5: cb2b0ea909b97b3d70cd3921d1445e1a
-  depends:
-  - __osx >=11.0
-  license: X11 AND BSD-3-Clause
-  purls: []
-  size: 802321
-  timestamp: 1724658775723
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: hcccb83c_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-hcccb83c_1.conda
-  sha256: acad4cf1f57b12ee1e42995e6fac646fa06aa026529f05eb8c07eb0a84a47a84
-  md5: 91d49c85cacd92caa40cf375ef72a25d
-  depends:
-  - libgcc-ng >=12
-  license: X11 AND BSD-3-Clause
-  purls: []
-  size: 924472
-  timestamp: 1724658573518
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: he02047a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
   sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
   md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
   depends:
@@ -12603,13 +9687,25 @@ packages:
   purls: []
   size: 889086
   timestamp: 1724658547447
-- kind: conda
-  name: nodeenv
-  version: 1.9.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-hcccb83c_1.conda
+  sha256: acad4cf1f57b12ee1e42995e6fac646fa06aa026529f05eb8c07eb0a84a47a84
+  md5: 91d49c85cacd92caa40cf375ef72a25d
+  depends:
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 924472
+  timestamp: 1724658573518
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 802321
+  timestamp: 1724658775723
+- conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
   sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
   md5: dfe0528d0f1c16c1f7c528ea5536ab30
   depends:
@@ -12621,28 +9717,7 @@ packages:
   - pkg:pypi/nodeenv?source=hash-mapping
   size: 34489
   timestamp: 1717585382642
-- kind: conda
-  name: nspr
-  version: '4.36'
-  build: h5833ebf_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.36-h5833ebf_0.conda
-  sha256: 71f790d3dafe309e46c2214a6354d8d1818d646d637b2f5f9f84c5aa5c315a42
-  md5: 026a08bd5b6a2a2f240c00c32446156d
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  license: MPL-2.0
-  license_family: MOZILLA
-  purls: []
-  size: 202873
-  timestamp: 1729545964601
-- kind: conda
-  name: nspr
-  version: '4.36'
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
   sha256: a87471d9265a7c02a98c20debac8b13afd80963968ed7b1c1c2ac7b80955ce31
   md5: de9cd5bca9e4918527b9b72b6e2e1409
   depends:
@@ -12654,12 +9729,7 @@ packages:
   purls: []
   size: 230204
   timestamp: 1729545773406
-- kind: conda
-  name: nspr
-  version: '4.36'
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.36-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.36-h5ad3122_0.conda
   sha256: 404a4ec0430fbdce53fee00d9acf9f307aa9b3a6d06b5696c38ca3f92195a490
   md5: 6170d131ea39ca6e8f6695507c9d3388
   depends:
@@ -12670,50 +9740,18 @@ packages:
   purls: []
   size: 235389
   timestamp: 1729545760194
-- kind: conda
-  name: nss
-  version: '3.106'
-  build: h6f44f80_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.106-h6f44f80_0.conda
-  sha256: de7cc89e24b7e72c9f842534af205b566d7bceb95307aad0434a40e2ec13e73e
-  md5: 243f6ae13f81edd8e82f0baddab0aaf2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.36-h5833ebf_0.conda
+  sha256: 71f790d3dafe309e46c2214a6354d8d1818d646d637b2f5f9f84c5aa5c315a42
+  md5: 026a08bd5b6a2a2f240c00c32446156d
   depends:
   - __osx >=11.0
   - libcxx >=17
-  - libsqlite >=3.47.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - nspr >=4.36,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
   purls: []
-  size: 1814292
-  timestamp: 1729811695707
-- kind: conda
-  name: nss
-  version: '3.106'
-  build: hcffee33_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.106-hcffee33_0.conda
-  sha256: 76115ba1a5b5fbb7e3b471c84e983b514394c800adee30b158799ecdc15ded66
-  md5: e132b0f4cec9a1476c5c4da3722fc124
-  depends:
-  - libgcc >=13
-  - libsqlite >=3.47.0,<4.0a0
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  - nspr >=4.36,<5.0a0
-  license: MPL-2.0
-  license_family: MOZILLA
-  purls: []
-  size: 1990164
-  timestamp: 1729814601835
-- kind: conda
-  name: nss
-  version: '3.106'
-  build: hdf54f9c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.106-hdf54f9c_0.conda
+  size: 202873
+  timestamp: 1729545964601
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.106-hdf54f9c_0.conda
   sha256: e5dd3e57498decdef87ff641fa6b7bd5484fce3f2783811ee5ec278bc9e71281
   md5: efe735c7dc47dddbb14b3433d11c6feb
   depends:
@@ -12728,37 +9766,35 @@ packages:
   purls: []
   size: 2001391
   timestamp: 1729811441549
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py312h2eb110b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.1.3-py312h2eb110b_0.conda
-  sha256: 58a089949d87c4d54b9a02adc88f986318c6ff5525f37a82b0ddcc6acc8f4f37
-  md5: 09c72d80ff045b05a4bb3d3089f3e41e
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.106-hcffee33_0.conda
+  sha256: 76115ba1a5b5fbb7e3b471c84e983b514394c800adee30b158799ecdc15ded66
+  md5: e132b0f4cec9a1476c5c4da3722fc124
   depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
   - libgcc >=13
-  - liblapack >=3.9.0,<4.0a0
+  - libsqlite >=3.47.0,<4.0a0
   - libstdcxx >=13
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/numpy?source=hash-mapping
-  size: 7106685
-  timestamp: 1730588472368
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py312h58c1407_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py312h58c1407_0.conda
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls: []
+  size: 1990164
+  timestamp: 1729814601835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.106-h6f44f80_0.conda
+  sha256: de7cc89e24b7e72c9f842534af205b566d7bceb95307aad0434a40e2ec13e73e
+  md5: 243f6ae13f81edd8e82f0baddab0aaf2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls: []
+  size: 1814292
+  timestamp: 1729811695707
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py312h58c1407_0.conda
   sha256: e4c14f71588a5627a6935d3e7d9ca78a8387229ec8ebc91616b0988ce57ba0dc
   md5: dfdbc12e6d81889ba4c494a23f23eba8
   depends:
@@ -12778,12 +9814,27 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 8388631
   timestamp: 1730588649810
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py312h94ee1e1_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py312h94ee1e1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.1.3-py312h2eb110b_0.conda
+  sha256: 58a089949d87c4d54b9a02adc88f986318c6ff5525f37a82b0ddcc6acc8f4f37
+  md5: 09c72d80ff045b05a4bb3d3089f3e41e
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  size: 7106685
+  timestamp: 1730588472368
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py312h94ee1e1_0.conda
   sha256: cd287b6c270ee8af77d200c46d56fdfe1e2a9deeff68044439718b8d073214dd
   md5: a2af54c86582e08718805c69af737897
   depends:
@@ -12803,12 +9854,7 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 6398123
   timestamp: 1730588490904
-- kind: conda
-  name: numpy
-  version: 2.1.3
-  build: py313hee8cc43_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py313hee8cc43_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py313hee8cc43_0.conda
   sha256: 79b8493c839cd4cc22e2a7024f289067b029ef2b09212973a98a39e5bbeecc03
   md5: 083a90ad306f544f6eeb9ad00c4d9879
   depends:
@@ -12828,13 +9874,7 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 7072965
   timestamp: 1730588905304
-- kind: conda
-  name: ocl-icd
-  version: 2.3.2
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
   sha256: 0e01384423e48e5011eb6b224da8dc5e3567c87dbcefbe60cd9d5cead276cdcd
   md5: c66f837ac65e4d1cdeb80e2a1d5fcc3d
   depends:
@@ -12844,74 +9884,7 @@ packages:
   purls: []
   size: 135681
   timestamp: 1710946531879
-- kind: conda
-  name: openexr
-  version: 3.3.1
-  build: h483ef7f_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.3.1-h483ef7f_2.conda
-  sha256: 18e46da72ae5238214a92f20e50043d7e171820353f082918f4df6b59701d3c1
-  md5: 130687d65ecf832813bccc9ee9c0c104
-  depends:
-  - __osx >=11.0
-  - imath >=3.1.12,<3.1.13.0a0
-  - libcxx >=17
-  - libdeflate >=1.22,<1.23.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 1199722
-  timestamp: 1729546993047
-- kind: conda
-  name: openexr
-  version: 3.3.1
-  build: h974021d_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openexr-3.3.1-h974021d_2.conda
-  sha256: fc23c2cbd9694e2bbb30cfbb44a7e69ead17e2127d46f46634c68cf748e217ee
-  md5: 96786f3f3db7a7ccd89b87ee400ec2a7
-  depends:
-  - imath >=3.1.12,<3.1.13.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 1178553
-  timestamp: 1729546904039
-- kind: conda
-  name: openexr
-  version: 3.3.1
-  build: haace395_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.3.1-haace395_2.conda
-  sha256: 915f62f283331860d26cb2f6df57249ead3f8cf46a143beeed8ad0bff6311993
-  md5: c9d36ef5708c97f3398b18eb92f51fe7
-  depends:
-  - imath >=3.1.12,<3.1.13.0a0
-  - libdeflate >=1.22,<1.23.0a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 1353236
-  timestamp: 1729546539373
-- kind: conda
-  name: openexr
-  version: 3.3.1
-  build: hccdc605_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.1-hccdc605_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.3.1-hccdc605_2.conda
   sha256: de1abf7be0caca0cd83174ea77a9dbfeb1d36d748508e524cd2b9253ec3d86f6
   md5: 907ffbb8a276c12c5a8a8aed2c5a10f9
   depends:
@@ -12926,28 +9899,50 @@ packages:
   purls: []
   size: 1405340
   timestamp: 1729546542495
-- kind: conda
-  name: openh264
-  version: 2.4.1
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.1-h2f0025b_0.conda
-  sha256: fbd43d4ab82fd6dfd1502a55ccade4aabae4a85fa2353396078da8d5c10941db
-  md5: 97fc3bbca08e95e1d7af8366d5a4ece6
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openexr-3.3.1-haace395_2.conda
+  sha256: 915f62f283331860d26cb2f6df57249ead3f8cf46a143beeed8ad0bff6311993
+  md5: c9d36ef5708c97f3398b18eb92f51fe7
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
+  - imath >=3.1.12,<3.1.13.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 770201
-  timestamp: 1706873872574
-- kind: conda
-  name: openh264
-  version: 2.4.1
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
+  size: 1353236
+  timestamp: 1729546539373
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.3.1-h483ef7f_2.conda
+  sha256: 18e46da72ae5238214a92f20e50043d7e171820353f082918f4df6b59701d3c1
+  md5: 130687d65ecf832813bccc9ee9c0c104
+  depends:
+  - __osx >=11.0
+  - imath >=3.1.12,<3.1.13.0a0
+  - libcxx >=17
+  - libdeflate >=1.22,<1.23.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1199722
+  timestamp: 1729546993047
+- conda: https://conda.anaconda.org/conda-forge/win-64/openexr-3.3.1-h974021d_2.conda
+  sha256: fc23c2cbd9694e2bbb30cfbb44a7e69ead17e2127d46f46634c68cf748e217ee
+  md5: 96786f3f3db7a7ccd89b87ee400ec2a7
+  depends:
+  - imath >=3.1.12,<3.1.13.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1178553
+  timestamp: 1729546904039
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.1-h59595ed_0.conda
   sha256: 0d4eaf15fb771f25c924aef831d76eea11d90c824778fc1e7666346e93475f42
   md5: 3dfcf61b8e78af08110f5229f79580af
   depends:
@@ -12958,12 +9953,28 @@ packages:
   purls: []
   size: 735244
   timestamp: 1706873814072
-- kind: conda
-  name: openh264
-  version: 2.4.1
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.1-h2f0025b_0.conda
+  sha256: fbd43d4ab82fd6dfd1502a55ccade4aabae4a85fa2353396078da8d5c10941db
+  md5: 97fc3bbca08e95e1d7af8366d5a4ece6
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 770201
+  timestamp: 1706873872574
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.1-hebf3989_0.conda
+  sha256: ecadea5985082105b102f86ff8289128fb247c183b36355d867eb6fc6996df29
+  md5: 25a7835e284a4d947fe9a70efa97e019
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 598764
+  timestamp: 1706874342701
+- conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
   sha256: 37c954a1235531499c45439c602dda6f788e3683795e12fb6e1e4c86074386c7
   md5: 01d1a98fd9ac45d49040ad8cdd62083a
   depends:
@@ -12975,44 +9986,50 @@ packages:
   purls: []
   size: 409185
   timestamp: 1706874444698
-- kind: conda
-  name: openh264
-  version: 2.4.1
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.1-hebf3989_0.conda
-  sha256: ecadea5985082105b102f86ff8289128fb247c183b36355d867eb6fc6996df29
-  md5: 25a7835e284a4d947fe9a70efa97e019
-  depends:
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 598764
-  timestamp: 1706874342701
-- kind: conda
-  name: openmp
-  version: 5.0.0
-  build: vc14_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
   sha256: 05c19170938b589f59049679d4e0679c98160fecc6fd1bf721b0f4980bd235dd
   md5: 8284c925330fa53668ade00db3c9e787
   depends:
   - llvm-meta 5.0.0|5.0.0.*
   - vc 14.*
-  arch: x86_64
-  platform: win
   license: NCSA
   purls: []
   size: 590466
-- kind: conda
-  name: openssl
-  version: 3.3.2
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+  sha256: cee91036686419f6dd6086902acf7142b4916e1c4ba042e9ca23e151da012b6d
+  md5: 4d638782050ab6faa27275bed57e9b4e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 2891789
+  timestamp: 1725410790053
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.2-h86ecc28_0.conda
+  sha256: 4669d26dbf81e4d72093d8260f55d19d57204d82b1d9440be83d11d313b5990c
+  md5: 9e1e477b3f8ee3789297883faffa708b
+  depends:
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3428083
+  timestamp: 1725412266679
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
+  sha256: 940fa01c4dc6152158fe8943e05e55a1544cab639df0994e3b35937839e4f4d1
+  md5: 1773ebccdc13ec603356e8ff1db9e958
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 2882450
+  timestamp: 1725410638874
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
   sha256: a45c42f3577294e22ac39ddb6ef5a64fd5322e8a6725afefbf4f2b4109340bf9
   md5: 1dc86753693df5e3326bb8a85b74c589
   depends:
@@ -13025,80 +10042,20 @@ packages:
   purls: []
   size: 8396053
   timestamp: 1725412961673
-- kind: conda
-  name: openssl
-  version: 3.3.2
-  build: h8359307_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
-  sha256: 940fa01c4dc6152158fe8943e05e55a1544cab639df0994e3b35937839e4f4d1
-  md5: 1773ebccdc13ec603356e8ff1db9e958
-  depends:
-  - __osx >=11.0
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 2882450
-  timestamp: 1725410638874
-- kind: conda
-  name: openssl
-  version: 3.3.2
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.2-h86ecc28_0.conda
-  sha256: 4669d26dbf81e4d72093d8260f55d19d57204d82b1d9440be83d11d313b5990c
-  md5: 9e1e477b3f8ee3789297883faffa708b
-  depends:
-  - ca-certificates
-  - libgcc >=13
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 3428083
-  timestamp: 1725412266679
-- kind: conda
-  name: openssl
-  version: 3.3.2
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
-  sha256: cee91036686419f6dd6086902acf7142b4916e1c4ba042e9ca23e151da012b6d
-  md5: 4d638782050ab6faa27275bed57e9b4e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ca-certificates
-  - libgcc >=13
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 2891789
-  timestamp: 1725410790053
-- kind: conda
-  name: osqp-eigen
-  version: 0.8.1
-  build: h136a8c3_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-eigen-0.8.1-h136a8c3_1.conda
-  sha256: 75ee7b242b62f43f31f3caa5f85a56130dc3efeb09222ab21e041093eb364711
-  md5: 26c46a328a1a81dbd5f5d8b75a90d131
+- conda: https://conda.anaconda.org/conda-forge/linux-64/osqp-eigen-0.8.1-hdd734ac_1.conda
+  sha256: 4fdea6a623b8c2ca45ef6576cbe287b54b129ebf4467631b7d6bcc6a940bad21
+  md5: b36c121074bec51888739cfb2762d460
   depends:
   - eigen
-  - libcxx >=16
+  - libgcc-ng >=12
   - libosqp >=0.6.3,<0.6.4.0a0
+  - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 33987
-  timestamp: 1709559705042
-- kind: conda
-  name: osqp-eigen
-  version: 0.8.1
-  build: h63a7d18_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/osqp-eigen-0.8.1-h63a7d18_1.conda
+  size: 35336
+  timestamp: 1709559434463
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/osqp-eigen-0.8.1-h63a7d18_1.conda
   sha256: a8db1a2cd767bc172bd51351719712820dab440c30f74f1b5afeaca26db4f40f
   md5: ffc5561a5a697954fdde3289e245e2c9
   depends:
@@ -13111,13 +10068,19 @@ packages:
   purls: []
   size: 34800
   timestamp: 1709559465740
-- kind: conda
-  name: osqp-eigen
-  version: 0.8.1
-  build: h6d7489e_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/osqp-eigen-0.8.1-h6d7489e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/osqp-eigen-0.8.1-h136a8c3_1.conda
+  sha256: 75ee7b242b62f43f31f3caa5f85a56130dc3efeb09222ab21e041093eb364711
+  md5: 26c46a328a1a81dbd5f5d8b75a90d131
+  depends:
+  - eigen
+  - libcxx >=16
+  - libosqp >=0.6.3,<0.6.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 33987
+  timestamp: 1709559705042
+- conda: https://conda.anaconda.org/conda-forge/win-64/osqp-eigen-0.8.1-h6d7489e_1.conda
   sha256: 24bd9f72d13d4451d9e7099bfaef9eddb53c95f2310acd598b536b05c31d7d38
   md5: 623017d0d46414e5eacc08e42a7042c0
   depends:
@@ -13131,32 +10094,7 @@ packages:
   purls: []
   size: 63988
   timestamp: 1709560102716
-- kind: conda
-  name: osqp-eigen
-  version: 0.8.1
-  build: hdd734ac_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/osqp-eigen-0.8.1-hdd734ac_1.conda
-  sha256: 4fdea6a623b8c2ca45ef6576cbe287b54b129ebf4467631b7d6bcc6a940bad21
-  md5: b36c121074bec51888739cfb2762d460
-  depends:
-  - eigen
-  - libgcc-ng >=12
-  - libosqp >=0.6.3,<0.6.4.0a0
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 35336
-  timestamp: 1709559434463
-- kind: conda
-  name: packaging
-  version: '24.1'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
   sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
   md5: cbe1bb1f21567018ce595d9c2be0f0db
   depends:
@@ -13167,13 +10105,7 @@ packages:
   - pkg:pypi/packaging?source=hash-mapping
   size: 50290
   timestamp: 1718189540074
-- kind: conda
-  name: pango
-  version: 1.54.0
-  build: h4c5309f_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h4c5309f_1.conda
   sha256: d362237be82d5a0d532fe66ec8d68018c3b2a9705bad6d73c2b63dae2970da02
   md5: 7df02e445367703cd87a574046e3a6f0
   depends:
@@ -13190,13 +10122,7 @@ packages:
   purls: []
   size: 447117
   timestamp: 1719839527713
-- kind: conda
-  name: pango
-  version: 1.54.0
-  build: h7579590_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.54.0-h7579590_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.54.0-h7579590_1.conda
   sha256: 98e1706ef62c766e2a57f14da95d9d6652b594f901cb9a1b6c04208bd616bd99
   md5: 905145a94ad41fce135074a0214616e9
   depends:
@@ -13213,13 +10139,7 @@ packages:
   purls: []
   size: 460989
   timestamp: 1719841137355
-- kind: conda
-  name: pango
-  version: 1.54.0
-  build: h9ee27a3_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.54.0-h9ee27a3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.54.0-h9ee27a3_2.conda
   sha256: cfa2d11204bb75f6fbcfe1ff0cc1f6e4fc01185bf07b8eee8f698bfbd3702a79
   md5: af2a2118261adf2d7a350d6767b450f2
   depends:
@@ -13236,13 +10156,7 @@ packages:
   purls: []
   size: 417224
   timestamp: 1723832458095
-- kind: conda
-  name: pango
-  version: 1.54.0
-  build: hbb871f6_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pango-1.54.0-hbb871f6_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pango-1.54.0-hbb871f6_2.conda
   sha256: 90327dd606f78ae9c881e285f85bc2b0f57d11c807be58ee3f690742354918b2
   md5: 409c0b778deee649c025b7106549a24f
   depends:
@@ -13261,13 +10175,7 @@ packages:
   purls: []
   size: 450610
   timestamp: 1723832834434
-- kind: conda
-  name: pathspec
-  version: 0.12.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
   sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
   md5: 17064acba08d3686f1135b5ec1b32b12
   depends:
@@ -13278,13 +10186,20 @@ packages:
   - pkg:pypi/pathspec?source=hash-mapping
   size: 41173
   timestamp: 1702250135032
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: h070dd5b_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.44-h070dd5b_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
+  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
+  md5: df359c09c41cd186fffb93a2d87aa6f5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 952308
+  timestamp: 1723488734144
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.44-h070dd5b_2.conda
   sha256: e9f4b912e48514771d477f2ee955f59d4ff4ef799c3d4d16e4d0f335ce91df67
   md5: 94022de9682cb1a0bb18a99cbc3541b3
   depends:
@@ -13296,13 +10211,7 @@ packages:
   purls: []
   size: 884590
   timestamp: 1723488793100
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: h297a79d_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
   sha256: 83153c7d8fd99cab33c92ce820aa7bfed0f1c94fc57010cf227b6e3c50cb7796
   md5: 147c83e5e44780c7492998acbacddf52
   depends:
@@ -13314,13 +10223,7 @@ packages:
   purls: []
   size: 618973
   timestamp: 1723488853807
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: h3d7b363_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
   sha256: f4a12cbf8a7c5bfa2592b9dc92b492c438781898e5b02f397979b0be6e1b5851
   md5: a3a3baddcfb8c80db84bec3cb7746fb8
   depends:
@@ -13334,31 +10237,7 @@ packages:
   purls: []
   size: 820831
   timestamp: 1723489427046
-- kind: conda
-  name: pcre2
-  version: '10.44'
-  build: hba22ea6_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
-  sha256: 1087716b399dab91cc9511d6499036ccdc53eb29a288bebcb19cf465c51d7c0d
-  md5: df359c09c41cd186fffb93a2d87aa6f5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 952308
-  timestamp: 1723488734144
-- kind: conda
-  name: pixman
-  version: 0.43.2
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
   sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
   md5: 71004cbf7924e19c02746ccde9fd7123
   depends:
@@ -13369,12 +10248,7 @@ packages:
   purls: []
   size: 386826
   timestamp: 1706549500138
-- kind: conda
-  name: pixman
-  version: 0.43.4
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
   sha256: e145b0d89c800326a20d1afd86c74f9422b81549b17fe53add46c2fa43a4c93e
   md5: 81b2ddea4b0eca188da9c5a7aa4b0cff
   depends:
@@ -13385,12 +10259,17 @@ packages:
   purls: []
   size: 295064
   timestamp: 1709240909660
-- kind: conda
-  name: pixman
-  version: 0.43.4
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
+  sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
+  md5: 0308c68e711cd295aaa026a4f8c4b1e5
+  depends:
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 198755
+  timestamp: 1709239846651
+- conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
   sha256: 51de4d7fb41597b06d60f1b82e269dafcb55e994e08fdcca8e4d6f7d42bedd07
   md5: b98135614135d5f458b75ab9ebb9558c
   depends:
@@ -13402,28 +10281,7 @@ packages:
   purls: []
   size: 461854
   timestamp: 1709239971654
-- kind: conda
-  name: pixman
-  version: 0.43.4
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
-  sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
-  md5: 0308c68e711cd295aaa026a4f8c4b1e5
-  depends:
-  - libcxx >=16
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 198755
-  timestamp: 1709239846651
-- kind: conda
-  name: platformdirs
-  version: 4.3.6
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
   sha256: c81bdeadc4adcda216b2c7b373f0335f5c78cc480d1d55d10f21823590d7e46f
   md5: fd8f2b18b65bbf62e8f653100690c8d2
   depends:
@@ -13434,13 +10292,7 @@ packages:
   - pkg:pypi/platformdirs?source=hash-mapping
   size: 20625
   timestamp: 1726613611845
-- kind: conda
-  name: pluggy
-  version: 1.5.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
   sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
   md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
   depends:
@@ -13451,65 +10303,7 @@ packages:
   - pkg:pypi/pluggy?source=hash-mapping
   size: 23815
   timestamp: 1713667175451
-- kind: conda
-  name: portaudio
-  version: 19.6.0
-  build: h13dd4ca_9
-  build_number: 9
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/portaudio-19.6.0-h13dd4ca_9.conda
-  sha256: 5ff2b55d685c29dfe632ef856796a4b862305088543d4982f0b807e8d9bb756e
-  md5: d325d46394b6c46d15718c855fb20b4a
-  depends:
-  - libcxx >=15.0.7
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 78863
-  timestamp: 1693868663440
-- kind: conda
-  name: portaudio
-  version: 19.6.0
-  build: h5c6c0ed_9
-  build_number: 9
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/portaudio-19.6.0-h5c6c0ed_9.conda
-  sha256: a73e31c5fe9d717cd42470b394018f4e48eed4a439b9371d2c6d380c86aed591
-  md5: ab049f8223bccc6f621975beaa75c624
-  depends:
-  - alsa-lib >=1.2.10,<1.3.0.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 118203
-  timestamp: 1693868376750
-- kind: conda
-  name: portaudio
-  version: 19.6.0
-  build: h63175ca_9
-  build_number: 9
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/portaudio-19.6.0-h63175ca_9.conda
-  sha256: 5f5cf0c24075e9006c96537c885342f24a8c4f4408e994bfe1a63a2ae2528f13
-  md5: 62046084688064857ae9152cefd10abf
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 152179
-  timestamp: 1693868652380
-- kind: conda
-  name: portaudio
-  version: 19.6.0
-  build: h7c63dc7_9
-  build_number: 9
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/portaudio-19.6.0-h7c63dc7_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/portaudio-19.6.0-h7c63dc7_9.conda
   sha256: c09ae032d0303abfea34c0957834538b48133b0431283852741ed3e0f66fdb36
   md5: 893f2c33af6b03cfd04820a8c31f5798
   depends:
@@ -13521,13 +10315,41 @@ packages:
   purls: []
   size: 115512
   timestamp: 1693868383
-- kind: conda
-  name: pre-commit
-  version: 4.0.1
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portaudio-19.6.0-h5c6c0ed_9.conda
+  sha256: a73e31c5fe9d717cd42470b394018f4e48eed4a439b9371d2c6d380c86aed591
+  md5: ab049f8223bccc6f621975beaa75c624
+  depends:
+  - alsa-lib >=1.2.10,<1.3.0.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 118203
+  timestamp: 1693868376750
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/portaudio-19.6.0-h13dd4ca_9.conda
+  sha256: 5ff2b55d685c29dfe632ef856796a4b862305088543d4982f0b807e8d9bb756e
+  md5: d325d46394b6c46d15718c855fb20b4a
+  depends:
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 78863
+  timestamp: 1693868663440
+- conda: https://conda.anaconda.org/conda-forge/win-64/portaudio-19.6.0-h63175ca_9.conda
+  sha256: 5f5cf0c24075e9006c96537c885342f24a8c4f4408e994bfe1a63a2ae2528f13
+  md5: 62046084688064857ae9152cefd10abf
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 152179
+  timestamp: 1693868652380
+- conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_0.conda
   sha256: 2490b18ec802d8f085f2de8298a3d275451f7db17769353080dfb121fe386675
   md5: 5971cc64048943605f352f7f8612de6c
   depends:
@@ -13543,29 +10365,7 @@ packages:
   - pkg:pypi/pre-commit?source=hash-mapping
   size: 194633
   timestamp: 1728420305558
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: h86ecc28_1002
-  build_number: 1002
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
-  sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
-  md5: bb5a90c93e3bac3d5690acf76b4a6386
-  depends:
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 8342
-  timestamp: 1726803319942
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: hb9d3cd8_1002
-  build_number: 1002
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
   depends:
@@ -13576,13 +10376,17 @@ packages:
   purls: []
   size: 8252
   timestamp: 1726802366959
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: hd74edd7_1002
-  build_number: 1002
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+  sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
+  md5: bb5a90c93e3bac3d5690acf76b4a6386
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 8342
+  timestamp: 1726803319942
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
   sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
   md5: 415816daf82e0b23a736a069a75e9da7
   depends:
@@ -13592,13 +10396,7 @@ packages:
   purls: []
   size: 8381
   timestamp: 1726802424786
-- kind: conda
-  name: pthreads-win32
-  version: 2.9.1
-  build: h2466b09_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-h2466b09_4.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-h2466b09_4.conda
   sha256: b989bdcf0a22ba05a238adac1ad3452c11871681f565e509f629e225a26b7d45
   md5: cf98a67a1ec8040b42455002a24f0b0b
   depends:
@@ -13609,43 +10407,7 @@ packages:
   purls: []
   size: 265827
   timestamp: 1728400965968
-- kind: conda
-  name: pugixml
-  version: '1.14'
-  build: h13dd4ca_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
-  sha256: 0bfeac4f1a374da9ff0a322344cdab577d397d6a0a0e5591f08cb7b491926825
-  md5: 4de774bb04e03af9704ec1a2618c636c
-  depends:
-  - libcxx >=15.0.7
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 92472
-  timestamp: 1696182843052
-- kind: conda
-  name: pugixml
-  version: '1.14'
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
-  sha256: 4f37f0a94bb465157e66f1a38ac1843f223db72b80c5e6a87ff354219ee86037
-  md5: 9af93a191056b12e841b7d32f1b01b1c
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 110831
-  timestamp: 1696182637281
-- kind: conda
-  name: pugixml
-  version: '1.14'
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
   sha256: ea5f2d593177318f6b19af05018c953f41124cbb3bf21f9fdedfdb6ac42913ae
   md5: 2c97dd90633508b422c11bd3018206ab
   depends:
@@ -13656,12 +10418,28 @@ packages:
   purls: []
   size: 114871
   timestamp: 1696182708943
-- kind: conda
-  name: pugixml
-  version: '1.14'
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
+  sha256: 4f37f0a94bb465157e66f1a38ac1843f223db72b80c5e6a87ff354219ee86037
+  md5: 9af93a191056b12e841b7d32f1b01b1c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 110831
+  timestamp: 1696182637281
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
+  sha256: 0bfeac4f1a374da9ff0a322344cdab577d397d6a0a0e5591f08cb7b491926825
+  md5: 4de774bb04e03af9704ec1a2618c636c
+  depends:
+  - libcxx >=15.0.7
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 92472
+  timestamp: 1696182843052
+- conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
   sha256: 68a5cb9a7560b2ce0d72ccebc7f6623e13ca66a67f80feb1094a75199bd1a50c
   md5: 6794ab7a1f26ebfe0452297eba029d4f
   depends:
@@ -13673,33 +10451,7 @@ packages:
   purls: []
   size: 111324
   timestamp: 1696182979614
-- kind: conda
-  name: pulseaudio-client
-  version: '17.0'
-  build: h729494f_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h729494f_0.conda
-  sha256: 209eac3123ee2c84a35401626941c4aa64e04e2c9854084ddeba6432c6078a41
-  md5: f35f57712d5c2abca98c85a51a408bc1
-  depends:
-  - dbus >=1.13.6,<2.0a0
-  - libgcc-ng >=12
-  - libglib >=2.78.3,<3.0a0
-  - libsndfile >=1.2.2,<1.3.0a0
-  - libsystemd0 >=255
-  constrains:
-  - pulseaudio 17.0 *_0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  purls: []
-  size: 766184
-  timestamp: 1705690164726
-- kind: conda
-  name: pulseaudio-client
-  version: '17.0'
-  build: hb77b528_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hb77b528_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hb77b528_0.conda
   sha256: b27c0c8671bd95c205a61aeeac807c095b60bc76eb5021863f919036d7a964fc
   md5: 07f45f1be1c25345faddb8db0de8039b
   depends:
@@ -13715,14 +10467,23 @@ packages:
   purls: []
   size: 757633
   timestamp: 1705690081905
-- kind: conda
-  name: pybind11-abi
-  version: '4'
-  build: hd8ed1ab_3
-  build_number: 3
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-17.0-h729494f_0.conda
+  sha256: 209eac3123ee2c84a35401626941c4aa64e04e2c9854084ddeba6432c6078a41
+  md5: f35f57712d5c2abca98c85a51a408bc1
+  depends:
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.3,<3.0a0
+  - libsndfile >=1.2.2,<1.3.0a0
+  - libsystemd0 >=255
+  constrains:
+  - pulseaudio 17.0 *_0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 766184
+  timestamp: 1705690164726
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-4-hd8ed1ab_3.tar.bz2
   sha256: d4fb485b79b11042a16dc6abfb0c44c4f557707c2653ac47c81e5d32b24a3bb0
   md5: 878f923dd6acc8aeb47a75da6c4098be
   license: BSD-3-Clause
@@ -13730,13 +10491,7 @@ packages:
   purls: []
   size: 9906
   timestamp: 1610372835205
-- kind: conda
-  name: pycparser
-  version: '2.22'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
   sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
   md5: 844d9eb3b43095b031874477f7d70088
   depends:
@@ -13747,14 +10502,7 @@ packages:
   - pkg:pypi/pycparser?source=hash-mapping
   size: 105098
   timestamp: 1711811634025
-- kind: conda
-  name: pyglfw
-  version: 2.7.0
-  build: pyha770c72_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pyglfw-2.7.0-pyha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyglfw-2.7.0-pyha770c72_1.conda
   sha256: 56d8c315448e8ab91db7913fae7d75e8a8d0e54af7f8dd51d883d91fe6fd0e06
   md5: ce3b7d69c618c9f899a016c917f9f9c2
   depends:
@@ -13766,14 +10514,7 @@ packages:
   - pkg:pypi/glfw?source=hash-mapping
   size: 30968
   timestamp: 1729073644832
-- kind: conda
-  name: pyopengl
-  version: 3.1.6
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopengl-3.1.6-pyhd8ed1ab_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyopengl-3.1.6-pyhd8ed1ab_1.tar.bz2
   sha256: 4ef77f5227e198b20c1498706fa6b3eb3a32f1cef641b8039d55b7df12e54863
   md5: c968eb974b0fae4676e7a7858c4cc56e
   depends:
@@ -13783,13 +10524,7 @@ packages:
   - pkg:pypi/pyopengl?source=hash-mapping
   size: 887829
   timestamp: 1652285640360
-- kind: conda
-  name: pytest
-  version: 8.3.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
   sha256: e99376d0068455712109d233f5790458ff861aeceb458bfda74e353338e4d815
   md5: c03d61f31f38fdb9facf70c29958bf7a
   depends:
@@ -13808,70 +10543,7 @@ packages:
   - pkg:pypi/pytest?source=hash-mapping
   size: 258293
   timestamp: 1725977334143
-- kind: conda
-  name: python
-  version: 3.12.7
-  build: h5d932e8_0_cpython
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.7-h5d932e8_0_cpython.conda
-  sha256: 25570873d92d4d9490c6db780cc85e6c28bd3ff61dc1ece79f602cf82bc73bc1
-  md5: e6cab21bb5787270388939cf41cc5f43
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-aarch64 >=2.36.1
-  - libexpat >=2.6.3,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc >=13
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
-  - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.2,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  purls: []
-  size: 13762126
-  timestamp: 1728057461028
-- kind: conda
-  name: python
-  version: 3.12.7
-  build: h739c21a_0_cpython
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
-  sha256: 45d7ca2074aa92594bd2f91a9003b338cc1df8a46b9492b7fc8167110783c3ef
-  md5: e0d82e57ebb456077565e6d82cd4a323
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.2,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  purls: []
-  size: 12975439
-  timestamp: 1728057819519
-- kind: conda
-  name: python
-  version: 3.12.7
-  build: hc5c86c4_0_cpython
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-hc5c86c4_0_cpython.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-hc5c86c4_0_cpython.conda
   sha256: 674be31ff152d9f0e0fe16959a45e3803a730fc4f54d87df6a9ac4e6a698c41d
   md5: 0515111a9cdf69f83278f7c197db9807
   depends:
@@ -13898,13 +10570,56 @@ packages:
   purls: []
   size: 31574780
   timestamp: 1728059777603
-- kind: conda
-  name: python
-  version: 3.13.0
-  build: hf5aa216_100_cp313
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.7-h5d932e8_0_cpython.conda
+  sha256: 25570873d92d4d9490c6db780cc85e6c28bd3ff61dc1ece79f602cf82bc73bc1
+  md5: e6cab21bb5787270388939cf41cc5f43
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-aarch64 >=2.36.1
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 13762126
+  timestamp: 1728057461028
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
+  sha256: 45d7ca2074aa92594bd2f91a9003b338cc1df8a46b9492b7fc8167110783c3ef
+  md5: e0d82e57ebb456077565e6d82cd4a323
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 12975439
+  timestamp: 1728057819519
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.0-hf5aa216_100_cp313.conda
   build_number: 100
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.13.0-hf5aa216_100_cp313.conda
   sha256: 18f3f0bd514c9101d38d57835b2d027958f3ae4b3b65c22d187a857aa26b3a08
   md5: 3c2f7ad3f598480fe2a09e4e33cb1a2a
   depends:
@@ -13926,13 +10641,8 @@ packages:
   purls: []
   size: 16641177
   timestamp: 1728417810202
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
   build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
   sha256: d10e93d759931ffb6372b45d65ff34d95c6000c61a07e298d162a3bc2accebb0
   md5: 0424ae29b104430108f5218a66db7260
   constrains:
@@ -13942,13 +10652,8 @@ packages:
   purls: []
   size: 6238
   timestamp: 1723823388266
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-5_cp312.conda
   build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-5_cp312.conda
   sha256: 5ccdad9981753cc4a2d126e356673a21c0cd5b34e209cb8d476a3947d4ad9b39
   md5: 62b20f305498284a07dc6c45fd0e5c87
   constrains:
@@ -13958,13 +10663,8 @@ packages:
   purls: []
   size: 6329
   timestamp: 1723823366253
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
   build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
   sha256: 49d624e4b809c799d2bf257b22c23cf3fc4460f5570d9a58e7ad86350aeaa1f4
   md5: b76f9b1c862128e56ac7aa8cd2333de9
   constrains:
@@ -13974,13 +10674,8 @@ packages:
   purls: []
   size: 6278
   timestamp: 1723823099686
-- kind: conda
-  name: python_abi
-  version: '3.13'
-  build: 5_cp313
+- conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.13-5_cp313.conda
   build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.13-5_cp313.conda
   sha256: 0c12cc1b84962444002c699ed21e815fb9f686f950d734332a1b74d07db97756
   md5: 44b4fe6f22b57103afb2299935c8b68e
   constrains:
@@ -13990,34 +10685,7 @@ packages:
   purls: []
   size: 6716
   timestamp: 1723823166911
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py312h024a12e_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h024a12e_1.conda
-  sha256: b06f1c15fb39695bbf707ae8fb554b9a77519af577b5556784534c7db10b52e3
-  md5: 1ee23620cf46cb15900f70a1300bae55
-  depends:
-  - __osx >=11.0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyyaml?source=hash-mapping
-  size: 187143
-  timestamp: 1725456547263
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py312h66e93f0_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h66e93f0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h66e93f0_1.conda
   sha256: a60705971e958724168f2ebbb8ed4853067f1d3f7059843df3903e3092bbcffa
   md5: 549e5930e768548a89c23f595dac5a95
   depends:
@@ -14032,13 +10700,7 @@ packages:
   - pkg:pypi/pyyaml?source=hash-mapping
   size: 206553
   timestamp: 1725456256213
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py312hb2c0f52_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.2-py312hb2c0f52_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyyaml-6.0.2-py312hb2c0f52_1.conda
   sha256: 8c515ebe1e7e85d972d72b75760af9dfac06fd11a9dba7e05c42d69aedbb303c
   md5: dc5de424f7dbb9772da720dbb81317b2
   depends:
@@ -14053,13 +10715,22 @@ packages:
   - pkg:pypi/pyyaml?source=hash-mapping
   size: 199141
   timestamp: 1725456356043
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py313ha7868ed_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py313ha7868ed_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h024a12e_1.conda
+  sha256: b06f1c15fb39695bbf707ae8fb554b9a77519af577b5556784534c7db10b52e3
+  md5: 1ee23620cf46cb15900f70a1300bae55
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  size: 187143
+  timestamp: 1725456547263
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py313ha7868ed_1.conda
   sha256: ffa21c4715aa139d20c96ae7274fbb7de12a546f3332eb8d07cc794741fcbde6
   md5: c1743e5c4c7402a14b515cf276778e59
   depends:
@@ -14075,29 +10746,7 @@ packages:
   - pkg:pypi/pyyaml?source=hash-mapping
   size: 181722
   timestamp: 1725456802746
-- kind: conda
-  name: qhull
-  version: '2020.2'
-  build: h420ef59_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
-  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
-  md5: 6483b1f59526e05d7d894e466b5b6924
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: LicenseRef-Qhull
-  purls: []
-  size: 516376
-  timestamp: 1720814307311
-- kind: conda
-  name: qhull
-  version: '2020.2'
-  build: h434a139_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
   sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
   md5: 353823361b1d27eb3960efb076dfcaf6
   depends:
@@ -14108,13 +10757,7 @@ packages:
   purls: []
   size: 552937
   timestamp: 1720813982144
-- kind: conda
-  name: qhull
-  version: '2020.2'
-  build: h70be974_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
   sha256: 49f777bdf3c5e030a8c7b24c58cdfe9486b51d6ae0001841079a3228bdf9fb51
   md5: bb138086d938e2b64f5f364945793ebf
   depends:
@@ -14124,13 +10767,17 @@ packages:
   purls: []
   size: 554571
   timestamp: 1720813941183
-- kind: conda
-  name: qhull
-  version: '2020.2'
-  build: hc790b64_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
+  sha256: 873ac689484262a51fd79bc6103c1a1bedbf524924d7f0088fb80703042805e4
+  md5: 6483b1f59526e05d7d894e466b5b6924
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  purls: []
+  size: 516376
+  timestamp: 1720814307311
+- conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
   sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
   md5: 854fbdff64b572b5c0b470f334d34c11
   depends:
@@ -14141,43 +10788,7 @@ packages:
   purls: []
   size: 1377020
   timestamp: 1720814433486
-- kind: conda
-  name: qt-main
-  version: 5.15.15
-  build: h264fbc2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.15-h264fbc2_0.conda
-  sha256: 77c78ce62e5c53ed529f035535283b96ee617ffd64ae1ea6a2dfdea186e39608
-  md5: e6e473c620bc0c3772dbed14f9eb4ab2
-  depends:
-  - gst-plugins-base >=1.24.7,<1.25.0a0
-  - gstreamer >=1.24.7,<1.25.0a0
-  - icu >=75.1,<76.0a0
-  - krb5 >=1.21.3,<1.22.0a0
-  - libclang13 >=19.1.2
-  - libglib >=2.82.2,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.44,<1.7.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
-  - qt 5.15.15
-  license: LGPL-3.0-only
-  license_family: LGPL
-  purls: []
-  size: 60059195
-  timestamp: 1729904868434
-- kind: conda
-  name: qt-main
-  version: 5.15.15
-  build: h374914d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h374914d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h374914d_0.conda
   sha256: 333be9817b492b7303d3a01073d3cff71719e72ba11507141ddfdd89732dc7a8
   md5: 26e8b00e73c114c9b787d36edcbf4424
   depends:
@@ -14237,12 +10848,7 @@ packages:
   purls: []
   size: 52549288
   timestamp: 1729904847636
-- kind: conda
-  name: qt-main
-  version: 5.15.15
-  build: h3c8598d_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h3c8598d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.15-h3c8598d_0.conda
   sha256: efe565fbe7f0b0c39f3c179d383a8a3f39582934e225775927b9c05c9b9792ea
   md5: 2b6e3e9f306565824c25f64df8953f39
   depends:
@@ -14301,12 +10907,7 @@ packages:
   purls: []
   size: 51848391
   timestamp: 1729887971802
-- kind: conda
-  name: qt-main
-  version: 5.15.15
-  build: h7d33341_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.15-h7d33341_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.15-h7d33341_0.conda
   sha256: 995563c7c2ae112179cb1cec67837af1624234a1e39e1ca86f6b5de44cbc6af8
   md5: 065abdbfa76bdb7b89cee314a594055e
   depends:
@@ -14336,12 +10937,33 @@ packages:
   purls: []
   size: 50010318
   timestamp: 1729905112196
-- kind: conda
-  name: qt6-main
-  version: 6.7.3
-  build: h20baabe_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.7.3-h20baabe_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.15-h264fbc2_0.conda
+  sha256: 77c78ce62e5c53ed529f035535283b96ee617ffd64ae1ea6a2dfdea186e39608
+  md5: e6e473c620bc0c3772dbed14f9eb4ab2
+  depends:
+  - gst-plugins-base >=1.24.7,<1.25.0a0
+  - gstreamer >=1.24.7,<1.25.0a0
+  - icu >=75.1,<76.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang13 >=19.1.2
+  - libglib >=2.82.2,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - qt 5.15.15
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 60059195
+  timestamp: 1729904868434
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.7.3-h20baabe_0.conda
   sha256: ea392f29b89505f878f4654f297674cd18a068abba764fd9b84802804ba97d23
   md5: 1b22804cf94e520ff2bafc0a908dd6a4
   depends:
@@ -14399,13 +11021,7 @@ packages:
   purls: []
   size: 47296097
   timestamp: 1727454717035
-- kind: conda
-  name: qt6-main
-  version: 6.7.3
-  build: hfb098fa_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.7.3-hfb098fa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.7.3-hfb098fa_1.conda
   sha256: c10933396b409f74f05fe7036ddf2b129e219dd3939170c3ebb0fd0790cd14ac
   md5: 3dd4b78a610e48def640c3c9acd0c7e7
   depends:
@@ -14434,13 +11050,7 @@ packages:
   purls: []
   size: 88587578
   timestamp: 1727941590323
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h8228510_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
   md5: 47d31b792659ce70f470b5c82fdfb7a4
   depends:
@@ -14451,13 +11061,7 @@ packages:
   purls: []
   size: 281456
   timestamp: 1679532220005
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h8fc344f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
   sha256: 4c99f7417419734e3797d45bc355e61c26520e111893b0d7087a01a7fbfbe3dd
   md5: 105eb1e16bf83bfb2eb380a48032b655
   depends:
@@ -14468,13 +11072,7 @@ packages:
   purls: []
   size: 294092
   timestamp: 1679532238805
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h92ec313_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
   sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
   md5: 8cbb776a2f641b943d413b3e19df71f4
   depends:
@@ -14484,13 +11082,7 @@ packages:
   purls: []
   size: 250351
   timestamp: 1679532511311
-- kind: conda
-  name: resolve-robotics-uri-py
-  version: 0.3.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/resolve-robotics-uri-py-0.3.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/resolve-robotics-uri-py-0.3.0-pyhd8ed1ab_0.conda
   sha256: 38cc85afc1455cbaeef65b5c6820d3a1d60397533bef28b5b0fee7db6dee9f89
   md5: cb0b32d4c087b4170c7bcdb74ece33e7
   depends:
@@ -14501,13 +11093,39 @@ packages:
   - pkg:pypi/resolve-robotics-uri-py?source=hash-mapping
   size: 12439
   timestamp: 1715749955479
-- kind: conda
-  name: robot-testing-framework
-  version: 2.0.1
-  build: h63175ca_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/robot-testing-framework-2.0.1-h63175ca_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/robot-testing-framework-2.0.1-hcb278e6_1.conda
+  sha256: 242a98d006cb6056ada72553b856d89c3965f1f76ee96aaeac1020922ae5fffb
+  md5: 3e26d7c5a6e543cd83264ac70df92b6b
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - tinyxml
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 185412
+  timestamp: 1674116888665
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/robot-testing-framework-2.0.1-hd600fc2_1.conda
+  sha256: 326bdaab98b2f68f0b5b83e5b022fff50fa49ded1e959a1c9b00e378aa6ff2e2
+  md5: d186a8ab75c012d89f274cc903b17182
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - tinyxml
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 181367
+  timestamp: 1674116967037
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/robot-testing-framework-2.0.1-hb7217d7_1.conda
+  sha256: b9e1e7c27b0c3559691921d07a6cdb1b57d2bea575cce2939401f3c643a2a1cc
+  md5: f94db447c6bd18a0a22087dd897e400c
+  depends:
+  - libcxx >=14.0.6
+  - tinyxml
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 181170
+  timestamp: 1674117151771
+- conda: https://conda.anaconda.org/conda-forge/win-64/robot-testing-framework-2.0.1-h63175ca_1.conda
   sha256: 5552242dd9b16126fb19bbece630d1a7184e44ab5a9b40f2fb6d11472006ccce
   md5: fc8684b4e2e739e6dc3d33b5863c64a5
   depends:
@@ -14519,63 +11137,7 @@ packages:
   purls: []
   size: 229485
   timestamp: 1674117166712
-- kind: conda
-  name: robot-testing-framework
-  version: 2.0.1
-  build: hb7217d7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/robot-testing-framework-2.0.1-hb7217d7_1.conda
-  sha256: b9e1e7c27b0c3559691921d07a6cdb1b57d2bea575cce2939401f3c643a2a1cc
-  md5: f94db447c6bd18a0a22087dd897e400c
-  depends:
-  - libcxx >=14.0.6
-  - tinyxml
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 181170
-  timestamp: 1674117151771
-- kind: conda
-  name: robot-testing-framework
-  version: 2.0.1
-  build: hcb278e6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/robot-testing-framework-2.0.1-hcb278e6_1.conda
-  sha256: 242a98d006cb6056ada72553b856d89c3965f1f76ee96aaeac1020922ae5fffb
-  md5: 3e26d7c5a6e543cd83264ac70df92b6b
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - tinyxml
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 185412
-  timestamp: 1674116888665
-- kind: conda
-  name: robot-testing-framework
-  version: 2.0.1
-  build: hd600fc2_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/robot-testing-framework-2.0.1-hd600fc2_1.conda
-  sha256: 326bdaab98b2f68f0b5b83e5b022fff50fa49ded1e959a1c9b00e378aa6ff2e2
-  md5: d186a8ab75c012d89f274cc903b17182
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - tinyxml
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 181367
-  timestamp: 1674116967037
-- kind: conda
-  name: robot_descriptions
-  version: 1.13.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/robot_descriptions-1.13.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/robot_descriptions-1.13.0-pyhd8ed1ab_0.conda
   sha256: eb25ab2dff0632b6c05b4b4763954230e5e1301705d6128f49260af9e423aa82
   md5: 0b8dd9e1c1065974786dc50677bdcfc6
   depends:
@@ -14588,12 +11150,218 @@ packages:
   - pkg:pypi/robot-descriptions?source=hash-mapping
   size: 39838
   timestamp: 1730323476139
-- kind: conda
-  name: sdl
-  version: 1.2.68
-  build: h21dd15a_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/sdl-1.2.68-h21dd15a_0.conda
+- pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: scipy
+  version: 1.17.1
+  sha256: 02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458
+  requires_dist:
+  - numpy>=1.26.4,<2.7
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.10.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl
+  name: scipy
+  version: 1.17.1
+  sha256: 37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448
+  requires_dist:
+  - numpy>=1.26.4,<2.7
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.10.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl
+  name: scipy
+  version: 1.17.1
+  sha256: fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76
+  requires_dist:
+  - numpy>=1.26.4,<2.7
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.10.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+  name: scipy
+  version: 1.17.1
+  sha256: e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21
+  requires_dist:
+  - numpy>=1.26.4,<2.7
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.10.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl-1.2.68-h293081c_0.conda
+  sha256: 794978a95605128144fc14c193eae1abf79524dafe34d9ef36aa5d6ba40ff7bb
+  md5: 53326ff6864578787913ba15616ad2f9
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - sdl2 >=2.28.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 156115
+  timestamp: 1695759535287
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl-1.2.68-h32cd00b_0.conda
+  sha256: 7c6efceabfb742aa84cd745dd5e3cf24d9ee7167ee3851c99b29425faf21fd1c
+  md5: 2beaa8269df50204969ed14432cec69e
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - sdl2 >=2.28.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 159244
+  timestamp: 1695759461200
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl-1.2.68-hfc12253_0.conda
+  sha256: 7f1e0d3e765a629852f00aef8a66a23ac98d2251efdb18073239d8e76493e14a
+  md5: 3f2b68e7acdffc200fea7b801be0ed36
+  depends:
+  - libcxx >=15.0.7
+  - sdl2 >=2.28.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 156067
+  timestamp: 1695759902673
+- conda: https://conda.anaconda.org/conda-forge/win-64/sdl-1.2.68-h21dd15a_0.conda
   sha256: 6db7e8853bf7b2ed45c987c927ee4190d0255f914c9cd135693a169416bef727
   md5: 695be37cf7e9d14a14ec5f79ef1ffc6b
   depends:
@@ -14606,80 +11374,7 @@ packages:
   purls: []
   size: 151281
   timestamp: 1695760016129
-- kind: conda
-  name: sdl
-  version: 1.2.68
-  build: h293081c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sdl-1.2.68-h293081c_0.conda
-  sha256: 794978a95605128144fc14c193eae1abf79524dafe34d9ef36aa5d6ba40ff7bb
-  md5: 53326ff6864578787913ba15616ad2f9
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - sdl2 >=2.28.3,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 156115
-  timestamp: 1695759535287
-- kind: conda
-  name: sdl
-  version: 1.2.68
-  build: h32cd00b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl-1.2.68-h32cd00b_0.conda
-  sha256: 7c6efceabfb742aa84cd745dd5e3cf24d9ee7167ee3851c99b29425faf21fd1c
-  md5: 2beaa8269df50204969ed14432cec69e
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - sdl2 >=2.28.3,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 159244
-  timestamp: 1695759461200
-- kind: conda
-  name: sdl
-  version: 1.2.68
-  build: hfc12253_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sdl-1.2.68-hfc12253_0.conda
-  sha256: 7f1e0d3e765a629852f00aef8a66a23ac98d2251efdb18073239d8e76493e14a
-  md5: 3f2b68e7acdffc200fea7b801be0ed36
-  depends:
-  - libcxx >=15.0.7
-  - sdl2 >=2.28.3,<3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 156067
-  timestamp: 1695759902673
-- kind: conda
-  name: sdl2
-  version: 2.30.7
-  build: h2a74887_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.7-h2a74887_0.conda
-  sha256: 6c21954d98a915d7617c0944440167e5ac695117ca7410f37eea4af0a9f0821c
-  md5: 719245709dd47dbc3f93ce85fa544f43
-  depends:
-  - libgcc >=13
-  - libstdcxx >=13
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  license: Zlib
-  purls: []
-  size: 1317383
-  timestamp: 1725255076176
-- kind: conda
-  name: sdl2
-  version: 2.30.7
-  build: h3ed165c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.7-h3ed165c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.7-h3ed165c_0.conda
   sha256: 80691a3ce313f0f7908480c0af216520d655e9480e036feb489c2095ad37950a
   md5: be75875082c99c7a9f9fe930a1bd2bb1
   depends:
@@ -14693,12 +11388,30 @@ packages:
   purls: []
   size: 1391142
   timestamp: 1725255009793
-- kind: conda
-  name: sdl2
-  version: 2.30.7
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.7-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sdl2-2.30.7-h2a74887_0.conda
+  sha256: 6c21954d98a915d7617c0944440167e5ac695117ca7410f37eea4af0a9f0821c
+  md5: 719245709dd47dbc3f93ce85fa544f43
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  purls: []
+  size: 1317383
+  timestamp: 1725255076176
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.30.7-hf9b8971_0.conda
+  sha256: d86b4f39c09efb6febd5e2e5a2c0894c82f7ac4b8b4aebb24e4fbd9acf797d60
+  md5: 33f5451441cbc0ce083b3d37c181519e
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: Zlib
+  purls: []
+  size: 1256184
+  timestamp: 1725254933792
+- conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.7-he0c23c2_0.conda
   sha256: bf850eba90ff5103c2a92d3ab0395edd078b7c95cbabc4254462d9bea7850c48
   md5: e452497e0b9824c0be7f6670adbabc63
   depends:
@@ -14709,28 +11422,7 @@ packages:
   purls: []
   size: 2243873
   timestamp: 1725255268158
-- kind: conda
-  name: sdl2
-  version: 2.30.7
-  build: hf9b8971_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.30.7-hf9b8971_0.conda
-  sha256: d86b4f39c09efb6febd5e2e5a2c0894c82f7ac4b8b4aebb24e4fbd9acf797d60
-  md5: 33f5451441cbc0ce083b3d37c181519e
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  license: Zlib
-  purls: []
-  size: 1256184
-  timestamp: 1725254933792
-- kind: conda
-  name: setuptools
-  version: 75.3.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
   sha256: a36d020b9f32fc3f1a6488a1c4a9c13988c6468faf6895bf30ca69521a61230e
   md5: 2ce9825396daf72baabaade36cee16da
   depends:
@@ -14741,13 +11433,7 @@ packages:
   - pkg:pypi/setuptools?source=hash-mapping
   size: 779561
   timestamp: 1730382173961
-- kind: conda
-  name: smmap
-  version: 5.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
   sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
   md5: 62f26a3d1387acee31322208f0cfa3e0
   depends:
@@ -14758,12 +11444,18 @@ packages:
   - pkg:pypi/smmap?source=hash-mapping
   size: 22483
   timestamp: 1634310465482
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: h1088aeb_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.1-h1088aeb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+  md5: 6b7dcc7349efd123d493d2dbe85a045f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 42465
+  timestamp: 1720003704360
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.1-h1088aeb_0.conda
   sha256: 79f5d0a9098acf2ed16e6ecc4c11472b50ccf59feea37a7d585fd43888d7e41f
   md5: e4ed5b015f525b56f95c26d85a4ea208
   depends:
@@ -14774,12 +11466,18 @@ packages:
   purls: []
   size: 42888
   timestamp: 1720003817527
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: h23299a8_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
+  md5: 69d0f9694f3294418ee935da3d5f7272
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 35708
+  timestamp: 1720003794374
+- conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
   sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
   md5: 7635a408509e20dcfc7653ca305ad799
   depends:
@@ -14791,45 +11489,7 @@ packages:
   purls: []
   size: 59350
   timestamp: 1720004197144
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: ha2e4443_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
-  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
-  md5: 6b7dcc7349efd123d493d2dbe85a045f
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 42465
-  timestamp: 1720003704360
-- kind: conda
-  name: snappy
-  version: 1.2.1
-  build: hd02b534_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
-  sha256: cb7a9440241c6092e0f1c795fdca149c4767023e783eaf9cfebc501f906b4897
-  md5: 69d0f9694f3294418ee935da3d5f7272
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 35708
-  timestamp: 1720003794374
-- kind: conda
-  name: soxr
-  version: 0.1.3
-  build: h0b41bf4_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/soxr-0.1.3-h0b41bf4_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/soxr-0.1.3-h0b41bf4_3.conda
   sha256: 141e3364d26f162bfeae8491787c0d8796ada6c29a8cd567c1cd17c3c6b418f9
   md5: e8d261785be19b1575d23ccbbeae4ddd
   depends:
@@ -14839,28 +11499,7 @@ packages:
   purls: []
   size: 131370
   timestamp: 1674059502792
-- kind: conda
-  name: soxr
-  version: 0.1.3
-  build: h5008568_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/soxr-0.1.3-h5008568_3.conda
-  sha256: b3028eab2df50ebfbfbf7e21074d4862a8aa12867272ae363c0b415c6119ebe7
-  md5: 02fbc2cdd53ed18f8a4dbf36125d8b7d
-  depends:
-  - llvm-openmp >=14.0.6
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 90088
-  timestamp: 1674122598089
-- kind: conda
-  name: soxr
-  version: 0.1.3
-  build: hb4cce97_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/soxr-0.1.3-hb4cce97_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/soxr-0.1.3-hb4cce97_3.conda
   sha256: 58b006195863f200efdb5785a4a954f8d0284b5984703d4d74ec4c09343e58e2
   md5: 13e1d5bd316dec4077351f4246b9b2a8
   depends:
@@ -14870,13 +11509,16 @@ packages:
   purls: []
   size: 111209
   timestamp: 1674059588618
-- kind: conda
-  name: soxr
-  version: 0.1.3
-  build: hcfcfb64_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/soxr-0.1.3-hcfcfb64_3.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/soxr-0.1.3-h5008568_3.conda
+  sha256: b3028eab2df50ebfbfbf7e21074d4862a8aa12867272ae363c0b415c6119ebe7
+  md5: 02fbc2cdd53ed18f8a4dbf36125d8b7d
+  depends:
+  - llvm-openmp >=14.0.6
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 90088
+  timestamp: 1674122598089
+- conda: https://conda.anaconda.org/conda-forge/win-64/soxr-0.1.3-hcfcfb64_3.conda
   sha256: 167201931c6be6355fa79e22fe5b8993f67a2efd0fc94acbb15393918d9a7578
   md5: 8112bd0d3eb530551b2adebda0ea4c0c
   depends:
@@ -14887,12 +11529,7 @@ packages:
   purls: []
   size: 112328
   timestamp: 1674059996047
-- kind: conda
-  name: svt-av1
-  version: 2.3.0
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-2.3.0-h5888daf_0.conda
   sha256: df30a9be29f1a8b5a2e314dd5b16ccfbcbd1cc6a4f659340e8bc2bd4de37bc6f
   md5: 355898d24394b2af353eb96358db9fdd
   depends:
@@ -14904,12 +11541,7 @@ packages:
   purls: []
   size: 2746291
   timestamp: 1730246036363
-- kind: conda
-  name: svt-av1
-  version: 2.3.0
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-2.3.0-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-2.3.0-h5ad3122_0.conda
   sha256: 2fad2496a21d198ea72f5dabfdace2fae0ced5cc3ea243922cb372fcf4c18222
   md5: efb60b536bbf64772929b57f6b30298b
   depends:
@@ -14920,12 +11552,18 @@ packages:
   purls: []
   size: 1796731
   timestamp: 1730246027014
-- kind: conda
-  name: svt-av1
-  version: 2.3.0
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.3.0-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.3.0-hf24288c_0.conda
+  sha256: ab876ed8bdd20e22a868dcb8d03e9ce9bbba7762d7e652d49bfff6af768a5b8f
+  md5: 114c33e9eec335a379c9ee6c498bb807
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 1387330
+  timestamp: 1730246134730
+- conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.3.0-he0c23c2_0.conda
   sha256: c25bf68ef411d41ee29f353acc698c482fdd087426a77398b7b41ce9d968519e
   md5: ac11ae1da661e573b71870b1191ce079
   depends:
@@ -14937,80 +11575,7 @@ packages:
   purls: []
   size: 1845727
   timestamp: 1730246453216
-- kind: conda
-  name: svt-av1
-  version: 2.3.0
-  build: hf24288c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-2.3.0-hf24288c_0.conda
-  sha256: ab876ed8bdd20e22a868dcb8d03e9ce9bbba7762d7e652d49bfff6af768a5b8f
-  md5: 114c33e9eec335a379c9ee6c498bb807
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 1387330
-  timestamp: 1730246134730
-- kind: conda
-  name: tbb
-  version: 2021.13.0
-  build: hc790b64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
-  sha256: 990dbe4fb42f14700c22bd434d8312607bf8d0bd9f922b054e51fda14c41994c
-  md5: 28496a1e6af43c63927da4f80260348d
-  depends:
-  - libhwloc >=2.11.1,<2.11.2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 151494
-  timestamp: 1725532984828
-- kind: conda
-  name: tbb
-  version: 2022.0.0
-  build: h0cbf7ec_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2022.0.0-h0cbf7ec_0.conda
-  sha256: f436517a16494c93e2d779b9cdb91e8f4a9b48cef67fe20a4e75e494c8631dff
-  md5: 44ba5ad9819821b9b176ba2bb937a79c
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - libhwloc >=2.11.2,<2.11.3.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 117825
-  timestamp: 1730477755617
-- kind: conda
-  name: tbb
-  version: 2022.0.0
-  build: h243be18_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2022.0.0-h243be18_0.conda
-  sha256: 914b8f72004bc72dda573ae6579f2443f9be2556865b91a0a958368b40b189c6
-  md5: adc00506117e9ea09114ce0dac3681f0
-  depends:
-  - libgcc >=13
-  - libhwloc >=2.11.2,<2.11.3.0a0
-  - libstdcxx >=13
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 146414
-  timestamp: 1730479107676
-- kind: conda
-  name: tbb
-  version: 2022.0.0
-  build: hceb3a55_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.0.0-hceb3a55_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.0.0-hceb3a55_0.conda
   sha256: 2f7931cad1682d8b6bdc90dbb51edf01f6f5c33fc00392c396d63e24437df1e8
   md5: 79f0161f3ca73804315ca980f65d9c60
   depends:
@@ -15023,44 +11588,44 @@ packages:
   purls: []
   size: 178584
   timestamp: 1730477634943
-- kind: conda
-  name: tinyxml
-  version: 2.6.2
-  build: h260d524_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml-2.6.2-h260d524_2.tar.bz2
-  sha256: ffed96f7167394be9007c1b4e2b28cf690388f9aaef0b57f0d44ad44bb247f94
-  md5: 514f487df6232e8dd819faf3c5915e58
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2022.0.0-h243be18_0.conda
+  sha256: 914b8f72004bc72dda573ae6579f2443f9be2556865b91a0a958368b40b189c6
+  md5: adc00506117e9ea09114ce0dac3681f0
   depends:
-  - libcxx >=11.0.1
-  license: Zlib
+  - libgcc >=13
+  - libhwloc >=2.11.2,<2.11.3.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 52319
-  timestamp: 1613627858183
-- kind: conda
-  name: tinyxml
-  version: 2.6.2
-  build: h2d74725_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tinyxml-2.6.2-h2d74725_2.tar.bz2
-  sha256: 92b01cf22522c6da6e56825692c2ae2c0dd1a1bc7251a86cdf47d5ab451cb31c
-  md5: a5c2010323ceaa8faec6697921b23928
+  size: 146414
+  timestamp: 1730479107676
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2022.0.0-h0cbf7ec_0.conda
+  sha256: f436517a16494c93e2d779b9cdb91e8f4a9b48cef67fe20a4e75e494c8631dff
+  md5: 44ba5ad9819821b9b176ba2bb937a79c
   depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: Zlib
+  - __osx >=11.0
+  - libcxx >=17
+  - libhwloc >=2.11.2,<2.11.3.0a0
+  license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 71271
-  timestamp: 1611562303689
-- kind: conda
-  name: tinyxml
-  version: 2.6.2
-  build: h4bd325d_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
+  size: 117825
+  timestamp: 1730477755617
+- conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
+  sha256: 990dbe4fb42f14700c22bd434d8312607bf8d0bd9f922b054e51fda14c41994c
+  md5: 28496a1e6af43c63927da4f80260348d
+  depends:
+  - libhwloc >=2.11.1,<2.11.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 151494
+  timestamp: 1725532984828
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml-2.6.2-h4bd325d_2.tar.bz2
   sha256: d9e3c192c535c06ec139ada7bcd1f12313ebd377208fc8149348e8534229f39e
   md5: 39dd0757ee71ccd5b120440dce126c37
   depends:
@@ -15070,13 +11635,7 @@ packages:
   purls: []
   size: 56535
   timestamp: 1611562094388
-- kind: conda
-  name: tinyxml
-  version: 2.6.2
-  build: hd62202e_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml-2.6.2-hd62202e_2.tar.bz2
   sha256: d7f66bd0ddfbe1b8f2638678d962140e8ab8a63d779b9366247e1f7daabeb575
   md5: 454eb4b31a1f4313c72ef7f536cae5d9
   depends:
@@ -15086,27 +11645,26 @@ packages:
   purls: []
   size: 56283
   timestamp: 1611562275383
-- kind: conda
-  name: tinyxml2
-  version: 10.0.0
-  build: h2f0025b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml2-10.0.0-h2f0025b_0.conda
-  sha256: 10d0976ffede72b49538655593a3b85313c757e6a7a42711beff71f3cb9c7b13
-  md5: 9d115f3d0c4e07d872ad1b96d489d63c
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml-2.6.2-h260d524_2.tar.bz2
+  sha256: ffed96f7167394be9007c1b4e2b28cf690388f9aaef0b57f0d44ad44bb247f94
+  md5: 514f487df6232e8dd819faf3c5915e58
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - libcxx >=11.0.1
   license: Zlib
   purls: []
-  size: 122297
-  timestamp: 1704497052039
-- kind: conda
-  name: tinyxml2
-  version: 10.0.0
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-10.0.0-h59595ed_0.conda
+  size: 52319
+  timestamp: 1613627858183
+- conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml-2.6.2-h2d74725_2.tar.bz2
+  sha256: 92b01cf22522c6da6e56825692c2ae2c0dd1a1bc7251a86cdf47d5ab451cb31c
+  md5: a5c2010323ceaa8faec6697921b23928
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: Zlib
+  purls: []
+  size: 71271
+  timestamp: 1611562303689
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-10.0.0-h59595ed_0.conda
   sha256: e89306d01999f629a329ddb2e2ca9b8fbfe7c483d13f9805f0c6891a24a6e9c8
   md5: 5e27e4a780264caed4be372ded70a9e9
   depends:
@@ -15116,12 +11674,26 @@ packages:
   purls: []
   size: 120640
   timestamp: 1704495493222
-- kind: conda
-  name: tinyxml2
-  version: 10.0.0
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-10.0.0-h63175ca_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml2-10.0.0-h2f0025b_0.conda
+  sha256: 10d0976ffede72b49538655593a3b85313c757e6a7a42711beff71f3cb9c7b13
+  md5: 9d115f3d0c4e07d872ad1b96d489d63c
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Zlib
+  purls: []
+  size: 122297
+  timestamp: 1704497052039
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml2-10.0.0-hebf3989_0.conda
+  sha256: 80fa29e6a631e51a6cad94f83a60437e26c61be940dd456cd4ef571f8b5de0a6
+  md5: f5c3be2ff74793fc072a9462ace0bdc1
+  depends:
+  - libcxx >=15
+  license: Zlib
+  purls: []
+  size: 112711
+  timestamp: 1704495776088
+- conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-10.0.0-h63175ca_0.conda
   sha256: 76ba12053a358d5c4b07ac3a8eb1cc3282df5cada273fc625fc2211e48082036
   md5: 353cf648e0d3165c9f9c8adbe7c9d05d
   depends:
@@ -15132,26 +11704,18 @@ packages:
   purls: []
   size: 127979
   timestamp: 1704496014562
-- kind: conda
-  name: tinyxml2
-  version: 10.0.0
-  build: hebf3989_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml2-10.0.0-hebf3989_0.conda
-  sha256: 80fa29e6a631e51a6cad94f83a60437e26c61be940dd456cd4ef571f8b5de0a6
-  md5: f5c3be2ff74793fc072a9462ace0bdc1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
   depends:
-  - libcxx >=15
-  license: Zlib
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
   purls: []
-  size: 112711
-  timestamp: 1704495776088
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h194ca79_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+  size: 3318875
+  timestamp: 1699202167581
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
   sha256: 7fa27cc512d3a783f38bd16bbbffc008807372499d5b65d089a8e43bde9db267
   md5: f75105e0585851f818e0009dd1dde4dc
   depends:
@@ -15162,13 +11726,7 @@ packages:
   purls: []
   size: 3351802
   timestamp: 1695506242997
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h5083fa2_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
   sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
   md5: b50a57ba89c32b62428b71a875291c9b
   depends:
@@ -15178,13 +11736,7 @@ packages:
   purls: []
   size: 3145523
   timestamp: 1699202432999
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h5226925_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
   sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
   md5: fc048363eb8f03cd1737600a5d08aafe
   depends:
@@ -15196,30 +11748,7 @@ packages:
   purls: []
   size: 3503410
   timestamp: 1699202577803
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: noxft_h4845f30_101
-  build_number: 101
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
-  md5: d453b98d9c83e71da0741bb0ff4d76bc
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  purls: []
-  size: 3318875
-  timestamp: 1699202167581
-- kind: conda
-  name: tomli
-  version: 2.0.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.2-pyhd8ed1ab_0.conda
   sha256: 5e742ba856168b606ac3c814d247657b1c33b8042371f1a08000bdc5075bc0cc
   md5: e977934e00b355ff55ed154904044727
   depends:
@@ -15230,13 +11759,7 @@ packages:
   - pkg:pypi/tomli?source=hash-mapping
   size: 18203
   timestamp: 1727974767524
-- kind: conda
-  name: tqdm
-  version: 4.67.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.0-pyhd8ed1ab_0.conda
   sha256: fb25b18cec1ebae56e7d7ebbd3e504f063b61a0fac17b1ca798fcaf205bdc874
   md5: 196a9e6ab4e036ceafa516ea036619b0
   depends:
@@ -15247,13 +11770,7 @@ packages:
   - pkg:pypi/tqdm?source=hash-mapping
   size: 89434
   timestamp: 1730926216380
-- kind: conda
-  name: typing_extensions
-  version: 4.12.2
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
   sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
   md5: ebe6952715e1d5eb567eeebf25250fa7
   depends:
@@ -15264,26 +11781,14 @@ packages:
   - pkg:pypi/typing-extensions?source=hash-mapping
   size: 39888
   timestamp: 1717802653893
-- kind: conda
-  name: tzdata
-  version: 2024b
-  build: hc8b5060_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
   sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
   md5: 8ac3367aafb1cc0a068483c580af8015
   license: LicenseRef-Public-Domain
   purls: []
   size: 122354
   timestamp: 1728047496079
-- kind: conda
-  name: ucrt
-  version: 10.0.22621.0
-  build: h57928b3_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
   sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
   md5: 6797b005cd0f439c4c5c9ac565783700
   constrains:
@@ -15292,57 +11797,7 @@ packages:
   purls: []
   size: 559710
   timestamp: 1728377334097
-- kind: conda
-  name: ukkonen
-  version: 1.0.1
-  build: py312h451a7dd_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ukkonen-1.0.1-py312h451a7dd_5.conda
-  sha256: a4fdd0ce8532174bb7caf475fac947d3cdfe85d3b71ebeb2892281c650614c08
-  md5: 800fc7dab0bb640c93f530f8fa280c7b
-  depends:
-  - cffi
-  - libgcc >=13
-  - libstdcxx >=13
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ukkonen?source=hash-mapping
-  size: 14718
-  timestamp: 1725784301836
-- kind: conda
-  name: ukkonen
-  version: 1.0.1
-  build: py312h6142ec9_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py312h6142ec9_5.conda
-  sha256: 1e4452b4a12d8a69c237f14b876fbf0cdc456914170b49ba805779c749c31eca
-  md5: 2b485a809d1572cbe7f0ad9ee107e4b0
-  depends:
-  - __osx >=11.0
-  - cffi
-  - libcxx >=17
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ukkonen?source=hash-mapping
-  size: 13605
-  timestamp: 1725784243533
-- kind: conda
-  name: ukkonen
-  version: 1.0.1
-  build: py312h68727a3_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312h68727a3_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312h68727a3_5.conda
   sha256: 9fb020083a7f4fee41f6ece0f4840f59739b3e249f157c8a407bb374ffb733b5
   md5: f9664ee31aed96c85b7319ab0a693341
   depends:
@@ -15358,13 +11813,39 @@ packages:
   - pkg:pypi/ukkonen?source=hash-mapping
   size: 13904
   timestamp: 1725784191021
-- kind: conda
-  name: ukkonen
-  version: 1.0.1
-  build: py313h1ec8472_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py313h1ec8472_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ukkonen-1.0.1-py312h451a7dd_5.conda
+  sha256: a4fdd0ce8532174bb7caf475fac947d3cdfe85d3b71ebeb2892281c650614c08
+  md5: 800fc7dab0bb640c93f530f8fa280c7b
+  depends:
+  - cffi
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
+  size: 14718
+  timestamp: 1725784301836
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py312h6142ec9_5.conda
+  sha256: 1e4452b4a12d8a69c237f14b876fbf0cdc456914170b49ba805779c749c31eca
+  md5: 2b485a809d1572cbe7f0ad9ee107e4b0
+  depends:
+  - __osx >=11.0
+  - cffi
+  - libcxx >=17
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=hash-mapping
+  size: 13605
+  timestamp: 1725784243533
+- conda: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py313h1ec8472_5.conda
   sha256: 4f57f2eccd5584421f1b4d8c96c167c1008cba660d7fab5bdec1de212a0e0ff0
   md5: 97337494471e4265a203327f9a194234
   depends:
@@ -15380,28 +11861,7 @@ packages:
   - pkg:pypi/ukkonen?source=hash-mapping
   size: 17210
   timestamp: 1725784604368
-- kind: conda
-  name: unixodbc
-  version: 2.3.12
-  build: h0e2417a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/unixodbc-2.3.12-h0e2417a_0.conda
-  sha256: c23df29cd90c80f1bd599909cb8fb0281058d372324afde481687f240a7e77c7
-  md5: 466dfbfb384f10c790f48c9b4316ffb1
-  depends:
-  - libcxx >=15.0.7
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libiconv >=1.17,<2.0a0
-  license: LGPL-2.1
-  purls: []
-  size: 253937
-  timestamp: 1691504579753
-- kind: conda
-  name: unixodbc
-  version: 2.3.12
-  build: h661eb56_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.12-h661eb56_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.12-h661eb56_0.conda
   sha256: 718eb807a5e6e6993ee06745cb2a25a6b353427485a6e50df01db99c6016a53f
   md5: a737e5c549c13fbb5590c581848b0446
   depends:
@@ -15413,12 +11873,7 @@ packages:
   purls: []
   size: 281830
   timestamp: 1691504075258
-- kind: conda
-  name: unixodbc
-  version: 2.3.12
-  build: h7b6a552_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/unixodbc-2.3.12-h7b6a552_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unixodbc-2.3.12-h7b6a552_0.conda
   sha256: 09156b060dbfba9480bbd782ee57e4e6b324365385fb75e1ddaffb25cb79e218
   md5: 7da048d2fb224953a804da9e8026197f
   depends:
@@ -15430,13 +11885,18 @@ packages:
   purls: []
   size: 319756
   timestamp: 1691504019265
-- kind: conda
-  name: vc
-  version: '14.3'
-  build: ha32ba9b_22
-  build_number: 22
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_22.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/unixodbc-2.3.12-h0e2417a_0.conda
+  sha256: c23df29cd90c80f1bd599909cb8fb0281058d372324afde481687f240a7e77c7
+  md5: 466dfbfb384f10c790f48c9b4316ffb1
+  depends:
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1
+  purls: []
+  size: 253937
+  timestamp: 1691504579753
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_22.conda
   sha256: 2a47c5bd8bec045959afada7063feacd074ad66b170c1ea92dd139b389fcf8fd
   md5: 311c9ba1dfdd2895a8cb08346ff26259
   depends:
@@ -15448,13 +11908,7 @@ packages:
   purls: []
   size: 17447
   timestamp: 1728400826998
-- kind: conda
-  name: vc14_runtime
-  version: 14.40.33810
-  build: hcc2c482_22
-  build_number: 22
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
   sha256: 4c669c65007f88a7cdd560192f7e6d5679d191ac71610db724e18b2410964d64
   md5: ce23a4b980ee0556a118ed96550ff3f3
   depends:
@@ -15466,13 +11920,7 @@ packages:
   purls: []
   size: 750719
   timestamp: 1728401055788
-- kind: conda
-  name: virtualenv
-  version: 20.27.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.27.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.27.1-pyhd8ed1ab_0.conda
   sha256: 189b935224732267df10dc116bce0835bd76fcdb20c30f560591c92028d513b0
   md5: dae21509d62aa7bf676279ced3edcb3f
   depends:
@@ -15486,13 +11934,7 @@ packages:
   - pkg:pypi/virtualenv?source=hash-mapping
   size: 2965442
   timestamp: 1730204927840
-- kind: conda
-  name: vs2015_runtime
-  version: 14.40.33810
-  build: h3bf8584_22
-  build_number: 22
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
   sha256: 80aa9932203d65a96f817b8be4fafc176fb2b3fe6cf6899ede678b8f0317fbff
   md5: 8c6b061d44cafdfc8e8c6eb5f100caf0
   depends:
@@ -15502,12 +11944,7 @@ packages:
   purls: []
   size: 17453
   timestamp: 1728400827536
-- kind: conda
-  name: wayland
-  version: 1.23.1
-  build: h3e06ad9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
   sha256: 0884b2023a32d2620192cf2e2fc6784b8d1e31cf9f137e49e00802d4daf7d1c1
   md5: 0a732427643ae5e0486a727927791da1
   depends:
@@ -15521,12 +11958,7 @@ packages:
   purls: []
   size: 321561
   timestamp: 1724530461598
-- kind: conda
-  name: wayland
-  version: 1.23.1
-  build: h698ed42_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.23.1-h698ed42_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.23.1-h698ed42_0.conda
   sha256: 71c591803459e1f68f9ad206a4f2fa3971147502bad8791e94fd18d8362f8ce6
   md5: 2661f9252065051914f1cdf5835e7430
   depends:
@@ -15539,13 +11971,7 @@ packages:
   purls: []
   size: 324815
   timestamp: 1724530528414
-- kind: conda
-  name: wayland-protocols
-  version: '1.37'
-  build: hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.37-hd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.37-hd8ed1ab_0.conda
   sha256: f6cac1efd4d2a6e30c1671f0566d4e6ac3fe2dc34c9ff7f309bbbc916520ebcf
   md5: 73ec79a77d31eb7e4a3276cd246b776c
   depends:
@@ -15555,13 +11981,7 @@ packages:
   purls: []
   size: 95953
   timestamp: 1725657284103
-- kind: conda
-  name: x264
-  version: 1!164.3095
-  build: h166bdaf_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
   sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
   md5: 6c99772d483f566d59e25037fea2c4b1
   depends:
@@ -15571,13 +11991,7 @@ packages:
   purls: []
   size: 897548
   timestamp: 1660323080555
-- kind: conda
-  name: x264
-  version: 1!164.3095
-  build: h4e544f5_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
   sha256: b48f150db8c052c197691c9d76f59e252d3a7f01de123753d51ebf2eed1cf057
   md5: 0efaf807a0b5844ce5f605bd9b668281
   depends:
@@ -15587,13 +12001,7 @@ packages:
   purls: []
   size: 1000661
   timestamp: 1660324722559
-- kind: conda
-  name: x264
-  version: 1!164.3095
-  build: h57fd34a_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
   sha256: debdf60bbcfa6a60201b12a1d53f36736821db281a28223a09e0685edcce105a
   md5: b1f6dccde5d3a1f911960b6e567113ff
   license: GPL-2.0-or-later
@@ -15601,13 +12009,7 @@ packages:
   purls: []
   size: 717038
   timestamp: 1660323292329
-- kind: conda
-  name: x264
-  version: 1!164.3095
-  build: h8ffe710_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
   sha256: 97166b318f8c68ffe4d50b2f4bd36e415219eeaef233e7d41c54244dc6108249
   md5: 19e39905184459760ccb8cf5c75f148b
   depends:
@@ -15618,30 +12020,7 @@ packages:
   purls: []
   size: 1041889
   timestamp: 1660323726084
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: h2d74725_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
-  sha256: 02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2
-  md5: ca7129a334198f08347fb19ac98a2de9
-  depends:
-  - vc >=14.1,<15
-  - vs2015_runtime >=14.16.27033
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 5517425
-  timestamp: 1646611941216
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: h924138e_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
   sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
   md5: e7f6ed84d4623d52ee581325c1587a6b
   depends:
@@ -15652,29 +12031,7 @@ packages:
   purls: []
   size: 3357188
   timestamp: 1646609687141
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: hbc6ce65_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
-  sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
-  md5: b1f7f2780feffe310b068c021e8ff9b2
-  depends:
-  - libcxx >=12.0.1
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 1832744
-  timestamp: 1646609481185
-- kind: conda
-  name: x265
-  version: '3.5'
-  build: hdd96247_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
   sha256: cb2227f2441499900bdc0168eb423d7b2056c8fd5a3541df4e2d05509a88c668
   md5: 786853760099c74a1d4f0da98dd67aea
   depends:
@@ -15685,30 +12042,28 @@ packages:
   purls: []
   size: 1018181
   timestamp: 1646610147365
-- kind: conda
-  name: xcb-util
-  version: 0.4.1
-  build: h5c728e9_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-h5c728e9_2.conda
-  sha256: 59f586defd3c1295a32d8eb587036302ab254300d88e605354e8eaa4a27563ec
-  md5: b4cf8ba6cff9cdf1249bcfe1314222b0
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+  sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
+  md5: b1f7f2780feffe310b068c021e8ff9b2
   depends:
-  - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  license: MIT
-  license_family: MIT
+  - libcxx >=12.0.1
+  license: GPL-2.0-or-later
+  license_family: GPL
   purls: []
-  size: 20597
-  timestamp: 1718844955591
-- kind: conda
-  name: xcb-util
-  version: 0.4.1
-  build: hb711507_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
+  size: 1832744
+  timestamp: 1646609481185
+- conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+  sha256: 02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2
+  md5: ca7129a334198f08347fb19ac98a2de9
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 5517425
+  timestamp: 1646611941216
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
   sha256: 416aa55d946ce4ab173ab338796564893a2f820e80e04e098ff00c25fb981263
   md5: 8637c3e5821654d0edf97e2b0404b443
   depends:
@@ -15719,12 +12074,18 @@ packages:
   purls: []
   size: 19965
   timestamp: 1718843348208
-- kind: conda
-  name: xcb-util-cursor
-  version: 0.1.5
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-h5c728e9_2.conda
+  sha256: 59f586defd3c1295a32d8eb587036302ab254300d88e605354e8eaa4a27563ec
+  md5: b4cf8ba6cff9cdf1249bcfe1314222b0
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20597
+  timestamp: 1718844955591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
   sha256: c7b35db96f6e32a9e5346f97adc968ef2f33948e3d7084295baebc0e33abdd5b
   md5: eb44b3b6deb1cab08d72cb61686fe64c
   depends:
@@ -15739,31 +12100,7 @@ packages:
   purls: []
   size: 20296
   timestamp: 1726125844850
-- kind: conda
-  name: xcb-util-image
-  version: 0.4.0
-  build: h5c728e9_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
-  sha256: a43058edc001e8fb97f9b291028a6ca16a8969d9b56a998c7aecea083323ac97
-  md5: b82e5c78dbbfa931980e8bfe83bce913
-  depends:
-  - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
-  - xcb-util >=0.4.1,<0.5.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 24910
-  timestamp: 1718880504308
-- kind: conda
-  name: xcb-util-image
-  version: 0.4.0
-  build: hb711507_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
   sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
   md5: a0901183f08b6c7107aab109733a3c91
   depends:
@@ -15775,28 +12112,19 @@ packages:
   purls: []
   size: 24551
   timestamp: 1718880534789
-- kind: conda
-  name: xcb-util-keysyms
-  version: 0.4.1
-  build: h5c728e9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
-  sha256: 9d92daa7feb0e14f81bf0d4b3f0b6ff1e8cec3ff514df8a0c06c4d49b518c315
-  md5: 57ca8564599ddf8b633c4ea6afee6f3a
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
+  sha256: a43058edc001e8fb97f9b291028a6ca16a8969d9b56a998c7aecea083323ac97
+  md5: b82e5c78dbbfa931980e8bfe83bce913
   depends:
   - libgcc-ng >=12
   - libxcb >=1.16,<2.0.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 14343
-  timestamp: 1718846624153
-- kind: conda
-  name: xcb-util-keysyms
-  version: 0.4.1
-  build: hb711507_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+  size: 24910
+  timestamp: 1718880504308
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
   sha256: 546e3ee01e95a4c884b6401284bb22da449a2f4daf508d038fdfa0712fe4cc69
   md5: ad748ccca349aec3e91743e08b5e2b50
   depends:
@@ -15807,28 +12135,18 @@ packages:
   purls: []
   size: 14314
   timestamp: 1718846569232
-- kind: conda
-  name: xcb-util-renderutil
-  version: 0.3.10
-  build: h5c728e9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
-  sha256: 5827f5617c9741599f72bb7f090726f89c6ef91e4bada621895fdc2bbadfb0f1
-  md5: 7beeda4223c5484ef72d89fb66b7e8c1
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
+  sha256: 9d92daa7feb0e14f81bf0d4b3f0b6ff1e8cec3ff514df8a0c06c4d49b518c315
+  md5: 57ca8564599ddf8b633c4ea6afee6f3a
   depends:
   - libgcc-ng >=12
   - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 18139
-  timestamp: 1718849914457
-- kind: conda
-  name: xcb-util-renderutil
-  version: 0.3.10
-  build: hb711507_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+  size: 14343
+  timestamp: 1718846624153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
   sha256: 2d401dadc43855971ce008344a4b5bd804aca9487d8ebd83328592217daca3df
   md5: 0e0cbe0564d03a99afd5fd7b362feecd
   depends:
@@ -15839,28 +12157,18 @@ packages:
   purls: []
   size: 16978
   timestamp: 1718848865819
-- kind: conda
-  name: xcb-util-wm
-  version: 0.4.2
-  build: h5c728e9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-  sha256: 3f52cd8783e7d953c54266255fd11886c611c2620545eabc28ec8cf470ae8be7
-  md5: f14dcda6894722e421da2b7dcffb0b78
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
+  sha256: 5827f5617c9741599f72bb7f090726f89c6ef91e4bada621895fdc2bbadfb0f1
+  md5: 7beeda4223c5484ef72d89fb66b7e8c1
   depends:
   - libgcc-ng >=12
   - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 50772
-  timestamp: 1718845072660
-- kind: conda
-  name: xcb-util-wm
-  version: 0.4.2
-  build: hb711507_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+  size: 18139
+  timestamp: 1718849914457
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
   sha256: 31d44f297ad87a1e6510895740325a635dd204556aa7e079194a0034cdd7e66a
   md5: 608e0ef8256b81d04456e8d211eee3e8
   depends:
@@ -15871,28 +12179,18 @@ packages:
   purls: []
   size: 51689
   timestamp: 1718844051451
-- kind: conda
-  name: xkeyboard-config
-  version: '2.43'
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.43-h86ecc28_0.conda
-  sha256: b3f09cc99b6b7707aa8812bbc7556fd431999ad3a48292e4ff82335b5fda976c
-  md5: a809b8e3776fbc05696c82f8cf6f5a92
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
+  sha256: 3f52cd8783e7d953c54266255fd11886c611c2620545eabc28ec8cf470ae8be7
+  md5: f14dcda6894722e421da2b7dcffb0b78
   depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 391011
-  timestamp: 1727840308426
-- kind: conda
-  name: xkeyboard-config
-  version: '2.43'
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
+  size: 50772
+  timestamp: 1718845072660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.43-hb9d3cd8_0.conda
   sha256: 0d89b5873515a1f05d311f37ea4e087bbccc0418afa38f2f6189e97280db3179
   md5: f725c7425d6d7c15e31f3b99a88ea02f
   depends:
@@ -15904,29 +12202,18 @@ packages:
   purls: []
   size: 389475
   timestamp: 1727840188958
-- kind: conda
-  name: xorg-libice
-  version: 1.1.1
-  build: h57736b2_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h57736b2_1.conda
-  sha256: 525f197136d0c136dcba68b16d8f3636f27be111d677b2a06d8b99cf3f45ba4a
-  md5: 99a9c8245a1cc6dacd292ffeca39425f
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.43-h86ecc28_0.conda
+  sha256: b3f09cc99b6b7707aa8812bbc7556fd431999ad3a48292e4ff82335b5fda976c
+  md5: a809b8e3776fbc05696c82f8cf6f5a92
   depends:
   - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 60151
-  timestamp: 1727533134400
-- kind: conda
-  name: xorg-libice
-  version: 1.1.1
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
+  size: 391011
+  timestamp: 1727840308426
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hb9d3cd8_1.conda
   sha256: ec276da68d1c4a3d34a63195b35ca5b248d4aff0812464dcd843d74649b5cec4
   md5: 19608a9656912805b2b9a2f6bd257b04
   depends:
@@ -15937,31 +12224,17 @@ packages:
   purls: []
   size: 58159
   timestamp: 1727531850109
-- kind: conda
-  name: xorg-libsm
-  version: 1.2.4
-  build: hbac51e1_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-hbac51e1_1.conda
-  sha256: 3d3c78a2e2a915d96b8bf8a670ba91e5abba50f55dc3ff699d345c958118e94c
-  md5: 18655ac9fc6624db89b33a89fed51c5f
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h57736b2_1.conda
+  sha256: 525f197136d0c136dcba68b16d8f3636f27be111d677b2a06d8b99cf3f45ba4a
+  md5: 99a9c8245a1cc6dacd292ffeca39425f
   depends:
   - libgcc >=13
-  - libuuid >=2.38.1,<3.0a0
-  - xorg-libice >=1.1.1,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 28357
-  timestamp: 1727635998392
-- kind: conda
-  name: xorg-libsm
-  version: 1.2.4
-  build: he73a12e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
+  size: 60151
+  timestamp: 1727533134400
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-he73a12e_1.conda
   sha256: 70e903370977d44c9120a5641ab563887bd48446e9ef6fc2a3f5f60531c2cd6c
   md5: 05a8ea5f446de33006171a7afe6ae857
   depends:
@@ -15974,47 +12247,19 @@ packages:
   purls: []
   size: 27516
   timestamp: 1727634669421
-- kind: conda
-  name: xorg-libx11
-  version: 1.8.9
-  build: he755bbd_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-he755bbd_2.conda
-  sha256: bcd9ebdd7ca25d8ab1eb4f3f919113e264a8ad84fa713c48e737e9167a82fb4b
-  md5: 7acc45f80415e6ec352b729105dc0375
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-hbac51e1_1.conda
+  sha256: 3d3c78a2e2a915d96b8bf8a670ba91e5abba50f55dc3ff699d345c958118e94c
+  md5: 18655ac9fc6624db89b33a89fed51c5f
   depends:
   - libgcc >=13
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.1,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 863528
-  timestamp: 1727352755656
-- kind: conda
-  name: xorg-libx11
-  version: 1.8.10
-  build: h2321a68_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.10-h2321a68_0.conda
-  sha256: d7b68c1a67cc074b14cda8ccc90d52291ee78607fb2294fdf84cfe49eecaeea8
-  md5: 8daa358aecb1dbba214ea468a17f934c
-  depends:
-  - __osx >=11.0
-  - libxcb >=1.17.0,<2.0a0
-  - xorg-xorgproto
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 753888
-  timestamp: 1727356859339
-- kind: conda
-  name: xorg-libx11
-  version: 1.8.10
-  build: h4f16b4b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
+  size: 28357
+  timestamp: 1727635998392
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.10-h4f16b4b_0.conda
   sha256: c4650634607864630fb03696474a0535f6fce5fda7d81a6462346e071b53dfa7
   md5: 0b666058a179b744a622d0a4a0c56353
   depends:
@@ -16027,29 +12272,31 @@ packages:
   purls: []
   size: 838308
   timestamp: 1727356837875
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: h86ecc28_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h86ecc28_1.conda
-  sha256: a00c4c6054209c84fb460c5e4ae7193c335a9ee1851645c9ad59312438e853f7
-  md5: c5f72a733c461aa7785518d29b997cc8
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-he755bbd_2.conda
+  sha256: bcd9ebdd7ca25d8ab1eb4f3f919113e264a8ad84fa713c48e737e9167a82fb4b
+  md5: 7acc45f80415e6ec352b729105dc0375
   depends:
   - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto
   license: MIT
   license_family: MIT
   purls: []
-  size: 15690
-  timestamp: 1727036097294
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
+  size: 863528
+  timestamp: 1727352755656
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.10-h2321a68_0.conda
+  sha256: d7b68c1a67cc074b14cda8ccc90d52291ee78607fb2294fdf84cfe49eecaeea8
+  md5: 8daa358aecb1dbba214ea468a17f934c
+  depends:
+  - __osx >=11.0
+  - libxcb >=1.17.0,<2.0a0
+  - xorg-xorgproto
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 753888
+  timestamp: 1727356859339
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hb9d3cd8_1.conda
   sha256: 532a046fee0b3a402db867b6ec55c84ba4cdedb91d817147c8feeae9766be3d6
   md5: 77cbc488235ebbaab2b6e912d3934bae
   depends:
@@ -16060,13 +12307,17 @@ packages:
   purls: []
   size: 14679
   timestamp: 1727034741045
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: hd74edd7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h86ecc28_1.conda
+  sha256: a00c4c6054209c84fb460c5e4ae7193c335a9ee1851645c9ad59312438e853f7
+  md5: c5f72a733c461aa7785518d29b997cc8
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 15690
+  timestamp: 1727036097294
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
   sha256: 7113618021cf6c80831a429b2ebb9d639f3c43cf7fe2257d235dc6ae0ab43289
   md5: 7e0125f8fb619620a0011dc9297e2493
   depends:
@@ -16076,30 +12327,7 @@ packages:
   purls: []
   size: 13515
   timestamp: 1727034783560
-- kind: conda
-  name: xorg-libxdamage
-  version: 1.1.6
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
-  sha256: 3afaa2f43eb4cb679fc0c3d9d7c50f0f2c80cc5d3df01d5d5fd60655d0bfa9be
-  md5: d5773c4e4d64428d7ddaa01f6f845dc7
-  depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 13794
-  timestamp: 1727891406431
-- kind: conda
-  name: xorg-libxdamage
-  version: 1.1.6
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
   sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
   md5: b5fcc7172d22516e1f965490e65e33a4
   depends:
@@ -16113,27 +12341,20 @@ packages:
   purls: []
   size: 13217
   timestamp: 1727891438799
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.5
-  build: h57736b2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
-  sha256: efcc150da5926cf244f757b8376d96a4db78bc15b8d90ca9f56ac6e75755971f
-  md5: 25a5a7b797fe6e084e04ffe2db02fc62
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdamage-1.1.6-h86ecc28_0.conda
+  sha256: 3afaa2f43eb4cb679fc0c3d9d7c50f0f2c80cc5d3df01d5d5fd60655d0bfa9be
+  md5: d5773c4e4d64428d7ddaa01f6f845dc7
   depends:
   - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 20615
-  timestamp: 1727796660574
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.5
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+  size: 13794
+  timestamp: 1727891406431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
   sha256: 6b250f3e59db07c2514057944a3ea2044d6a8cdde8a47b6497c254520fade1ee
   md5: 8035c64cb77ed555e3f150b7b3972480
   depends:
@@ -16144,12 +12365,17 @@ packages:
   purls: []
   size: 19901
   timestamp: 1727794976192
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.5
-  build: hd74edd7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-h57736b2_0.conda
+  sha256: efcc150da5926cf244f757b8376d96a4db78bc15b8d90ca9f56ac6e75755971f
+  md5: 25a5a7b797fe6e084e04ffe2db02fc62
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20615
+  timestamp: 1727796660574
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
   sha256: 9939a166d780700d81023546759102b33fdc2c5f11ef09f5f66c77210fd334c8
   md5: 77c447f48cab5d3a15ac224edb86a968
   depends:
@@ -16159,28 +12385,7 @@ packages:
   purls: []
   size: 18487
   timestamp: 1727795205022
-- kind: conda
-  name: xorg-libxext
-  version: 1.3.6
-  build: h57736b2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
-  sha256: 8e216b024f52e367463b4173f237af97cf7053c77d9ce3e958bc62473a053f71
-  md5: bd1e86dd8aa3afd78a4bfdb4ef918165
-  depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 50746
-  timestamp: 1727754268156
-- kind: conda
-  name: xorg-libxext
-  version: 1.3.6
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.6-hb9d3cd8_0.conda
   sha256: da5dc921c017c05f38a38bd75245017463104457b63a1ce633ed41f214159c14
   md5: febbab7d15033c913d53c7a2c102309d
   depends:
@@ -16192,12 +12397,18 @@ packages:
   purls: []
   size: 50060
   timestamp: 1727752228921
-- kind: conda
-  name: xorg-libxext
-  version: 1.3.6
-  build: hd74edd7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.6-hd74edd7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
+  sha256: 8e216b024f52e367463b4173f237af97cf7053c77d9ce3e958bc62473a053f71
+  md5: bd1e86dd8aa3afd78a4bfdb4ef918165
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 50746
+  timestamp: 1727754268156
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxext-1.3.6-hd74edd7_0.conda
   sha256: 4526fcd879b74400e66cc2a041ca00c0ecd210486459cc65610b135be7c6a2d2
   md5: acf6c394865f1b7a51c8e57fec6fcde3
   depends:
@@ -16208,28 +12419,7 @@ packages:
   purls: []
   size: 41870
   timestamp: 1727752280756
-- kind: conda
-  name: xorg-libxfixes
-  version: 6.0.1
-  build: h57736b2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
-  sha256: f5c71e0555681a82a65c483374b91d91b2cb9a9903b3a22ddc00f36719fce549
-  md5: 78f8715c002cc66991d7c11e3cf66039
-  depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 20289
-  timestamp: 1727796500830
-- kind: conda
-  name: xorg-libxfixes
-  version: 6.0.1
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.1-hb9d3cd8_0.conda
   sha256: 2fef37e660985794617716eb915865ce157004a4d567ed35ec16514960ae9271
   md5: 4bdb303603e9821baf5fe5fdff1dc8f8
   depends:
@@ -16241,30 +12431,18 @@ packages:
   purls: []
   size: 19575
   timestamp: 1727794961233
-- kind: conda
-  name: xorg-libxi
-  version: 1.8.2
-  build: h57736b2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
-  sha256: 7b587407ecb9ccd2bbaf0fb94c5dbdde4d015346df063e9502dc0ce2b682fb5e
-  md5: eeee3bdb31c6acde2b81ad1b8c287087
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-6.0.1-h57736b2_0.conda
+  sha256: f5c71e0555681a82a65c483374b91d91b2cb9a9903b3a22ddc00f36719fce549
+  md5: 78f8715c002cc66991d7c11e3cf66039
   depends:
   - libgcc >=13
   - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 48197
-  timestamp: 1727801059062
-- kind: conda
-  name: xorg-libxi
-  version: 1.8.2
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+  size: 20289
+  timestamp: 1727796500830
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
   sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
   md5: 17dcc85db3c7886650b8908b183d6876
   depends:
@@ -16278,13 +12456,20 @@ packages:
   purls: []
   size: 47179
   timestamp: 1727799254088
-- kind: conda
-  name: xorg-libxinerama
-  version: 1.1.5
-  build: h5888daf_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.8.2-h57736b2_0.conda
+  sha256: 7b587407ecb9ccd2bbaf0fb94c5dbdde4d015346df063e9502dc0ce2b682fb5e
+  md5: eeee3bdb31c6acde2b81ad1b8c287087
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 48197
+  timestamp: 1727801059062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.5-h5888daf_1.conda
   sha256: 1b9141c027f9d84a9ee5eb642a0c19457c788182a5a73c5a9083860ac5c20a8c
   md5: 5e2eb9bf77394fc2e5918beefec9f9ab
   depends:
@@ -16298,13 +12483,7 @@ packages:
   purls: []
   size: 13891
   timestamp: 1727908521531
-- kind: conda
-  name: xorg-libxinerama
-  version: 1.1.5
-  build: h5ad3122_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxinerama-1.1.5-h5ad3122_1.conda
   sha256: 5f84f820397db504e187754665d48d385e0a2a49f07ffc2372c7f42fa36dd972
   md5: a7b99f104e14b99ca773d2fe2d195585
   depends:
@@ -16317,30 +12496,7 @@ packages:
   purls: []
   size: 14388
   timestamp: 1727908606602
-- kind: conda
-  name: xorg-libxrandr
-  version: 1.5.4
-  build: h86ecc28_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
-  sha256: b2588a2b101d1b0a4e852532c8b9c92c59ef584fc762dd700567bdbf8cd00650
-  md5: dd3e74283a082381aa3860312e3c721e
-  depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 30197
-  timestamp: 1727794957221
-- kind: conda
-  name: xorg-libxrandr
-  version: 1.5.4
-  build: hb9d3cd8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.4-hb9d3cd8_0.conda
   sha256: ac0f037e0791a620a69980914a77cb6bb40308e26db11698029d6708f5aa8e0d
   md5: 2de7f99d6581a4a7adbff607b5c278ca
   depends:
@@ -16354,31 +12510,20 @@ packages:
   purls: []
   size: 29599
   timestamp: 1727794874300
-- kind: conda
-  name: xorg-libxrender
-  version: 0.9.11
-  build: h57736b2_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
-  sha256: 50c000a26e828313b668902c2ae5ff7956d9d34418b4fc6fc15f73cba31b45e0
-  md5: 19fb476dc5cdd51b67719a6342fab237
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrandr-1.5.4-h86ecc28_0.conda
+  sha256: b2588a2b101d1b0a4e852532c8b9c92c59ef584fc762dd700567bdbf8cd00650
+  md5: dd3e74283a082381aa3860312e3c721e
   depends:
   - libgcc >=13
   - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-xorgproto
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 38052
-  timestamp: 1727530023529
-- kind: conda
-  name: xorg-libxrender
-  version: 0.9.11
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
+  size: 30197
+  timestamp: 1727794957221
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hb9d3cd8_1.conda
   sha256: f1217e902c0b1d8bc5d3ce65e483ebf38b049c823c9117b7198cfb16bd2b9143
   md5: a7a49a8b85122b49214798321e2e96b4
   depends:
@@ -16391,13 +12536,19 @@ packages:
   purls: []
   size: 37780
   timestamp: 1727529943015
-- kind: conda
-  name: xorg-libxtst
-  version: 1.2.5
-  build: hb9d3cd8_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
+  sha256: 50c000a26e828313b668902c2ae5ff7956d9d34418b4fc6fc15f73cba31b45e0
+  md5: 19fb476dc5cdd51b67719a6342fab237
+  depends:
+  - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-xorgproto
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 38052
+  timestamp: 1727530023529
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
   sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
   md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
   depends:
@@ -16411,31 +12562,7 @@ packages:
   purls: []
   size: 32808
   timestamp: 1727964811275
-- kind: conda
-  name: xorg-libxxf86vm
-  version: 1.1.5
-  build: h57736b2_4
-  build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.5-h57736b2_4.conda
-  sha256: db7455e84e3427e800e4830296247e8a465a13f2cd0b389415a5aec989f5fab0
-  md5: 82fa1f5642ef7ac7172e295327ce20e2
-  depends:
-  - libgcc >=13
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 18392
-  timestamp: 1728920054223
-- kind: conda
-  name: xorg-libxxf86vm
-  version: 1.1.5
-  build: hb9d3cd8_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.5-hb9d3cd8_4.conda
   sha256: 0b8f062a5b4a2c3833267285b7d41b3542f54d2c935c86ca98504c3e5296354c
   md5: 7da9007c0582712c4bad4131f89c8372
   depends:
@@ -16448,29 +12575,19 @@ packages:
   purls: []
   size: 18072
   timestamp: 1728920051869
-- kind: conda
-  name: xorg-xextproto
-  version: 7.3.0
-  build: h57736b2_1004
-  build_number: 1004
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
-  sha256: 00e2bb1f05e7737002165a4523300c1c28dda127de099288c38ce4a62789183e
-  md5: 4589bf66785ace0f78e8d59d403aad98
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxxf86vm-1.1.5-h57736b2_4.conda
+  sha256: db7455e84e3427e800e4830296247e8a465a13f2cd0b389415a5aec989f5fab0
+  md5: 82fa1f5642ef7ac7172e295327ce20e2
   depends:
   - libgcc >=13
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 30717
-  timestamp: 1726847443586
-- kind: conda
-  name: xorg-xextproto
-  version: 7.3.0
-  build: hb9d3cd8_1004
-  build_number: 1004
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
+  size: 18392
+  timestamp: 1728920054223
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
   sha256: f302a3f6284ee9ad3b39e45251d7ed15167896564dc33e006077a896fd3458a6
   md5: bc4cd53a083b6720d61a1519a1900878
   depends:
@@ -16481,29 +12598,17 @@ packages:
   purls: []
   size: 30549
   timestamp: 1726846235301
-- kind: conda
-  name: xorg-xf86vidmodeproto
-  version: 2.3.1
-  build: h57736b2_1004
-  build_number: 1004
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-h57736b2_1004.conda
-  sha256: db4373a3c910ceaf821ecf0e79c0263d727813c21b94995c3b5629955cf934ef
-  md5: c63c8de70afa2fd9848375d27ef92a66
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
+  sha256: 00e2bb1f05e7737002165a4523300c1c28dda127de099288c38ce4a62789183e
+  md5: 4589bf66785ace0f78e8d59d403aad98
   depends:
   - libgcc >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 26277
-  timestamp: 1728918984977
-- kind: conda
-  name: xorg-xf86vidmodeproto
-  version: 2.3.1
-  build: hb9d3cd8_1004
-  build_number: 1004
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-hb9d3cd8_1004.conda
+  size: 30717
+  timestamp: 1726847443586
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-hb9d3cd8_1004.conda
   sha256: f649e15e53d82fe5cece0b1fcc82deea3cd71a01ea4b3ebdc2cef1cdfeaf19b3
   md5: 24831329718daa6cbe35fcd071b778d4
   depends:
@@ -16514,29 +12619,17 @@ packages:
   purls: []
   size: 26209
   timestamp: 1728918994652
-- kind: conda
-  name: xorg-xorgproto
-  version: '2024.1'
-  build: h86ecc28_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
-  sha256: 3dbbf4cdb5ad82d3479ab2aa68ae67de486a6d57d67f0402d8e55869f6f13aec
-  md5: 91cef7867bf2b47f614597b59705ff56
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-h57736b2_1004.conda
+  sha256: db4373a3c910ceaf821ecf0e79c0263d727813c21b94995c3b5629955cf934ef
+  md5: c63c8de70afa2fd9848375d27ef92a66
   depends:
   - libgcc >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 566948
-  timestamp: 1726847598167
-- kind: conda
-  name: xorg-xorgproto
-  version: '2024.1'
-  build: hb9d3cd8_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
+  size: 26277
+  timestamp: 1728918984977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2024.1-hb9d3cd8_1.conda
   sha256: 1316680be6edddee0156b86ec1102fc8286f51c1a5440366ed1db596a2dc3731
   md5: 7c21106b851ec72c037b162c216d8f05
   depends:
@@ -16547,13 +12640,17 @@ packages:
   purls: []
   size: 565425
   timestamp: 1726846388217
-- kind: conda
-  name: xorg-xorgproto
-  version: '2024.1'
-  build: hd74edd7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xorgproto-2024.1-hd74edd7_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2024.1-h86ecc28_1.conda
+  sha256: 3dbbf4cdb5ad82d3479ab2aa68ae67de486a6d57d67f0402d8e55869f6f13aec
+  md5: 91cef7867bf2b47f614597b59705ff56
+  depends:
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 566948
+  timestamp: 1726847598167
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xorgproto-2024.1-hd74edd7_1.conda
   sha256: f76eb03c674719ccaf599c7f5e50a02747382928bdc0927509ef946d450edfa6
   md5: 1b974e05b976e33edb29a0475013ac60
   depends:
@@ -16563,12 +12660,7 @@ packages:
   purls: []
   size: 567698
   timestamp: 1726846426361
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
   sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
   md5: 2161070d867d1b1204ea749c8eec4ef0
   depends:
@@ -16577,24 +12669,23 @@ packages:
   purls: []
   size: 418368
   timestamp: 1660346797927
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h57fd34a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
+  sha256: 93f58a7b393adf41fa007ac8c55978765e957e90cd31877ece1e5a343cb98220
+  md5: 83baad393a31d59c20b63ba4da6592df
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  purls: []
+  size: 440555
+  timestamp: 1660348056328
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
   sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
   md5: 39c6b54e94014701dd157f4f576ed211
   license: LGPL-2.1 and GPL-2.0
   purls: []
   size: 235693
   timestamp: 1660346961024
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h8d14728_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
   sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
   md5: 515d77642eaa3639413c6b1bc3f94219
   depends:
@@ -16604,41 +12695,7 @@ packages:
   purls: []
   size: 217804
   timestamp: 1660346976440
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h9cdd2b7_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
-  sha256: 93f58a7b393adf41fa007ac8c55978765e957e90cd31877ece1e5a343cb98220
-  md5: 83baad393a31d59c20b63ba4da6592df
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1 and GPL-2.0
-  purls: []
-  size: 440555
-  timestamp: 1660348056328
-- kind: conda
-  name: yaml
-  version: 0.2.5
-  build: h3422bc3_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
-  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
-  md5: 4bb3f014845110883a3c5ee811fd84b4
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 88016
-  timestamp: 1641347076660
-- kind: conda
-  name: yaml
-  version: 0.2.5
-  build: h7f98852_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
   sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
   md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
   depends:
@@ -16648,13 +12705,25 @@ packages:
   purls: []
   size: 89141
   timestamp: 1641346969816
-- kind: conda
-  name: yaml
-  version: 0.2.5
-  build: h8ffe710_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
+  sha256: 8bc601d6dbe249eba44b3c456765265cd8f42ef1e778f8df9b0c9c88b8558d7e
+  md5: b853307650cb226731f653aa623936a4
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 92927
+  timestamp: 1641347626613
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 88016
+  timestamp: 1641347076660
+- conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
   sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
   md5: adbfb9f45d1004a26763652246a33764
   depends:
@@ -16665,28 +12734,7 @@ packages:
   purls: []
   size: 63274
   timestamp: 1641347623319
-- kind: conda
-  name: yaml
-  version: 0.2.5
-  build: hf897c2e_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-hf897c2e_2.tar.bz2
-  sha256: 8bc601d6dbe249eba44b3c456765265cd8f42ef1e778f8df9b0c9c88b8558d7e
-  md5: b853307650cb226731f653aa623936a4
-  depends:
-  - libgcc-ng >=9.4.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 92927
-  timestamp: 1641347626613
-- kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.9
-  build: h5888daf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.9-h5888daf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ycm-cmake-modules-0.16.9-h5888daf_0.conda
   sha256: 6769b34a14f710a93d16f620d49f41941ca3ba1e2d4dc632e3b337560646c7f1
   md5: 26683374f411369c90da91947a126287
   depends:
@@ -16698,12 +12746,7 @@ packages:
   purls: []
   size: 143998
   timestamp: 1725628711468
-- kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.9
-  build: h5ad3122_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.9-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ycm-cmake-modules-0.16.9-h5ad3122_0.conda
   sha256: e561dfc7b3ff30940424359b06efdd1ac74abcf0331433dc787c417bcb794787
   md5: ac96ccc881727dafb5a5418487255769
   depends:
@@ -16714,12 +12757,18 @@ packages:
   purls: []
   size: 143813
   timestamp: 1725628825447
-- kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.9
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.9-he0c23c2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.9-hf9b8971_0.conda
+  sha256: 094b959a13f5c90407dd84c82221a8187b787cf571a6ed70110f8d13c4e6027b
+  md5: 53e254d12b23ee5c301e625932a6aa77
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 143788
+  timestamp: 1725628834144
+- conda: https://conda.anaconda.org/conda-forge/win-64/ycm-cmake-modules-0.16.9-he0c23c2_0.conda
   sha256: 25e574e6e8588830e2e5d8227f12c5d61043b9111bc8bf826588355a4fe74246
   md5: 68ae20bf2e6f6787994c17789885cdf0
   depends:
@@ -16731,29 +12780,7 @@ packages:
   purls: []
   size: 144067
   timestamp: 1725628982924
-- kind: conda
-  name: ycm-cmake-modules
-  version: 0.16.9
-  build: hf9b8971_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ycm-cmake-modules-0.16.9-hf9b8971_0.conda
-  sha256: 094b959a13f5c90407dd84c82221a8187b787cf571a6ed70110f8d13c4e6027b
-  md5: 53e254d12b23ee5c301e625932a6aa77
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 143788
-  timestamp: 1725628834144
-- kind: conda
-  name: zipp
-  version: 3.20.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.2-pyhd8ed1ab_0.conda
   sha256: 1e84fcfa41e0afdd87ff41e6fbb719c96a0e098c1f79be342293ab0bd8dea322
   md5: 4daaed111c05672ae669f7036ee5bba3
   depends:
@@ -16764,13 +12791,41 @@ packages:
   - pkg:pypi/zipp?source=hash-mapping
   size: 21409
   timestamp: 1726248679175
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib 1.3.1 hb9d3cd8_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 92286
+  timestamp: 1727963153079
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
+  sha256: b4f649aa3ecdae384d5dad7074e198bff120edd3dfb816588e31738fc6d627b1
+  md5: bc230abb5d21b63ff4799b0e75204783
+  depends:
+  - libgcc >=13
+  - libzlib 1.3.1 h86ecc28_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 95582
+  timestamp: 1727963203597
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
+  md5: e3170d898ca6cb48f1bb567afb92f775
+  depends:
+  - __osx >=11.0
+  - libzlib 1.3.1 h8359307_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 77606
+  timestamp: 1727963209370
+- conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
   sha256: 8c688797ba23b9ab50cef404eca4d004a948941b6ee533ead0ff3bf52012528c
   md5: be60c4e8efa55fddc17b4131aa47acbd
   depends:
@@ -16783,64 +12838,19 @@ packages:
   purls: []
   size: 107439
   timestamp: 1727963788936
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: h8359307_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
-  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
-  md5: e3170d898ca6cb48f1bb567afb92f775
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
   depends:
-  - __osx >=11.0
-  - libzlib 1.3.1 h8359307_2
-  license: Zlib
-  license_family: Other
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
   purls: []
-  size: 77606
-  timestamp: 1727963209370
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: h86ecc28_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.1-h86ecc28_2.conda
-  sha256: b4f649aa3ecdae384d5dad7074e198bff120edd3dfb816588e31738fc6d627b1
-  md5: bc230abb5d21b63ff4799b0e75204783
-  depends:
-  - libgcc >=13
-  - libzlib 1.3.1 h86ecc28_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 95582
-  timestamp: 1727963203597
-- kind: conda
-  name: zlib
-  version: 1.3.1
-  build: hb9d3cd8_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
-  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
-  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libzlib 1.3.1 hb9d3cd8_2
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 92286
-  timestamp: 1727963153079
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: h02f22dd_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
+  size: 554846
+  timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
   sha256: 484f9d0722c77685ae379fbff3ccd662af9ead7e59eb39cd6d0c677cdf25ff6c
   md5: be8d5f8cf21aed237b8b182ea86b3dd6
   depends:
@@ -16852,12 +12862,18 @@ packages:
   purls: []
   size: 539937
   timestamp: 1714723130243
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: h0ea2cb4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 405089
+  timestamp: 1714723101397
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
   sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
   md5: 9a17230f95733c04dc40a2b1e5491d74
   depends:
@@ -16870,36 +12886,3 @@ packages:
   purls: []
   size: 349143
   timestamp: 1714723445995
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: ha6fb4c9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
-  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
-  md5: 4d056880988120e29d75bfff282e0f45
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 554846
-  timestamp: 1714722996770
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: hb46c0d2_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
-  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
-  md5: d96942c06c3e84bfcc5efb038724a7fd
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 405089
-  timestamp: 1714723101397

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 requires-python = ">= 3.10"
-dependencies = ["mujoco", "resolve-robotics-uri-py", "idyntree"]
+dependencies = ["mujoco", "resolve-robotics-uri-py", "idyntree", "numpy", "scipy"]
 
 [project.readme]
 file = "README.md"

--- a/tests/test_loader_camera_cfg.py
+++ b/tests/test_loader_camera_cfg.py
@@ -3,6 +3,9 @@ import xml.etree.ElementTree as ET
 import pytest
 
 from mujoco_urdf_loader.loader import CameraCfg, URDFtoMuJoCoLoader, URDFtoMuJoCoLoaderCfg
+from mujoco_urdf_loader.urdf_fcn import get_mesh_path
+
+import resolve_robotics_uri_py as rru
 
 
 def _make_empty_mjcf() -> ET.Element:
@@ -89,3 +92,54 @@ def test_add_cameras_raises_on_missing_required_fields():
 
     with pytest.raises(ValueError):
         loader.add_cameras([{"name": "root_depth_camera", "fovy": 60.0}])
+
+def test_add_cameras_to_ergocub_sn001():
+    urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
+    controlled_joints = [
+            "l_hip_pitch",
+            "r_hip_pitch",
+            "torso_roll",
+            "l_hip_roll",
+            "r_hip_roll",
+            "torso_pitch",
+            "torso_yaw",
+            "l_hip_yaw",
+            "r_hip_yaw",
+            "l_shoulder_pitch",
+            "neck_pitch",
+            "r_shoulder_pitch",
+            "l_knee",
+            "r_knee",
+            "l_shoulder_roll",
+            "neck_roll",
+            "r_shoulder_roll",
+            "l_ankle_pitch",
+            "r_ankle_pitch",
+            "neck_yaw",
+            "l_ankle_roll",
+            "r_ankle_roll",
+            "l_shoulder_yaw",
+            "r_shoulder_yaw",
+            "l_elbow",
+            "r_elbow",
+    ]
+    mesh_path = get_mesh_path(ET.parse(urdf_root).getroot())
+    cameras_cfg = [
+        CameraCfg(name="root_depth_camera", site="realsense_depth_frame", fovy=60.0),
+        CameraCfg(name="root_rgb_camera", site="realsense_rgb_frame", fovy=75.0),
+    ]
+    cfg = URDFtoMuJoCoLoaderCfg(
+        controlled_joints=controlled_joints,
+        cameras_cfg=cameras_cfg,
+        all_missing_joints_as_sites=True,
+    )
+    loader = URDFtoMuJoCoLoader.load_urdf(urdf_root, mesh_path, cfg)
+
+    depth_camera = loader.mjcf.find(".//camera[@name='root_depth_camera']")
+    rgb_camera = loader.mjcf.find(".//camera[@name='root_rgb_camera']")
+
+    assert depth_camera is not None
+    assert depth_camera.attrib["fovy"] == "60.0"
+
+    assert rgb_camera is not None
+    assert rgb_camera.attrib["fovy"] == "75.0"

--- a/tests/test_loader_camera_cfg.py
+++ b/tests/test_loader_camera_cfg.py
@@ -1,0 +1,91 @@
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from mujoco_urdf_loader.loader import CameraCfg, URDFtoMuJoCoLoader, URDFtoMuJoCoLoaderCfg
+
+
+def _make_empty_mjcf() -> ET.Element:
+    return ET.fromstring(
+        """
+        <mujoco model="test_model">
+            <worldbody>
+                <body name="base">
+                    <site name="camera_site" pos="0 0 0" quat="1 0 0 0"/>
+                    <site name="camera_site_2" pos="0.1 0.2 0.3" quat="1 0 0 0"/>
+                </body>
+            </worldbody>
+        </mujoco>
+        """
+    )
+
+
+def test_add_cameras_none_keeps_model_unchanged():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    loader.add_cameras(None)
+
+    assert loader.mjcf.find(".//camera") is None
+
+
+def test_add_cameras_accepts_list_of_dataclasses():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    loader.add_cameras(
+        [
+            CameraCfg(name="root_depth_camera", site="camera_site", fovy=60.0),
+            CameraCfg(name="root_rgb_camera", site="camera_site_2", fovy=75.0),
+        ]
+    )
+
+    depth_camera = loader.mjcf.find(".//camera[@name='root_depth_camera']")
+    rgb_camera = loader.mjcf.find(".//camera[@name='root_rgb_camera']")
+
+    assert depth_camera is not None
+    assert depth_camera.attrib["fovy"] == "60.0"
+
+    assert rgb_camera is not None
+    assert rgb_camera.attrib["fovy"] == "75.0"
+
+
+def test_add_cameras_accepts_dict_with_site_key():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    loader.add_cameras(
+        [
+            {
+                "name": "root_depth_camera",
+                "site": "camera_site",
+                "fovy": 60.0,
+            }
+        ]
+    )
+
+    camera = loader.mjcf.find(".//camera[@name='root_depth_camera']")
+    assert camera is not None
+    assert camera.attrib["fovy"] == "60.0"
+
+
+def test_add_cameras_accepts_dict_with_link_alias():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    loader.add_cameras(
+        [
+            {
+                "name": "root_depth_camera",
+                "link": "camera_site",
+                "fovy": 60.0,
+            }
+        ]
+    )
+
+    camera = loader.mjcf.find(".//camera[@name='root_depth_camera']")
+    assert camera is not None
+    assert camera.attrib["fovy"] == "60.0"
+
+
+def test_add_cameras_raises_on_missing_required_fields():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    with pytest.raises(ValueError):
+        loader.add_cameras([{"name": "root_depth_camera", "fovy": 60.0}])

--- a/tests/test_loader_camera_cfg.py
+++ b/tests/test_loader_camera_cfg.py
@@ -24,7 +24,7 @@ def _make_empty_mjcf() -> ET.Element:
 
 
 def test_add_cameras_none_keeps_model_unchanged():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_cameras(None)
 
@@ -32,7 +32,7 @@ def test_add_cameras_none_keeps_model_unchanged():
 
 
 def test_add_cameras_accepts_list_of_dataclasses():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_cameras(
         [
@@ -52,7 +52,7 @@ def test_add_cameras_accepts_list_of_dataclasses():
 
 
 def test_add_cameras_accepts_dict_with_site_key():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_cameras(
         [
@@ -70,7 +70,7 @@ def test_add_cameras_accepts_dict_with_site_key():
 
 
 def test_add_cameras_accepts_dict_with_link_alias():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_cameras(
         [
@@ -88,14 +88,14 @@ def test_add_cameras_accepts_dict_with_link_alias():
 
 
 def test_add_cameras_raises_on_missing_required_fields():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     with pytest.raises(ValueError):
         loader.add_cameras([{"name": "root_depth_camera", "fovy": 60.0}])
 
 def test_add_cameras_to_ergocub_sn001():
     urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
-    controlled_joints = [
+    observed_joints = [
             "l_hip_pitch",
             "r_hip_pitch",
             "torso_roll",
@@ -129,7 +129,7 @@ def test_add_cameras_to_ergocub_sn001():
         CameraCfg(name="root_rgb_camera", site="realsense_rgb_frame", fovy=75.0),
     ]
     cfg = URDFtoMuJoCoLoaderCfg(
-        controlled_joints=controlled_joints,
+        observed_joints=observed_joints,
         cameras_cfg=cameras_cfg,
         all_missing_joints_as_sites=True,
     )

--- a/tests/test_loader_equality_constraints_cfg.py
+++ b/tests/test_loader_equality_constraints_cfg.py
@@ -28,7 +28,7 @@ def _make_empty_mjcf() -> ET.Element:
 
 def test_add_equality_constraints_none_keeps_model_unchanged():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     loader.add_equality_constraints(None)
@@ -38,7 +38,7 @@ def test_add_equality_constraints_none_keeps_model_unchanged():
 
 def test_add_equality_constraints_accepts_list_of_dataclasses():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     loader.add_equality_constraints(
@@ -53,7 +53,7 @@ def test_add_equality_constraints_accepts_list_of_dataclasses():
 
 def test_add_equality_constraints_accepts_dict():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     loader.add_equality_constraints(
@@ -68,7 +68,7 @@ def test_add_equality_constraints_accepts_dict():
 
 def test_add_equality_constraints_multiple():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     loader.add_equality_constraints(
@@ -86,7 +86,7 @@ def test_add_equality_constraints_multiple():
 
 def test_add_equality_constraints_weld_type():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     loader.add_equality_constraints(
@@ -101,7 +101,7 @@ def test_add_equality_constraints_weld_type():
 
 def test_add_equality_constraints_raises_on_missing_fields():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     with pytest.raises(ValueError):
@@ -110,7 +110,7 @@ def test_add_equality_constraints_raises_on_missing_fields():
 
 def test_add_equality_constraints_raises_on_invalid_type():
     loader = URDFtoMuJoCoLoader(
-        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
     with pytest.raises(TypeError):

--- a/tests/test_loader_equality_constraints_cfg.py
+++ b/tests/test_loader_equality_constraints_cfg.py
@@ -56,9 +56,7 @@ def test_add_equality_constraints_accepts_dict():
         _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
     )
 
-    loader.add_equality_constraints(
-        [{"site1": "site_a", "site2": "site_b"}]
-    )
+    loader.add_equality_constraints([{"site1": "site_a", "site2": "site_b"}])
 
     connect = loader.mjcf.find(".//equality/connect")
     assert connect is not None
@@ -97,6 +95,61 @@ def test_add_equality_constraints_weld_type():
     assert weld is not None
     assert weld.attrib["body1"] == "body_a"
     assert weld.attrib["body2"] == "body_b"
+
+
+def test_add_equality_constraints_sets_solimp_and_solref_when_provided():
+    loader = URDFtoMuJoCoLoader(
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
+    )
+
+    loader.add_equality_constraints(
+        [
+            EqualityConstraintCfg(
+                site1="site_a",
+                site2="site_b",
+                constraint_type="connect",
+                solimp=[0.9, 0.95, 0.001],
+                solref=[0.02, 1.0],
+            )
+        ]
+    )
+
+    connect = loader.mjcf.find(".//equality/connect")
+    assert connect is not None
+    assert connect.attrib["solimp"] == "0.9 0.95 0.001"
+    assert connect.attrib["solref"] == "0.02 1.0"
+
+
+def test_add_equality_constraints_supports_different_solimp_solref_per_constraint():
+    loader = URDFtoMuJoCoLoader(
+        _make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[])
+    )
+
+    loader.add_equality_constraints(
+        [
+            EqualityConstraintCfg(
+                site1="site_a",
+                site2="site_b",
+                constraint_type="connect",
+                solimp=[0.9, 0.95, 0.001],
+                solref=[0.02, 1.0],
+            ),
+            EqualityConstraintCfg(
+                site1="site_b",
+                site2="site_a",
+                constraint_type="connect",
+                solimp=[0.8, 0.9, 0.002],
+                solref=[0.03, 1.0],
+            ),
+        ]
+    )
+
+    connects = loader.mjcf.findall(".//equality/connect")
+    assert len(connects) == 2
+    assert connects[0].attrib["solimp"] == "0.9 0.95 0.001"
+    assert connects[0].attrib["solref"] == "0.02 1.0"
+    assert connects[1].attrib["solimp"] == "0.8 0.9 0.002"
+    assert connects[1].attrib["solref"] == "0.03 1.0"
 
 
 def test_add_equality_constraints_raises_on_missing_fields():

--- a/tests/test_loader_framequat_cfg.py
+++ b/tests/test_loader_framequat_cfg.py
@@ -1,0 +1,73 @@
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from mujoco_urdf_loader.loader import FrameQuatSensorCfg, URDFtoMuJoCoLoader, URDFtoMuJoCoLoaderCfg
+
+
+def _make_empty_mjcf() -> ET.Element:
+    return ET.fromstring(
+        """
+        <mujoco model="test_model">
+            <worldbody>
+                <body name="base"/>
+            </worldbody>
+        </mujoco>
+        """
+    )
+
+
+def test_add_framequat_sensors_none_keeps_model_unchanged():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    loader.add_framequat_sensors(None)
+
+    assert loader.mjcf.find(".//sensor/framequat") is None
+
+
+def test_add_framequat_sensors_accepts_list_of_dataclasses():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    loader.add_framequat_sensors(
+        [
+            FrameQuatSensorCfg(objname="imu_frame", objtype="site", name="imu_quat"),
+            FrameQuatSensorCfg(objname="base", objtype="body", name="base_quat"),
+        ]
+    )
+
+    imu_sensor = loader.mjcf.find(".//sensor/framequat[@name='imu_quat']")
+    base_sensor = loader.mjcf.find(".//sensor/framequat[@name='base_quat']")
+
+    assert imu_sensor is not None
+    assert imu_sensor.attrib["objtype"] == "site"
+    assert imu_sensor.attrib["objname"] == "imu_frame"
+
+    assert base_sensor is not None
+    assert base_sensor.attrib["objtype"] == "body"
+    assert base_sensor.attrib["objname"] == "base"
+
+
+def test_add_framequat_sensors_accepts_dict_with_obtype_alias():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    loader.add_framequat_sensors(
+        [
+            {
+                "objname": "imu_frame",
+                "obtype": "site",
+                "name": "imu_quat",
+            }
+        ]
+    )
+
+    sensor = loader.mjcf.find(".//sensor/framequat[@name='imu_quat']")
+    assert sensor is not None
+    assert sensor.attrib["objtype"] == "site"
+    assert sensor.attrib["objname"] == "imu_frame"
+
+
+def test_add_framequat_sensors_raises_on_missing_required_fields():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    with pytest.raises(ValueError):
+        loader.add_framequat_sensors([{"objname": "imu_frame", "name": "imu_quat"}])

--- a/tests/test_loader_framequat_cfg.py
+++ b/tests/test_loader_framequat_cfg.py
@@ -20,7 +20,7 @@ def _make_empty_mjcf() -> ET.Element:
 
 
 def test_add_framequat_sensors_none_keeps_model_unchanged():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_framequat_sensors(None)
 
@@ -28,7 +28,7 @@ def test_add_framequat_sensors_none_keeps_model_unchanged():
 
 
 def test_add_framequat_sensors_accepts_list_of_dataclasses():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_framequat_sensors(
         [
@@ -50,7 +50,7 @@ def test_add_framequat_sensors_accepts_list_of_dataclasses():
 
 
 def test_add_framequat_sensors_accepts_dict_with_obtype_alias():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_framequat_sensors(
         [
@@ -69,7 +69,7 @@ def test_add_framequat_sensors_accepts_dict_with_obtype_alias():
 
 
 def test_add_framequat_sensors_raises_on_missing_required_fields():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     with pytest.raises(ValueError):
         loader.add_framequat_sensors([{"objname": "imu_frame", "name": "imu_quat"}])
@@ -77,7 +77,7 @@ def test_add_framequat_sensors_raises_on_missing_required_fields():
 
 def test_add_framequat_sensors_to_ergocub_sn001():
     urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
-    controlled_joints = [
+    observed_joints = [
         "l_hip_pitch",
         "r_hip_pitch",
         "torso_roll",
@@ -111,7 +111,7 @@ def test_add_framequat_sensors_to_ergocub_sn001():
         FrameQuatSensorCfg(objname="realsense_rgb_frame", objtype="site", name="realsense_rgb_quat"),
     ]
     cfg = URDFtoMuJoCoLoaderCfg(
-        controlled_joints=controlled_joints,
+        observed_joints=observed_joints,
         framequat_sensors_cfg=framequat_sensors_cfg,
         all_missing_joints_as_sites=True,
     )

--- a/tests/test_loader_framequat_cfg.py
+++ b/tests/test_loader_framequat_cfg.py
@@ -1,8 +1,10 @@
 import xml.etree.ElementTree as ET
 
 import pytest
+import resolve_robotics_uri_py as rru
 
 from mujoco_urdf_loader.loader import FrameQuatSensorCfg, URDFtoMuJoCoLoader, URDFtoMuJoCoLoaderCfg
+from mujoco_urdf_loader.urdf_fcn import get_mesh_path
 
 
 def _make_empty_mjcf() -> ET.Element:
@@ -71,3 +73,57 @@ def test_add_framequat_sensors_raises_on_missing_required_fields():
 
     with pytest.raises(ValueError):
         loader.add_framequat_sensors([{"objname": "imu_frame", "name": "imu_quat"}])
+
+
+def test_add_framequat_sensors_to_ergocub_sn001():
+    urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
+    controlled_joints = [
+        "l_hip_pitch",
+        "r_hip_pitch",
+        "torso_roll",
+        "l_hip_roll",
+        "r_hip_roll",
+        "torso_pitch",
+        "torso_yaw",
+        "l_hip_yaw",
+        "r_hip_yaw",
+        "l_shoulder_pitch",
+        "neck_pitch",
+        "r_shoulder_pitch",
+        "l_knee",
+        "r_knee",
+        "l_shoulder_roll",
+        "neck_roll",
+        "r_shoulder_roll",
+        "l_ankle_pitch",
+        "r_ankle_pitch",
+        "neck_yaw",
+        "l_ankle_roll",
+        "r_ankle_roll",
+        "l_shoulder_yaw",
+        "r_shoulder_yaw",
+        "l_elbow",
+        "r_elbow",
+    ]
+    mesh_path = get_mesh_path(ET.parse(urdf_root).getroot())
+    framequat_sensors_cfg = [
+        FrameQuatSensorCfg(objname="realsense_depth_frame", objtype="site", name="realsense_depth_quat"),
+        FrameQuatSensorCfg(objname="realsense_rgb_frame", objtype="site", name="realsense_rgb_quat"),
+    ]
+    cfg = URDFtoMuJoCoLoaderCfg(
+        controlled_joints=controlled_joints,
+        framequat_sensors_cfg=framequat_sensors_cfg,
+        all_missing_joints_as_sites=True,
+    )
+    loader = URDFtoMuJoCoLoader.load_urdf(urdf_root, mesh_path, cfg)
+
+    depth_sensor = loader.mjcf.find(".//sensor/framequat[@name='realsense_depth_quat']")
+    rgb_sensor = loader.mjcf.find(".//sensor/framequat[@name='realsense_rgb_quat']")
+
+    assert depth_sensor is not None
+    assert depth_sensor.attrib["objtype"] == "site"
+    assert depth_sensor.attrib["objname"] == "realsense_depth_frame"
+
+    assert rgb_sensor is not None
+    assert rgb_sensor.attrib["objtype"] == "site"
+    assert rgb_sensor.attrib["objname"] == "realsense_rgb_frame"

--- a/tests/test_loader_gyro_cfg.py
+++ b/tests/test_loader_gyro_cfg.py
@@ -19,7 +19,7 @@ def _make_empty_mjcf() -> ET.Element:
 
 
 def test_add_gyro_sensors_none_keeps_model_unchanged():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_gyro_sensors(None)
 
@@ -27,7 +27,7 @@ def test_add_gyro_sensors_none_keeps_model_unchanged():
 
 
 def test_add_gyro_sensors_accepts_list_of_dataclasses():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_gyro_sensors(
         [
@@ -47,7 +47,7 @@ def test_add_gyro_sensors_accepts_list_of_dataclasses():
 
 
 def test_add_gyro_sensors_accepts_dict():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_gyro_sensors(
         [
@@ -64,7 +64,7 @@ def test_add_gyro_sensors_accepts_dict():
 
 
 def test_add_gyro_sensors_accepts_dict_with_objname_alias():
-    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(observed_joints=[]))
 
     loader.add_gyro_sensors(
         [
@@ -82,7 +82,7 @@ def test_add_gyro_sensors_accepts_dict_with_objname_alias():
 
 def test_add_gyro_sensors_to_ergocub_sn001():
     urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
-    controlled_joints = [
+    observed_joints = [
         "l_hip_pitch",
         "r_hip_pitch",
         "torso_roll",
@@ -116,7 +116,7 @@ def test_add_gyro_sensors_to_ergocub_sn001():
         GyroSensorCfg(site="realsense_rgb_frame", name="realsense_rgb_gyro"),
     ]
     cfg = URDFtoMuJoCoLoaderCfg(
-        controlled_joints=controlled_joints,
+        observed_joints=observed_joints,
         gyro_sensors_cfg=gyro_sensors_cfg,
         all_missing_joints_as_sites=True,
     )

--- a/tests/test_loader_gyro_cfg.py
+++ b/tests/test_loader_gyro_cfg.py
@@ -1,0 +1,77 @@
+import xml.etree.ElementTree as ET
+
+from mujoco_urdf_loader.loader import GyroSensorCfg, URDFtoMuJoCoLoader, URDFtoMuJoCoLoaderCfg
+
+
+def _make_empty_mjcf() -> ET.Element:
+    return ET.fromstring(
+        """
+        <mujoco model="test_model">
+            <worldbody>
+                <body name="base"/>
+            </worldbody>
+        </mujoco>
+        """
+    )
+
+
+def test_add_gyro_sensors_none_keeps_model_unchanged():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    loader.add_gyro_sensors(None)
+
+    assert loader.mjcf.find(".//sensor/gyro") is None
+
+
+def test_add_gyro_sensors_accepts_list_of_dataclasses():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    loader.add_gyro_sensors(
+        [
+            GyroSensorCfg(site="imu_frame", name="imu_gyro"),
+            GyroSensorCfg(site="torso_imu", name="torso_gyro"),
+        ]
+    )
+
+    imu_sensor = loader.mjcf.find(".//sensor/gyro[@name='imu_gyro']")
+    torso_sensor = loader.mjcf.find(".//sensor/gyro[@name='torso_gyro']")
+
+    assert imu_sensor is not None
+    assert imu_sensor.attrib["site"] == "imu_frame"
+
+    assert torso_sensor is not None
+    assert torso_sensor.attrib["site"] == "torso_imu"
+
+
+def test_add_gyro_sensors_accepts_dict():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    loader.add_gyro_sensors(
+        [
+            {
+                "site": "imu_frame",
+                "name": "imu_gyro",
+            }
+        ]
+    )
+
+    sensor = loader.mjcf.find(".//sensor/gyro[@name='imu_gyro']")
+    assert sensor is not None
+    assert sensor.attrib["site"] == "imu_frame"
+
+
+def test_add_gyro_sensors_accepts_dict_with_objname_alias():
+    loader = URDFtoMuJoCoLoader(_make_empty_mjcf(), URDFtoMuJoCoLoaderCfg(controlled_joints=[]))
+
+    loader.add_gyro_sensors(
+        [
+            {
+                "objname": "imu_frame",
+                "name": "imu_gyro",
+            }
+        ]
+    )
+
+    sensor = loader.mjcf.find(".//sensor/gyro[@name='imu_gyro']")
+    assert sensor is not None
+    assert sensor.attrib["site"] == "imu_frame"

--- a/tests/test_loader_gyro_cfg.py
+++ b/tests/test_loader_gyro_cfg.py
@@ -1,6 +1,9 @@
 import xml.etree.ElementTree as ET
 
+import resolve_robotics_uri_py as rru
+
 from mujoco_urdf_loader.loader import GyroSensorCfg, URDFtoMuJoCoLoader, URDFtoMuJoCoLoaderCfg
+from mujoco_urdf_loader.urdf_fcn import get_mesh_path
 
 
 def _make_empty_mjcf() -> ET.Element:
@@ -75,3 +78,55 @@ def test_add_gyro_sensors_accepts_dict_with_objname_alias():
     sensor = loader.mjcf.find(".//sensor/gyro[@name='imu_gyro']")
     assert sensor is not None
     assert sensor.attrib["site"] == "imu_frame"
+
+
+def test_add_gyro_sensors_to_ergocub_sn001():
+    urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
+    controlled_joints = [
+        "l_hip_pitch",
+        "r_hip_pitch",
+        "torso_roll",
+        "l_hip_roll",
+        "r_hip_roll",
+        "torso_pitch",
+        "torso_yaw",
+        "l_hip_yaw",
+        "r_hip_yaw",
+        "l_shoulder_pitch",
+        "neck_pitch",
+        "r_shoulder_pitch",
+        "l_knee",
+        "r_knee",
+        "l_shoulder_roll",
+        "neck_roll",
+        "r_shoulder_roll",
+        "l_ankle_pitch",
+        "r_ankle_pitch",
+        "neck_yaw",
+        "l_ankle_roll",
+        "r_ankle_roll",
+        "l_shoulder_yaw",
+        "r_shoulder_yaw",
+        "l_elbow",
+        "r_elbow",
+    ]
+    mesh_path = get_mesh_path(ET.parse(urdf_root).getroot())
+    gyro_sensors_cfg = [
+        GyroSensorCfg(site="realsense_depth_frame", name="realsense_depth_gyro"),
+        GyroSensorCfg(site="realsense_rgb_frame", name="realsense_rgb_gyro"),
+    ]
+    cfg = URDFtoMuJoCoLoaderCfg(
+        controlled_joints=controlled_joints,
+        gyro_sensors_cfg=gyro_sensors_cfg,
+        all_missing_joints_as_sites=True,
+    )
+    loader = URDFtoMuJoCoLoader.load_urdf(urdf_root, mesh_path, cfg)
+
+    depth_sensor = loader.mjcf.find(".//sensor/gyro[@name='realsense_depth_gyro']")
+    rgb_sensor = loader.mjcf.find(".//sensor/gyro[@name='realsense_rgb_gyro']")
+
+    assert depth_sensor is not None
+    assert depth_sensor.attrib["site"] == "realsense_depth_frame"
+
+    assert rgb_sensor is not None
+    assert rgb_sensor.attrib["site"] == "realsense_rgb_frame"

--- a/tests/test_loader_observed_actuated_cfg.py
+++ b/tests/test_loader_observed_actuated_cfg.py
@@ -1,0 +1,470 @@
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from mujoco_urdf_loader.loader import (
+    ControlMode,
+    EqualityConstraintCfg,
+    URDFtoMuJoCoLoader,
+    URDFtoMuJoCoLoaderCfg,
+)
+
+
+def _make_joint_mjcf() -> ET.Element:
+    return ET.fromstring(
+        """
+        <mujoco model="test_model">
+            <worldbody>
+                <body name="base">
+                    <joint name="l_hip_pitch" type="hinge" range="-1 1"/>
+                    <joint name="l_motor_1" type="hinge" range="-1 1"/>
+                    <joint name="l_motor_rod_in_universal_0" type="hinge" range="-1 1"/>
+                </body>
+            </worldbody>
+        </mujoco>
+        """
+    )
+
+
+def _make_closed_chain_urdf() -> str:
+    return """
+    <robot name="closed_chain_test">
+      <link name="world"/>
+      <link name="base">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="1.0"/>
+          <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        </inertial>
+      </link>
+      <joint name="world_to_base" type="fixed">
+        <parent link="world"/>
+        <child link="base"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+      </joint>
+
+      <link name="left_ankle">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.2"/>
+          <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+        </inertial>
+      </link>
+      <joint name="l_hip_pitch" type="revolute">
+        <parent link="base"/>
+        <child link="left_ankle"/>
+        <origin xyz="0 0.1 0" rpy="0 0 0"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-1.57" upper="1.57" effort="100" velocity="10"/>
+      </joint>
+
+      <link name="l_anklecr_in">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="l_anklecr_in_j" type="fixed">
+        <parent link="left_ankle"/>
+        <child link="l_anklecr_in"/>
+        <origin xyz="0 0.02 0" rpy="0 0 0"/>
+      </joint>
+      <link name="l_anklecr_out">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="l_anklecr_out_j" type="fixed">
+        <parent link="left_ankle"/>
+        <child link="l_anklecr_out"/>
+        <origin xyz="0 -0.02 0" rpy="0 0 0"/>
+      </joint>
+      <link name="l_rod_in_bottom">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="l_rod_in_bottom_j" type="fixed">
+        <parent link="left_ankle"/>
+        <child link="l_rod_in_bottom"/>
+        <origin xyz="0 0.03 0" rpy="0 0 0"/>
+      </joint>
+      <link name="l_rod_out_bottom">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="l_rod_out_bottom_j" type="fixed">
+        <parent link="left_ankle"/>
+        <child link="l_rod_out_bottom"/>
+        <origin xyz="0 -0.03 0" rpy="0 0 0"/>
+      </joint>
+
+      <link name="right_ankle">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.2"/>
+          <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+        </inertial>
+      </link>
+      <joint name="r_hip_pitch" type="revolute">
+        <parent link="base"/>
+        <child link="right_ankle"/>
+        <origin xyz="0 -0.1 0" rpy="0 0 0"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-1.57" upper="1.57" effort="100" velocity="10"/>
+      </joint>
+
+      <link name="r_anklecr_in">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="r_anklecr_in_j" type="fixed">
+        <parent link="right_ankle"/>
+        <child link="r_anklecr_in"/>
+        <origin xyz="0 0.02 0" rpy="0 0 0"/>
+      </joint>
+      <link name="r_anklecr_out">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="r_anklecr_out_j" type="fixed">
+        <parent link="right_ankle"/>
+        <child link="r_anklecr_out"/>
+        <origin xyz="0 -0.02 0" rpy="0 0 0"/>
+      </joint>
+      <link name="r_rod_in_bottom">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="r_rod_in_bottom_j" type="fixed">
+        <parent link="right_ankle"/>
+        <child link="r_rod_in_bottom"/>
+        <origin xyz="0 0.03 0" rpy="0 0 0"/>
+      </joint>
+      <link name="r_rod_out_bottom">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.01"/>
+          <inertia ixx="1e-5" ixy="0" ixz="0" iyy="1e-5" iyz="0" izz="1e-5"/>
+        </inertial>
+      </link>
+      <joint name="r_rod_out_bottom_j" type="fixed">
+        <parent link="right_ankle"/>
+        <child link="r_rod_out_bottom"/>
+        <origin xyz="0 -0.03 0" rpy="0 0 0"/>
+      </joint>
+    </robot>
+    """
+
+
+def _write_closed_chain_urdf(tmp_path) -> str:
+    urdf_path = tmp_path / "closed_chain_test.urdf"
+    urdf_path.write_text(_make_closed_chain_urdf(), encoding="utf-8")
+    return str(urdf_path)
+
+
+def test_observed_joints_must_be_provided():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=None,
+        actuated_joints=[],
+    )
+
+    with pytest.raises(ValueError, match="observed_joints must be provided"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_only_actuated_subset_gets_actuators():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1", "l_motor_rod_in_universal_0"],
+        actuated_joints=["l_hip_pitch", "l_motor_1"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+    )
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+    actuator_joints = sorted(
+        actuator.attrib["joint"] for actuator in loader.mjcf.findall(".//actuator/*")
+    )
+    assert actuator_joints == ["l_hip_pitch", "l_motor_1"]
+    assert loader.mjcf.find(
+        ".//actuator/*[@joint='l_motor_rod_in_universal_0']"
+    ) is None
+
+
+def test_observed_joint_without_actuator_remains_readable():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1", "l_motor_rod_in_universal_0"],
+        actuated_joints=["l_hip_pitch", "l_motor_1"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+    )
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+    assert loader.mjcf.find(".//joint[@name='l_motor_rod_in_universal_0']") is not None
+
+
+def test_actuated_joints_must_be_subset_of_observed_joints():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch"],
+        actuated_joints=["not_observed"],
+        control_modes=[ControlMode.TORQUE],
+    )
+
+    with pytest.raises(ValueError, match="subset of observed_joints"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_torque_mode_allows_missing_gains():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE],
+    )
+
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+    assert loader.mjcf.find(".//actuator/motor[@joint='l_hip_pitch']") is not None
+
+
+def test_position_mode_requires_stiffness():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.POSITION],
+        damping=[0.5],
+    )
+
+    with pytest.raises(ValueError, match="stiffness is required"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_position_mode_requires_damping():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.POSITION],
+        stiffness=[20.0],
+    )
+
+    with pytest.raises(ValueError, match="damping is required"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_position_mode_gain_length_mismatch_raises():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1"],
+        actuated_joints=["l_hip_pitch", "l_motor_1"],
+        control_modes=[ControlMode.POSITION, ControlMode.POSITION],
+        stiffness=[20.0],
+        damping=[0.5, 0.6],
+    )
+
+    with pytest.raises(ValueError, match="Length of stiffness"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_position_mode_sets_kp_and_joint_damping():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.POSITION],
+        stiffness=[42.0],
+        damping=[0.7],
+    )
+
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+    actuator = loader.mjcf.find(".//actuator/position[@joint='l_hip_pitch']")
+    assert actuator is not None
+    assert actuator.attrib["kp"] == "42.0"
+
+    joint = loader.mjcf.find(".//joint[@name='l_hip_pitch']")
+    assert joint is not None
+    assert joint.attrib["damping"] == "0.7"
+
+
+def test_joint_dynamics_are_set_from_observed_joint_lists():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1", "l_motor_rod_in_universal_0"],
+        actuated_joints=["l_hip_pitch", "l_motor_1"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        joint_damping=[0.1, 0.2, 0.3],
+        joint_frictionloss=[1.0, 2.0, 3.0],
+    )
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+    assert loader.mjcf.find(".//joint[@name='l_hip_pitch']").attrib["damping"] == "0.1"
+    assert loader.mjcf.find(".//joint[@name='l_motor_1']").attrib["damping"] == "0.2"
+    assert (
+        loader.mjcf.find(".//joint[@name='l_motor_rod_in_universal_0']").attrib["damping"]
+        == "0.3"
+    )
+
+    assert (
+        loader.mjcf.find(".//joint[@name='l_hip_pitch']").attrib["frictionloss"] == "1.0"
+    )
+    assert loader.mjcf.find(".//joint[@name='l_motor_1']").attrib["frictionloss"] == "2.0"
+    assert (
+        loader.mjcf.find(".//joint[@name='l_motor_rod_in_universal_0']").attrib[
+            "frictionloss"
+        ]
+        == "3.0"
+    )
+
+
+def test_joint_damping_length_must_match_observed_joints():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE],
+        joint_damping=[0.1],
+    )
+
+    with pytest.raises(ValueError, match="Length of joint_damping"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_joint_frictionloss_length_must_match_observed_joints():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_1"],
+        actuated_joints=["l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE],
+        joint_frictionloss=[0.0],
+    )
+
+    with pytest.raises(ValueError, match="Length of joint_frictionloss"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def test_armature_defined_on_observed_joints_is_applied_only_to_actuated_joints():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_rod_in_universal_0", "l_motor_1"],
+        actuated_joints=["l_motor_1", "l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        armature=[1.1, 2.2, 3.3],
+    )
+    normalized_cfg = URDFtoMuJoCoLoader._normalize_cfg(cfg)
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+    loader.set_armature(normalized_cfg.armature)
+
+    assert loader.mjcf.find(".//joint[@name='l_motor_1']").attrib["armature"] == "3.3"
+    assert loader.mjcf.find(".//joint[@name='l_hip_pitch']").attrib["armature"] == "1.1"
+    assert (
+        loader.mjcf.find(".//joint[@name='l_motor_rod_in_universal_0']").attrib.get(
+            "armature"
+        )
+        is None
+    )
+
+
+def test_armature_can_be_specified_for_actuated_joints_only():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_rod_in_universal_0", "l_motor_1"],
+        actuated_joints=["l_motor_1", "l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        armature=[9.0, 8.0],
+    )
+    normalized_cfg = URDFtoMuJoCoLoader._normalize_cfg(cfg)
+    loader = URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+    loader.set_armature(normalized_cfg.armature)
+
+    assert loader.mjcf.find(".//joint[@name='l_motor_1']").attrib["armature"] == "9.0"
+    assert loader.mjcf.find(".//joint[@name='l_hip_pitch']").attrib["armature"] == "8.0"
+
+
+def test_armature_length_must_match_actuated_or_observed_joints():
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "l_motor_rod_in_universal_0", "l_motor_1"],
+        actuated_joints=["l_motor_1", "l_hip_pitch"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        armature=[0.1],
+    )
+
+    with pytest.raises(ValueError, match="Length of armature"):
+        URDFtoMuJoCoLoader(_make_joint_mjcf(), cfg)
+
+
+def _closed_chain_cfg_with_constraints() -> URDFtoMuJoCoLoaderCfg:
+    return URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "r_hip_pitch"],
+        actuated_joints=["l_hip_pitch", "r_hip_pitch"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        all_missing_joints_as_sites=True,
+        equality_constraints_cfg=[
+            EqualityConstraintCfg(site1="l_anklecr_in", site2="l_rod_in_bottom"),
+            EqualityConstraintCfg(site1="l_anklecr_out", site2="l_rod_out_bottom"),
+            EqualityConstraintCfg(site1="r_anklecr_in", site2="r_rod_in_bottom"),
+            EqualityConstraintCfg(site1="r_anklecr_out", site2="r_rod_out_bottom"),
+        ],
+    )
+
+
+def test_closed_chain_connect_constraints_are_added_from_synthetic_urdf(tmp_path):
+    urdf_path = _write_closed_chain_urdf(tmp_path)
+    loader = URDFtoMuJoCoLoader.load_urdf(
+        urdf_path=urdf_path,
+        mesh_path=tmp_path,
+        cfg=_closed_chain_cfg_with_constraints(),
+    )
+
+    # Missing fixed-link frames are recovered as sites and can be constrained.
+    for site_name in (
+        "l_anklecr_in",
+        "l_anklecr_out",
+        "l_rod_in_bottom",
+        "l_rod_out_bottom",
+        "r_anklecr_in",
+        "r_anklecr_out",
+        "r_rod_in_bottom",
+        "r_rod_out_bottom",
+    ):
+        assert loader.mjcf.find(f".//site[@name='{site_name}']") is not None
+
+    connects = loader.mjcf.findall(".//equality/connect")
+    assert len(connects) == 4
+    pairs = {(c.attrib["site1"], c.attrib["site2"]) for c in connects}
+    assert pairs == {
+        ("l_anklecr_in", "l_rod_in_bottom"),
+        ("l_anklecr_out", "l_rod_out_bottom"),
+        ("r_anklecr_in", "r_rod_in_bottom"),
+        ("r_anklecr_out", "r_rod_out_bottom"),
+    }
+
+
+def test_closed_chain_missing_site_raises_from_synthetic_urdf(tmp_path):
+    urdf_path = _write_closed_chain_urdf(tmp_path)
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=["l_hip_pitch", "r_hip_pitch"],
+        actuated_joints=["l_hip_pitch", "r_hip_pitch"],
+        control_modes=[ControlMode.TORQUE, ControlMode.TORQUE],
+        all_missing_joints_as_sites=True,
+    )
+    loader = URDFtoMuJoCoLoader.load_urdf(
+        urdf_path=urdf_path,
+        mesh_path=tmp_path,
+        cfg=cfg,
+    )
+
+    with pytest.raises(ValueError, match="not found"):
+        loader.add_equality_constraints(
+            [
+                EqualityConstraintCfg(
+                    site1="l_anklecr_in",
+                    site2="missing_site",
+                )
+            ]
+        )

--- a/tests/test_missing_joint_sites.py
+++ b/tests/test_missing_joint_sites.py
@@ -1,0 +1,259 @@
+import xml.etree.ElementTree as ET
+
+from mujoco_urdf_loader.loader import ControlMode, URDFtoMuJoCoLoader, URDFtoMuJoCoLoaderCfg
+from mujoco_urdf_loader.urdf_fcn import get_mesh_path
+
+import resolve_robotics_uri_py as rru
+
+import mujoco
+import numpy as np
+import idyntree.bindings as idyntree
+
+def _make_urdf_root() -> ET.Element:
+    return ET.fromstring(
+        """
+        <robot name="test_robot">
+            <link name="base"/>
+            <link name="l1"/>
+            <link name="l2"/>
+            <joint name="j1" type="revolute">
+                <parent link="base"/>
+                <child link="l1"/>
+                <origin xyz="1 0 0" rpy="0 0 0"/>
+                <axis xyz="0 0 1"/>
+            </joint>
+            <joint name="j2" type="revolute">
+                <parent link="l1"/>
+                <child link="l2"/>
+                <origin xyz="0 2 0" rpy="0 0 0"/>
+                <axis xyz="0 0 1"/>
+            </joint>
+        </robot>
+        """
+    )
+
+
+def _make_mjcf_with_base_only() -> ET.Element:
+    return ET.fromstring(
+        """
+        <mujoco model="test_model">
+            <worldbody>
+                <body name="base"/>
+            </worldbody>
+        </mujoco>
+        """
+    )
+
+
+def test_get_missing_joint_sites_all_flag_collects_missing_urdf_links():
+    urdf_root = _make_urdf_root()
+    mjcf = ET.fromstring(
+        """
+        <mujoco model="test_model">
+            <worldbody>
+                <body name="base">
+                    <body name="l1">
+                        <joint name="j1" type="hinge"/>
+                    </body>
+                </body>
+            </worldbody>
+        </mujoco>
+        """
+    )
+
+    # j1 is controlled so l1 survives; j2 is NOT controlled so l2 is missing
+    sites = URDFtoMuJoCoLoader.get_missing_joint_sites(
+        urdf_root,
+        mjcf,
+        controlled_joints=["j1"],
+        all_missing_joints_as_sites=True,
+    )
+
+    site_names = {site["name"] for site in sites}
+    assert site_names == {"l2"}
+
+
+def test_add_sites_for_missing_joints_handles_nested_lumped_missing_joints():
+    urdf_root = _make_urdf_root()
+    # Neither j1 nor j2 are controlled, so both l1 and l2 are missing
+    fixed_joint_sites = URDFtoMuJoCoLoader.get_missing_joint_sites(
+        urdf_root,
+        _make_mjcf_with_base_only(),
+        controlled_joints=[],
+        all_missing_joints_as_sites=True,
+    )
+
+    fixed_joint_sites = [site for site in fixed_joint_sites if site["name"] == "l2"]
+
+    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+    loader = URDFtoMuJoCoLoader(_make_mjcf_with_base_only(), cfg)
+
+    loader.add_sites_for_missing_joints(fixed_joint_sites)
+
+    site = loader.mjcf.find(".//site[@name='l2']")
+    assert site is not None
+
+    site_parent_body = next(
+        (
+            body
+            for body in loader.mjcf.findall(".//body")
+            if body.find("./site[@name='l2']") is not None
+        ),
+        None,
+    )
+    assert site_parent_body is not None
+    assert site_parent_body.attrib["name"] == "base"
+
+    pos = list(map(float, site.attrib["pos"].split()))
+    assert pos == [1.0, 2.0, 0.0]
+
+def test_ergocub_sn001_missing_joint_sites():
+    urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
+    controlled_joints = [
+            "l_hip_pitch",
+            "r_hip_pitch",
+            "torso_roll",
+            "l_hip_roll",
+            "r_hip_roll",
+            "torso_pitch",
+            "torso_yaw",
+            "l_hip_yaw",
+            "r_hip_yaw",
+            "l_shoulder_pitch",
+            "neck_pitch",
+            "r_shoulder_pitch",
+            "l_knee",
+            "r_knee",
+            "l_shoulder_roll",
+            "neck_roll",
+            "r_shoulder_roll",
+            "l_ankle_pitch",
+            "r_ankle_pitch",
+            "neck_yaw",
+            "l_ankle_roll",
+            "r_ankle_roll",
+            "l_shoulder_yaw",
+            "r_shoulder_yaw",
+            "l_elbow",
+            "r_elbow",
+    ]
+    mesh_path = get_mesh_path(ET.parse(urdf_root).getroot())
+    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, all_missing_joints_as_sites=True)
+    loader = URDFtoMuJoCoLoader.load_urdf(urdf_root, mesh_path, cfg)
+
+    xml_path = "model.xml"
+    with open(xml_path, "w") as f:
+        f.write(loader.get_mjcf_string(pretty=True))
+    print(f"MuJoCo XML model saved to: {xml_path}")
+
+    mjcf_string = loader.get_mjcf_string()
+
+    # ---- MuJoCo setup ----
+    mj_model = mujoco.MjModel.from_xml_string(mjcf_string)
+    mj_data = mujoco.MjData(mj_model)
+
+    # ---- iDynTree reduced-model setup (using controlled joints) ----
+    idt_loader = idyntree.ModelLoader()
+    assert idt_loader.loadReducedModelFromFile(urdf_root, controlled_joints)
+    reduced_model = idt_loader.model()
+
+    kin_dyn = idyntree.KinDynComputations()
+    assert kin_dyn.loadRobotModel(reduced_model)
+
+    n_reduced_dofs = reduced_model.getNrOfDOFs()
+
+    # Map each controlled joint name to its DOF index in the reduced model
+    controlled_dof_indices = {}
+    for jname in controlled_joints:
+        jidx = reduced_model.getJointIndex(jname)
+        assert jidx >= 0, f"Joint {jname} not found in the reduced model"
+        controlled_dof_indices[jname] = reduced_model.getJoint(jidx).getDOFsOffset()
+
+    # Collect MuJoCo site names that also exist as frames in iDynTree
+    all_site_names = [mj_model.site(i).name for i in range(mj_model.nsite)]
+    sites_to_check = [
+        name for name in all_site_names
+        if reduced_model.getFrameIndex(name) >= 0
+    ]
+    assert len(sites_to_check) > 0, "No sites with matching iDynTree frames found"
+
+    # Get joint limits from MuJoCo for uniform sampling
+    joint_limits = np.zeros((len(controlled_joints), 2))
+    for i, jname in enumerate(controlled_joints):
+        jid = mj_model.joint(jname).id
+        if mj_model.jnt_limited[jid]:
+            joint_limits[i] = mj_model.jnt_range[jid]
+        else:
+            joint_limits[i] = [-1.0, 1.0]
+
+    nr_random_joints_cfg = 5
+
+    sites_with_pos_mismatches = set()  # to track which sites had mismatches across all configurations
+    sites_with_rot_mismatches = set()  # to track which sites had mismatches across all configurations
+    for joint_cfg_nr in range(nr_random_joints_cfg):
+        # Sample random joint positions within limits
+        s_ctrl = np.random.uniform(joint_limits[:, 0], joint_limits[:, 1])
+
+        # ---- iDynTree: set reduced-model state ----
+        s = idyntree.VectorDynSize(n_reduced_dofs)
+        s.zero()
+        for i, jname in enumerate(controlled_joints):
+            s.setVal(controlled_dof_indices[jname], s_ctrl[i])
+
+        ds = idyntree.VectorDynSize(n_reduced_dofs)
+        ds.zero()
+        gravity = idyntree.Vector3()
+        gravity.zero()
+        gravity.setVal(2, -9.81)
+
+        kin_dyn.setRobotState(
+            idyntree.Transform.Identity(), s,
+            idyntree.Twist(), ds, gravity,
+        )
+
+        # ---- MuJoCo: set qpos and run forward kinematics ----
+        mj_data.qpos[:] = 0.0
+        mj_data.qpos[3] = 1.0  # identity quaternion (w, x, y, z)
+        for i, jname in enumerate(controlled_joints):
+            jid = mj_model.joint(jname).id
+            addr = mj_model.jnt_qposadr[jid]
+            mj_data.qpos[addr] = s_ctrl[i]
+
+        mujoco.mj_forward(mj_model, mj_data)
+
+        # ---- Compare FK for every site ----
+        site_checked = 0
+        for site_name in sites_to_check:
+            site_checked += 1
+            site_id = mj_model.site(site_name).id
+            mj_pos = mj_data.site_xpos[site_id]
+            mj_rot = mj_data.site_xmat[site_id].reshape(3, 3)
+
+            tf = kin_dyn.getWorldTransform(site_name)
+            idt_pos = np.array([tf.getPosition().getVal(k) for k in range(3)])
+            idt_rot = np.array(
+                [[tf.getRotation().getVal(r, c) for c in range(3)] for r in range(3)]
+            )
+
+            # instead of interrumpting the test at the first failure, we check all sites and report all mismatches at the end
+
+            try:
+                np.testing.assert_allclose(
+                    mj_pos, idt_pos, atol=1e-3,
+                    err_msg=f"Position mismatch for site '{site_name}' in joint configuration #{joint_cfg_nr}",
+                )
+            except AssertionError as e:
+                # print(e) 
+                sites_with_pos_mismatches.add(site_name)
+
+            try:
+                np.testing.assert_allclose(
+                    mj_rot, idt_rot, atol=1e-3,
+                    err_msg=f"Rotation mismatch for site '{site_name}' in joint configuration #{joint_cfg_nr}",
+                )
+            except AssertionError as e:
+                # print(e) 
+                sites_with_rot_mismatches.add(site_name)
+
+    assert len(sites_with_pos_mismatches) == 0, f"Position mismatches found for sites: {sites_with_pos_mismatches}"
+    assert len(sites_with_rot_mismatches) == 0, f"Rotation mismatches found for sites: {sites_with_rot_mismatches}"

--- a/tests/test_missing_joint_sites.py
+++ b/tests/test_missing_joint_sites.py
@@ -65,7 +65,7 @@ def test_get_missing_joint_sites_all_flag_collects_missing_urdf_links():
     sites = URDFtoMuJoCoLoader.get_missing_joint_sites(
         urdf_root,
         mjcf,
-        controlled_joints=["j1"],
+        observed_joints=["j1"],
         all_missing_joints_as_sites=True,
     )
 
@@ -79,13 +79,13 @@ def test_add_sites_for_missing_joints_handles_nested_lumped_missing_joints():
     fixed_joint_sites = URDFtoMuJoCoLoader.get_missing_joint_sites(
         urdf_root,
         _make_mjcf_with_base_only(),
-        controlled_joints=[],
+        observed_joints=[],
         all_missing_joints_as_sites=True,
     )
 
     fixed_joint_sites = [site for site in fixed_joint_sites if site["name"] == "l2"]
 
-    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints=[])
+    cfg = URDFtoMuJoCoLoaderCfg(observed_joints=[])
     loader = URDFtoMuJoCoLoader(_make_mjcf_with_base_only(), cfg)
 
     loader.add_sites_for_missing_joints(fixed_joint_sites)
@@ -109,7 +109,7 @@ def test_add_sites_for_missing_joints_handles_nested_lumped_missing_joints():
 
 def test_ergocub_sn001_missing_joint_sites():
     urdf_root = str(rru.resolve_robotics_uri("package://ergoCub/robots/ergoCubSN001/model.urdf"))
-    controlled_joints = [
+    observed_joints = [
             "l_hip_pitch",
             "r_hip_pitch",
             "torso_roll",
@@ -138,7 +138,10 @@ def test_ergocub_sn001_missing_joint_sites():
             "r_elbow",
     ]
     mesh_path = get_mesh_path(ET.parse(urdf_root).getroot())
-    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, all_missing_joints_as_sites=True)
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=observed_joints,
+        all_missing_joints_as_sites=True,
+    )
     loader = URDFtoMuJoCoLoader.load_urdf(urdf_root, mesh_path, cfg)
 
     mjcf_string = loader.get_mjcf_string()
@@ -149,7 +152,7 @@ def test_ergocub_sn001_missing_joint_sites():
 
     # ---- iDynTree reduced-model setup (using controlled joints) ----
     idt_loader = idyntree.ModelLoader()
-    assert idt_loader.loadReducedModelFromFile(urdf_root, controlled_joints)
+    assert idt_loader.loadReducedModelFromFile(urdf_root, observed_joints)
     reduced_model = idt_loader.model()
 
     kin_dyn = idyntree.KinDynComputations()
@@ -159,7 +162,7 @@ def test_ergocub_sn001_missing_joint_sites():
 
     # Map each controlled joint name to its DOF index in the reduced model
     controlled_dof_indices = {}
-    for jname in controlled_joints:
+    for jname in observed_joints:
         jidx = reduced_model.getJointIndex(jname)
         assert jidx >= 0, f"Joint {jname} not found in the reduced model"
         controlled_dof_indices[jname] = reduced_model.getJoint(jidx).getDOFsOffset()
@@ -173,8 +176,8 @@ def test_ergocub_sn001_missing_joint_sites():
     assert len(sites_to_check) > 0, "No sites with matching iDynTree frames found"
 
     # Get joint limits from MuJoCo for uniform sampling
-    joint_limits = np.zeros((len(controlled_joints), 2))
-    for i, jname in enumerate(controlled_joints):
+    joint_limits = np.zeros((len(observed_joints), 2))
+    for i, jname in enumerate(observed_joints):
         jid = mj_model.joint(jname).id
         if mj_model.jnt_limited[jid]:
             joint_limits[i] = mj_model.jnt_range[jid]
@@ -192,7 +195,7 @@ def test_ergocub_sn001_missing_joint_sites():
         # ---- iDynTree: set reduced-model state ----
         s = idyntree.VectorDynSize(n_reduced_dofs)
         s.zero()
-        for i, jname in enumerate(controlled_joints):
+        for i, jname in enumerate(observed_joints):
             s.setVal(controlled_dof_indices[jname], s_ctrl[i])
 
         ds = idyntree.VectorDynSize(n_reduced_dofs)
@@ -209,7 +212,7 @@ def test_ergocub_sn001_missing_joint_sites():
         # ---- MuJoCo: set qpos and run forward kinematics ----
         mj_data.qpos[:] = 0.0
         mj_data.qpos[3] = 1.0  # identity quaternion (w, x, y, z)
-        for i, jname in enumerate(controlled_joints):
+        for i, jname in enumerate(observed_joints):
             jid = mj_model.joint(jname).id
             addr = mj_model.jnt_qposadr[jid]
             mj_data.qpos[addr] = s_ctrl[i]

--- a/tests/test_missing_joint_sites.py
+++ b/tests/test_missing_joint_sites.py
@@ -141,11 +141,6 @@ def test_ergocub_sn001_missing_joint_sites():
     cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, all_missing_joints_as_sites=True)
     loader = URDFtoMuJoCoLoader.load_urdf(urdf_root, mesh_path, cfg)
 
-    xml_path = "model.xml"
-    with open(xml_path, "w") as f:
-        f.write(loader.get_mjcf_string(pretty=True))
-    print(f"MuJoCo XML model saved to: {xml_path}")
-
     mjcf_string = loader.get_mjcf_string()
 
     # ---- MuJoCo setup ----

--- a/tests/test_mjcf_fcn.py
+++ b/tests/test_mjcf_fcn.py
@@ -9,6 +9,7 @@ from mujoco_urdf_loader.mjcf_fcn import (
     add_joint_vel_sensor,
     add_new_worldbody,
     add_position_actuator,
+    convert_hinge_to_ball_joints,
     separate_left_right_collision_groups,
     set_collision_groups,
     set_joint_damping,
@@ -187,3 +188,105 @@ def test_set_joint_damping():
 
     assert joint.attrib["damping"] == "1.0"
     return
+
+
+# ---------------------------------------------------------------------------
+# Tests for convert_hinge_to_ball_joints
+# ---------------------------------------------------------------------------
+
+def _make_mjcf_with_hinge():
+    """Build a minimal MJCF with a hinge joint that should be converted to ball."""
+    mjcf = ET.Element("mujoco")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    body = ET.SubElement(worldbody, "body")
+    body.set("name", "crank")
+
+    child_body = ET.SubElement(body, "body")
+    child_body.set("name", "rod")
+    child_body.set("pos", "0.05 0.02 0")
+
+    joint = ET.SubElement(child_body, "joint")
+    joint.set("name", "spherical_rev_my_rod_x")
+    joint.set("type", "hinge")
+    joint.set("axis", "1 0 0")
+    joint.set("range", "-6.28 6.28")
+    joint.set("limited", "true")
+    joint.set("damping", "0")
+    joint.set("armature", "0")
+
+    # Also add a regular hinge that should NOT be converted
+    other_body = ET.SubElement(worldbody, "body")
+    other_body.set("name", "other")
+    other_joint = ET.SubElement(other_body, "joint")
+    other_joint.set("name", "regular_hinge")
+    other_joint.set("type", "hinge")
+    other_joint.set("axis", "0 1 0")
+
+    return mjcf
+
+
+def test_convert_hinge_to_ball_joints():
+    mjcf = _make_mjcf_with_hinge()
+    ball_map = {"spherical_rev_my_rod_x": "my_rod"}
+
+    convert_hinge_to_ball_joints(mjcf, ball_map)
+
+    # The placeholder joint should now be a ball joint with new name
+    ball = mjcf.find(".//joint[@name='my_rod_ball']")
+    assert ball is not None
+    assert ball.attrib["type"] == "ball"
+
+    # Hinge-only attributes should be removed
+    assert "axis" not in ball.attrib
+    assert "ref" not in ball.attrib
+
+    # Damping and armature should be set (defaults)
+    assert float(ball.attrib["damping"]) == pytest.approx(0.01)
+    assert float(ball.attrib["armature"]) == pytest.approx(0.001)
+
+    # The old name should no longer exist
+    assert mjcf.find(".//joint[@name='spherical_rev_my_rod_x']") is None
+
+
+def test_convert_hinge_to_ball_custom_damping():
+    mjcf = _make_mjcf_with_hinge()
+    ball_map = {"spherical_rev_my_rod_x": "my_rod"}
+
+    convert_hinge_to_ball_joints(mjcf, ball_map, damping=0.5, armature=0.05)
+
+    ball = mjcf.find(".//joint[@name='my_rod_ball']")
+    assert float(ball.attrib["damping"]) == pytest.approx(0.5)
+    assert float(ball.attrib["armature"]) == pytest.approx(0.05)
+
+
+def test_convert_hinge_to_ball_preserves_other_joints():
+    mjcf = _make_mjcf_with_hinge()
+    ball_map = {"spherical_rev_my_rod_x": "my_rod"}
+
+    convert_hinge_to_ball_joints(mjcf, ball_map)
+
+    # The regular hinge should be untouched
+    regular = mjcf.find(".//joint[@name='regular_hinge']")
+    assert regular is not None
+    assert regular.attrib["type"] == "hinge"
+    assert regular.attrib["axis"] == "0 1 0"
+
+
+def test_convert_hinge_to_ball_missing_joint():
+    mjcf = _make_mjcf_with_hinge()
+    ball_map = {"nonexistent_joint": "some_base"}
+
+    with pytest.raises(ValueError, match="nonexistent_joint"):
+        convert_hinge_to_ball_joints(mjcf, ball_map)
+
+
+def test_convert_hinge_to_ball_empty_map():
+    mjcf = _make_mjcf_with_hinge()
+    ball_map = {}
+
+    # Should be a no-op
+    convert_hinge_to_ball_joints(mjcf, ball_map)
+
+    # Original joints should be unchanged
+    assert mjcf.find(".//joint[@name='spherical_rev_my_rod_x']") is not None
+    assert mjcf.find(".//joint[@name='regular_hinge']") is not None

--- a/tests/test_spherical_ball_conversion.py
+++ b/tests/test_spherical_ball_conversion.py
@@ -1,0 +1,229 @@
+"""Integration tests for spherical-to-ball-joint conversion pipeline.
+
+Tests that the full collapse → MuJoCo load → ball joint conversion pipeline
+works end-to-end, producing a valid MuJoCo model without zero-mass body errors.
+"""
+
+import xml.etree.ElementTree as ET
+
+import mujoco
+import pytest
+
+from mujoco_urdf_loader.generator import load_urdf_into_mjcf
+from mujoco_urdf_loader.mjcf_fcn import convert_hinge_to_ball_joints
+from mujoco_urdf_loader.urdf_fcn import (
+    add_mujoco_element,
+    collapse_spherical_revolute_triplets,
+    detect_spherical_joint_groups,
+)
+
+
+def _make_full_urdf():
+    """Build a URDF with a floating root, a crank, and a spherical-joint rod.
+
+    The spherical joint is represented as 3 revolute joints + 2 zero-mass
+    dummy links, following the iDynTree convention.
+    """
+    urdf_str = """\
+    <robot name="test_spherical">
+      <link name="world"/>
+      <link name="root_link">
+        <inertial>
+          <mass value="5.0"/>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <inertia ixx="0.05" ixy="0" ixz="0" iyy="0.05" iyz="0" izz="0.05"/>
+        </inertial>
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry><box size="0.1 0.1 0.1"/></geometry>
+        </visual>
+      </link>
+      <joint name="floating_base" type="floating">
+        <parent link="world"/>
+        <child link="root_link"/>
+      </joint>
+
+      <link name="crank">
+        <inertial>
+          <mass value="0.3"/>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+        </inertial>
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry><cylinder radius="0.01" length="0.05"/></geometry>
+        </visual>
+      </link>
+      <joint name="motor_joint" type="revolute">
+        <origin xyz="0 0 -0.1" rpy="0 0 0"/>
+        <axis xyz="0 1 0"/>
+        <parent link="root_link"/>
+        <child link="crank"/>
+        <limit lower="-3.14" upper="3.14" effort="100" velocity="10"/>
+      </joint>
+
+      <!-- Spherical joint triplet: crank -> dummy1 -> dummy2 -> rod -->
+      <joint name="spherical_rev_my_rod_x" type="revolute">
+        <origin xyz="0.05 0.02 0" rpy="0 0 0"/>
+        <axis xyz="1 0 0"/>
+        <parent link="crank"/>
+        <child link="spherical_fake_my_rod_link1"/>
+        <limit lower="-6.283" upper="6.283" effort="1000" velocity="1000"/>
+        <dynamics damping="0" friction="0"/>
+      </joint>
+      <link name="spherical_fake_my_rod_link1">
+        <inertial>
+          <mass value="0"/>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+        </inertial>
+      </link>
+      <joint name="spherical_rev_my_rod_y" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <axis xyz="0 1 0"/>
+        <parent link="spherical_fake_my_rod_link1"/>
+        <child link="spherical_fake_my_rod_link2"/>
+        <limit lower="-6.283" upper="6.283" effort="1000" velocity="1000"/>
+        <dynamics damping="0" friction="0"/>
+      </joint>
+      <link name="spherical_fake_my_rod_link2">
+        <inertial>
+          <mass value="0"/>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+        </inertial>
+      </link>
+      <joint name="spherical_rev_my_rod_z" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <axis xyz="0 0 1"/>
+        <parent link="spherical_fake_my_rod_link2"/>
+        <child link="rod"/>
+        <limit lower="-6.283" upper="6.283" effort="1000" velocity="1000"/>
+        <dynamics damping="0" friction="0"/>
+      </joint>
+      <link name="rod">
+        <inertial>
+          <mass value="0.17"/>
+          <origin xyz="0 0 -0.15" rpy="0 0 0"/>
+          <inertia ixx="0.002" ixy="0" ixz="0" iyy="0.002" iyz="0" izz="0.0001"/>
+        </inertial>
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry><cylinder radius="0.005" length="0.3"/></geometry>
+        </visual>
+      </link>
+    </robot>
+    """
+    return ET.fromstring(urdf_str)
+
+
+class TestSphericalBallConversionPipeline:
+    """Test the full pipeline: detect → collapse → load → convert."""
+
+    def test_uncollapsed_urdf_fails_in_mujoco(self):
+        """The original URDF with zero-mass dummy links should fail in MuJoCo."""
+        urdf = _make_full_urdf()
+        urdf_str = ET.tostring(urdf, encoding="unicode")
+        with pytest.raises(Exception):
+            mujoco.MjModel.from_xml_string(urdf_str)
+
+    def test_collapsed_urdf_loads_in_mujoco(self):
+        """After collapsing, the URDF should load in MuJoCo without errors."""
+        urdf = _make_full_urdf()
+        controlled = [
+            "motor_joint",
+            "spherical_rev_my_rod_x",
+            "spherical_rev_my_rod_y",
+            "spherical_rev_my_rod_z",
+        ]
+        groups = detect_spherical_joint_groups(controlled)
+        collapsed_urdf, ball_map = collapse_spherical_revolute_triplets(urdf, groups)
+
+        # Should be loadable by MuJoCo (no zero-mass error)
+        urdf_str = ET.tostring(collapsed_urdf, encoding="unicode")
+        model = mujoco.MjModel.from_xml_string(urdf_str)
+        assert model is not None
+
+    def test_full_pipeline_produces_ball_joint(self):
+        """Full pipeline: collapse → load_urdf_into_mjcf → convert to ball."""
+        urdf = _make_full_urdf()
+        controlled = [
+            "motor_joint",
+            "spherical_rev_my_rod_x",
+            "spherical_rev_my_rod_y",
+            "spherical_rev_my_rod_z",
+        ]
+        groups = detect_spherical_joint_groups(controlled)
+        collapsed_urdf, ball_map = collapse_spherical_revolute_triplets(urdf, groups)
+
+        # Add mujoco compiler element (no mesh dir needed for this URDF)
+        mj_elem = ET.SubElement(collapsed_urdf, "mujoco")
+        compiler = ET.SubElement(mj_elem, "compiler")
+        compiler.set("angle", "radian")
+
+        mjcf = load_urdf_into_mjcf(collapsed_urdf)
+
+        # Convert placeholder to ball
+        convert_hinge_to_ball_joints(mjcf, ball_map)
+
+        # Verify the ball joint exists
+        ball_joint = mjcf.find(".//joint[@name='my_rod_ball']")
+        assert ball_joint is not None
+        assert ball_joint.attrib["type"] == "ball"
+
+        # Verify damping and armature are set for stability
+        assert float(ball_joint.attrib["damping"]) > 0
+        assert float(ball_joint.attrib["armature"]) > 0
+
+        # Verify no dummy bodies remain
+        body_names = {b.attrib["name"] for b in mjcf.findall(".//body")}
+        assert "spherical_fake_my_rod_link1" not in body_names
+        assert "spherical_fake_my_rod_link2" not in body_names
+
+        # Rod body should exist
+        assert "rod" in body_names
+
+    def test_full_pipeline_model_simulates(self):
+        """The final model should be simulatable."""
+        urdf = _make_full_urdf()
+        controlled = [
+            "motor_joint",
+            "spherical_rev_my_rod_x",
+            "spherical_rev_my_rod_y",
+            "spherical_rev_my_rod_z",
+        ]
+        groups = detect_spherical_joint_groups(controlled)
+        collapsed_urdf, ball_map = collapse_spherical_revolute_triplets(urdf, groups)
+
+        mj_elem = ET.SubElement(collapsed_urdf, "mujoco")
+        compiler = ET.SubElement(mj_elem, "compiler")
+        compiler.set("angle", "radian")
+
+        mjcf = load_urdf_into_mjcf(collapsed_urdf)
+        convert_hinge_to_ball_joints(mjcf, ball_map, damping=0.01, armature=0.001)
+
+        mjcf_str = ET.tostring(mjcf, encoding="unicode")
+        model = mujoco.MjModel.from_xml_string(mjcf_str)
+        data = mujoco.MjData(model)
+
+        # Run simulation long enough to catch instability
+        for _ in range(1000):
+            mujoco.mj_step(model, data)
+
+        # Should not crash or produce NaN / Inf
+        import numpy as np
+        assert np.all(np.isfinite(data.qpos)), "qpos contains NaN/Inf after simulation"
+
+    def test_no_spherical_groups_is_noop(self):
+        """When there are no spherical groups, the pipeline is a no-op."""
+        urdf = _make_full_urdf()
+        controlled = ["motor_joint"]
+        groups = detect_spherical_joint_groups(controlled)
+        assert len(groups) == 0
+
+        # collapse with empty groups should not modify the URDF
+        collapsed_urdf, ball_map = collapse_spherical_revolute_triplets(urdf, groups)
+        assert ball_map == {}
+        # All links should still be present
+        link_names = {l.attrib["name"] for l in collapsed_urdf.findall(".//link")}
+        assert "spherical_fake_my_rod_link1" in link_names

--- a/tests/test_urdf_fcn.py
+++ b/tests/test_urdf_fcn.py
@@ -10,6 +10,8 @@ from mujoco_urdf_loader.urdf_fcn import (
     remove_gazebo_elements,
     remove_links_and_joints_by_keep_list,
     remove_links_and_joints_by_remove_list,
+    detect_spherical_joint_groups,
+    collapse_spherical_revolute_triplets,
 )
 
 
@@ -80,3 +82,213 @@ def test_get_joint_limits():
     assert joint_limits is not None
     assert len(joint_limits) == 57
     return
+
+
+# ---------------------------------------------------------------------------
+# Tests for spherical joint detection and collapse
+# ---------------------------------------------------------------------------
+
+def _make_spherical_urdf():
+    """Build a minimal URDF with one spherical-joint triplet (3 revolute + 2 dummy links)."""
+    urdf_str = """
+    <robot name="test_robot">
+      <link name="root_link">
+        <inertial>
+          <mass value="1.0"/>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        </inertial>
+      </link>
+      <link name="crank">
+        <inertial>
+          <mass value="0.5"/>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+        </inertial>
+      </link>
+      <joint name="crank_joint" type="revolute">
+        <origin xyz="0 0 0.1" rpy="0 0 0"/>
+        <axis xyz="0 1 0"/>
+        <parent link="root_link"/>
+        <child link="crank"/>
+        <limit lower="-1" upper="1" effort="100" velocity="10"/>
+      </joint>
+      <!-- Spherical joint triplet -->
+      <joint name="spherical_rev_my_rod_x" type="revolute">
+        <origin xyz="0.05 0.02 0" rpy="0 0 0"/>
+        <axis xyz="1 0 0"/>
+        <parent link="crank"/>
+        <child link="spherical_fake_my_rod_link1"/>
+        <limit lower="-6.28" upper="6.28" effort="1000" velocity="1000"/>
+        <dynamics damping="0" friction="0"/>
+      </joint>
+      <link name="spherical_fake_my_rod_link1">
+        <inertial>
+          <mass value="0"/>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+        </inertial>
+      </link>
+      <joint name="spherical_rev_my_rod_y" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <axis xyz="0 1 0"/>
+        <parent link="spherical_fake_my_rod_link1"/>
+        <child link="spherical_fake_my_rod_link2"/>
+        <limit lower="-6.28" upper="6.28" effort="1000" velocity="1000"/>
+        <dynamics damping="0" friction="0"/>
+      </joint>
+      <link name="spherical_fake_my_rod_link2">
+        <inertial>
+          <mass value="0"/>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+        </inertial>
+      </link>
+      <joint name="spherical_rev_my_rod_z" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <axis xyz="0 0 1"/>
+        <parent link="spherical_fake_my_rod_link2"/>
+        <child link="rod"/>
+        <limit lower="-6.28" upper="6.28" effort="1000" velocity="1000"/>
+        <dynamics damping="0" friction="0"/>
+      </joint>
+      <link name="rod">
+        <inertial>
+          <mass value="0.2"/>
+          <origin xyz="0 0 -0.15" rpy="0 0 0"/>
+          <inertia ixx="0.002" ixy="0" ixz="0" iyy="0.002" iyz="0" izz="0.0001"/>
+        </inertial>
+      </link>
+    </robot>
+    """
+    return ET.fromstring(urdf_str)
+
+
+def test_detect_spherical_joint_groups():
+    joints = [
+        "crank_joint",
+        "spherical_rev_my_rod_x",
+        "spherical_rev_my_rod_y",
+        "spherical_rev_my_rod_z",
+    ]
+    groups = detect_spherical_joint_groups(joints)
+    assert len(groups) == 1
+    assert groups[0]["base_name"] == "my_rod"
+    assert groups[0]["joint_x"] == "spherical_rev_my_rod_x"
+    assert groups[0]["joint_y"] == "spherical_rev_my_rod_y"
+    assert groups[0]["joint_z"] == "spherical_rev_my_rod_z"
+
+
+def test_detect_spherical_joint_groups_multiple():
+    joints = [
+        "spherical_rev_r_motor_rod_in_x",
+        "spherical_rev_r_motor_rod_in_y",
+        "spherical_rev_r_motor_rod_in_z",
+        "spherical_rev_l_motor_rod_in_x",
+        "spherical_rev_l_motor_rod_in_y",
+        "spherical_rev_l_motor_rod_in_z",
+        "l_hip_pitch",
+    ]
+    groups = detect_spherical_joint_groups(joints)
+    assert len(groups) == 2
+    base_names = {g["base_name"] for g in groups}
+    assert base_names == {"r_motor_rod_in", "l_motor_rod_in"}
+
+
+def test_detect_no_spherical_groups():
+    joints = ["l_hip_pitch", "r_hip_pitch", "l_knee", "r_knee"]
+    groups = detect_spherical_joint_groups(joints)
+    assert len(groups) == 0
+
+
+def test_detect_incomplete_triplet():
+    """Incomplete triplet (missing z) should not be detected."""
+    joints = ["spherical_rev_my_rod_x", "spherical_rev_my_rod_y"]
+    groups = detect_spherical_joint_groups(joints)
+    assert len(groups) == 0
+
+
+def test_collapse_spherical_revolute_triplets():
+    urdf = _make_spherical_urdf()
+    groups = detect_spherical_joint_groups([
+        "crank_joint",
+        "spherical_rev_my_rod_x",
+        "spherical_rev_my_rod_y",
+        "spherical_rev_my_rod_z",
+    ])
+
+    collapsed_urdf, ball_map = collapse_spherical_revolute_triplets(urdf, groups)
+
+    # Dummy links should be removed
+    link_names = {l.attrib["name"] for l in collapsed_urdf.findall(".//link")}
+    assert "spherical_fake_my_rod_link1" not in link_names
+    assert "spherical_fake_my_rod_link2" not in link_names
+
+    # _y and _z joints should be removed
+    joint_names = {j.attrib["name"] for j in collapsed_urdf.findall(".//joint")}
+    assert "spherical_rev_my_rod_y" not in joint_names
+    assert "spherical_rev_my_rod_z" not in joint_names
+
+    # _x joint should still exist as a continuous joint
+    assert "spherical_rev_my_rod_x" in joint_names
+    jx = collapsed_urdf.find(".//joint[@name='spherical_rev_my_rod_x']")
+    assert jx.attrib["type"] == "continuous"
+    # Child should be the final child (rod), not a dummy link
+    assert jx.find("child").attrib["link"] == "rod"
+    # Parent should still be crank
+    assert jx.find("parent").attrib["link"] == "crank"
+
+    # The ball_map should map placeholder -> base_name
+    assert ball_map == {"spherical_rev_my_rod_x": "my_rod"}
+
+
+def test_collapse_preserves_rod_link():
+    urdf = _make_spherical_urdf()
+    groups = detect_spherical_joint_groups([
+        "crank_joint",
+        "spherical_rev_my_rod_x",
+        "spherical_rev_my_rod_y",
+        "spherical_rev_my_rod_z",
+    ])
+
+    collapsed_urdf, _ = collapse_spherical_revolute_triplets(urdf, groups)
+
+    # Rod link should still exist with its original inertia
+    rod = collapsed_urdf.find(".//link[@name='rod']")
+    assert rod is not None
+    mass = rod.find("inertial/mass")
+    assert float(mass.attrib["value"]) == pytest.approx(0.2)
+
+
+def test_collapse_preserves_non_spherical_joints():
+    urdf = _make_spherical_urdf()
+    groups = detect_spherical_joint_groups([
+        "crank_joint",
+        "spherical_rev_my_rod_x",
+        "spherical_rev_my_rod_y",
+        "spherical_rev_my_rod_z",
+    ])
+
+    collapsed_urdf, _ = collapse_spherical_revolute_triplets(urdf, groups)
+
+    # crank_joint should be untouched
+    crank_joint = collapsed_urdf.find(".//joint[@name='crank_joint']")
+    assert crank_joint is not None
+    assert crank_joint.attrib["type"] == "revolute"
+
+
+def test_collapse_preserves_origin():
+    urdf = _make_spherical_urdf()
+    groups = detect_spherical_joint_groups([
+        "crank_joint",
+        "spherical_rev_my_rod_x",
+        "spherical_rev_my_rod_y",
+        "spherical_rev_my_rod_z",
+    ])
+
+    collapsed_urdf, _ = collapse_spherical_revolute_triplets(urdf, groups)
+
+    jx = collapsed_urdf.find(".//joint[@name='spherical_rev_my_rod_x']")
+    origin = jx.find("origin")
+    assert origin is not None
+    assert origin.attrib["xyz"] == "0.05 0.02 0"

--- a/tests/test_urdf_to_mujoco_loader_class.py
+++ b/tests/test_urdf_to_mujoco_loader_class.py
@@ -101,7 +101,35 @@ def test_total_mass(robot_name):
     control_modes = [ControlMode.TORQUE] * len(controlled_joints)
     stiffness = [0.0] * len(controlled_joints)
     damping = [0.0] * len(controlled_joints)
-    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping)
+    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping, all_missing_joints_as_sites=False)
+
+    loader = URDFtoMuJoCoLoader.load_urdf(urdf_path, mesh_path, cfg)
+    mjcf = loader.get_mjcf_string()
+
+    model = mujoco.MjModel.from_xml_string(mjcf)
+    data = mujoco.MjData(model)
+
+    total_mass_mj = sum(model.body_mass)
+
+    # Test with iDynTree
+    model_loader = idyntree.ModelLoader()
+    model_loader.loadReducedModelFromFile(urdf_path, controlled_joints)
+    idt_model = model_loader.model()
+    total_mass_idt = idt_model.getTotalMass()
+
+    assert total_mass_mj == pytest.approx(total_mass_idt, abs=1e-4)
+
+@pytest.mark.parametrize("robot_name", ["ergoCub", "ANYmal"])
+def test_total_mass_with_missing_links(robot_name):
+    robot = ROBOTS[robot_name]
+    controlled_joints = robot["controlled_joints"]
+    urdf_path = robot["urdf_path"]
+    mesh_path = robot["mesh_path"]
+
+    control_modes = [ControlMode.TORQUE] * len(controlled_joints)
+    stiffness = [0.0] * len(controlled_joints)
+    damping = [0.0] * len(controlled_joints)
+    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping, all_missing_joints_as_sites=True)
 
     loader = URDFtoMuJoCoLoader.load_urdf(urdf_path, mesh_path, cfg)
     mjcf = loader.get_mjcf_string()

--- a/tests/test_urdf_to_mujoco_loader_class.py
+++ b/tests/test_urdf_to_mujoco_loader_class.py
@@ -14,7 +14,7 @@ from mujoco_urdf_loader.urdf_fcn import get_mesh_path
 # Define robot configurations in a dictionary
 ROBOTS = {
     "ergoCub": {
-        "controlled_joints": [
+        "observed_joints": [
             "l_hip_pitch",
             "r_hip_pitch",
             "torso_roll",
@@ -48,7 +48,7 @@ ROBOTS = {
         "mesh_path": None,  # Will be set later
     },
     "ANYmal": {
-        "controlled_joints": [
+        "observed_joints": [
             "LF_HAA",
             "LF_HFE",
             "LF_KFE",
@@ -76,14 +76,19 @@ for robot in ROBOTS.values():
 @pytest.mark.parametrize("robot_name", ["ergoCub", "ANYmal"])
 def test_load_urdf_into_mjcf(robot_name):
     robot = ROBOTS[robot_name]
-    controlled_joints = robot["controlled_joints"]
+    observed_joints = robot["observed_joints"]
     urdf_path = robot["urdf_path"]
     mesh_path = robot["mesh_path"]
 
-    control_modes = [ControlMode.TORQUE] * len(controlled_joints)
-    stiffness = [0.0] * len(controlled_joints)
-    damping = [0.0] * len(controlled_joints)
-    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping)
+    control_modes = [ControlMode.TORQUE] * len(observed_joints)
+    stiffness = [0.0] * len(observed_joints)
+    damping = [0.0] * len(observed_joints)
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=observed_joints,
+        control_modes=control_modes,
+        stiffness=stiffness,
+        damping=damping,
+    )
 
     loader = URDFtoMuJoCoLoader.load_urdf(urdf_path, mesh_path, cfg)
     mjcf = loader.get_mjcf_string()
@@ -94,14 +99,20 @@ def test_load_urdf_into_mjcf(robot_name):
 @pytest.mark.parametrize("robot_name", ["ergoCub", "ANYmal"])
 def test_total_mass(robot_name):
     robot = ROBOTS[robot_name]
-    controlled_joints = robot["controlled_joints"]
+    observed_joints = robot["observed_joints"]
     urdf_path = robot["urdf_path"]
     mesh_path = robot["mesh_path"]
 
-    control_modes = [ControlMode.TORQUE] * len(controlled_joints)
-    stiffness = [0.0] * len(controlled_joints)
-    damping = [0.0] * len(controlled_joints)
-    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping, all_missing_joints_as_sites=False)
+    control_modes = [ControlMode.TORQUE] * len(observed_joints)
+    stiffness = [0.0] * len(observed_joints)
+    damping = [0.0] * len(observed_joints)
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=observed_joints,
+        control_modes=control_modes,
+        stiffness=stiffness,
+        damping=damping,
+        all_missing_joints_as_sites=False,
+    )
 
     loader = URDFtoMuJoCoLoader.load_urdf(urdf_path, mesh_path, cfg)
     mjcf = loader.get_mjcf_string()
@@ -113,7 +124,7 @@ def test_total_mass(robot_name):
 
     # Test with iDynTree
     model_loader = idyntree.ModelLoader()
-    model_loader.loadReducedModelFromFile(urdf_path, controlled_joints)
+    model_loader.loadReducedModelFromFile(urdf_path, observed_joints)
     idt_model = model_loader.model()
     total_mass_idt = idt_model.getTotalMass()
 
@@ -122,14 +133,20 @@ def test_total_mass(robot_name):
 @pytest.mark.parametrize("robot_name", ["ergoCub", "ANYmal"])
 def test_total_mass_with_missing_links(robot_name):
     robot = ROBOTS[robot_name]
-    controlled_joints = robot["controlled_joints"]
+    observed_joints = robot["observed_joints"]
     urdf_path = robot["urdf_path"]
     mesh_path = robot["mesh_path"]
 
-    control_modes = [ControlMode.TORQUE] * len(controlled_joints)
-    stiffness = [0.0] * len(controlled_joints)
-    damping = [0.0] * len(controlled_joints)
-    cfg = URDFtoMuJoCoLoaderCfg(controlled_joints, control_modes, stiffness, damping, all_missing_joints_as_sites=True)
+    control_modes = [ControlMode.TORQUE] * len(observed_joints)
+    stiffness = [0.0] * len(observed_joints)
+    damping = [0.0] * len(observed_joints)
+    cfg = URDFtoMuJoCoLoaderCfg(
+        observed_joints=observed_joints,
+        control_modes=control_modes,
+        stiffness=stiffness,
+        damping=damping,
+        all_missing_joints_as_sites=True,
+    )
 
     loader = URDFtoMuJoCoLoader.load_urdf(urdf_path, mesh_path, cfg)
     mjcf = loader.get_mjcf_string()
@@ -141,7 +158,7 @@ def test_total_mass_with_missing_links(robot_name):
 
     # Test with iDynTree
     model_loader = idyntree.ModelLoader()
-    model_loader.loadReducedModelFromFile(urdf_path, controlled_joints)
+    model_loader.loadReducedModelFromFile(urdf_path, observed_joints)
     idt_model = model_loader.model()
     total_mass_idt = idt_model.getTotalMass()
 


### PR DESCRIPTION
This PR extends the URDF-to-MuJoCo loader with support for preserving frames that are lost during URDF simplification or MJCF conversion. It introduces optional generation of MJCF sites for missing URDF links/joints, enabling downstream features such as sensors, cameras, and equality constraints to reference those frames reliably. 

Changes include:

* Add `all_missing_joints_as_sites` support to export missing URDF frames as MJCF sites.
* Add equality constraints between MJCF sites, including `connect`/`weld` support and configurable `solimp`/`solref`.
* Add configuration support for frame quaternion sensors, gyro sensors, cameras, armature, damping, and friction loss.
* Add helper utilities for updating `meshdir` and formatting MJCF output.
* Fix world-to-root floating joint generation.
* Update tests to use `observed_joints` and add coverage for missing sites, sensors, cameras, equality constraints, and mass consistency.
* Add required dependencies including `numpy`, `scipy`, and `pyyaml`.
