### PR TITLE
Re-enable Windows in CI

### DIFF
--- a/.github/workflows/test-pixi.yaml
+++ b/.github/workflows/test-pixi.yaml
@@ -23,8 +23,9 @@ jobs:
       matrix:
         # Windows disabled as a workaround for https://github.com/ami-iit/mujoco-urdf-loader/issues/11
         os: [
-          ubuntu-latest,
-          macos-latest
+          ubuntu-slim,
+          macos-latest,
+          windows-latest,
         ]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #11 

I'm not sure what the failure was in #11, but now the tests pass locally on Windows.

I also switched to ubuntu-slim