### PR TITLE
Maintain `urdf_link_names` ordering

### DIFF
--- a/mujoco_urdf_loader/loader.py
+++ b/mujoco_urdf_loader/loader.py
@@ -703,11 +703,11 @@ class URDFtoMuJoCoLoader:
         all_joint_elements = robot_urdf.findall(".//joint")
 
         # Collect all URDF link names
-        urdf_link_names = {
+        urdf_link_names = [
             link.attrib["name"]
             for link in robot_urdf.findall(".//link")
             if "name" in link.attrib
-        }
+        ]
 
         # Collect MJCF body names
         mjcf_body_names = {


### PR DESCRIPTION
Using a list instead of a set will keep link ordering when loading the model. The link names lookup is still O(1) since `mjcf_body_names` is still a set.

fyi @FabioBergonti @vpunithreddy 