### PR TITLE
Fix idyntree resolving from PyPI instead of conda on Windows nightly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ skip = [".pixi"]
 channels = ["conda-forge"]
 platforms = ["linux-64", "linux-aarch64", "win-64", "osx-arm64"]
 
+[tool.pixi.workspace.conda-pypi-map]
+conda-forge = { mapping-mode = "overlay", mapping = { idyntree-python = "idyntree" } }
+
 # We duplicate the dependencies here to ensure that they are installed via conda
 # instead of pypi, that may not be necessary at some point in future pixi versions
 # if pixi learns to automatically solve pypi dependencies via conda packages,


### PR DESCRIPTION
The job that deletes the pixi lockfile fails periodically on Windows because pixi tries to build idyntree from PyPI sdist, which fails to compile.

After some investigation I've found out that this happens because for some reason Python3_SITELIB changed the casing on the Windows build toolchain from `Lib/site-package` (<=v15.0.0) to `lib/site-package` (>=v15.0.1). For this reason, parselmouth is not able to find a conda mapping on it's own.

Proof:
```sh
# exits non-zero when the capital "Lib/" is gone
url=https://api.anaconda.org/download/conda-forge/idyntree-python
for v in 15.0.0 15.1.0; do
  curl -sL "$url/$v/win-64/idyntree-python-$v-np2py314hb7a55bc_0.conda" -o p.conda
  unzip -qo p.conda 'pkg-*.tar.zst'
  cap=$(tar --zstd -tf pkg-*.tar.zst | grep -c '^Lib/site-packages/')
  low=$(tar --zstd -tf pkg-*.tar.zst | grep -c '^lib/site-packages/')
  printf '%s  Lib=%s  lib=%s\n' "$v" "$cap" "$low"
  rm -f p.conda pkg-*.tar.zst
done

# Prints:
# 15.0.0  Lib=13  lib=0
# 15.1.0  Lib=0  lib=13
```

This PR adds a workaround using an implicit conda-pypi map

fyi @traversaro 